### PR TITLE
Add About page, remove Pricing nav, SEO meta tags, live topic counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,17 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8"/>
-    <link rel="icon" type="image/svg+xml" href="/vite.svg"/>
+    <link rel="icon" type="image/svg+xml" href="/logo-1.png"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>JomExam</title>
+    <title>JomExam — Free SPM Practice Questions for Malaysian Students</title>
+    <meta name="description" content="Practice SPM past paper questions online, free. Choose your subject, pick a topic and difficulty, and drill real exam questions for Mathematics, Additional Mathematics, and more."/>
+    <meta name="keywords" content="SPM practice, SPM past papers, SPM Mathematics, SPM Add Maths, Malaysia exam revision, free SPM questions, latihan SPM"/>
+    <meta name="author" content="JomExam"/>
+    <meta property="og:title" content="JomExam — Free SPM Practice Questions"/>
+    <meta property="og:description" content="Real SPM past paper questions, organised by topic and difficulty. Free, fast, and built for Malaysian students."/>
+    <meta property="og:type" content="website"/>
+    <meta property="og:url" content="https://www.jomexam.com"/>
+    <meta name="robots" content="index, follow"/>
 </head>
 <body>
 <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { LandingPage } from '@/pages/LandingPage.tsx'
 import SubjectsPage from '@/pages/SubjectsPage.tsx'
 import { QuizGeneratorPage } from '@/pages/v3/QuizGeneratorPage.tsx'
 import { QuizPage } from './components/questionBank/v3/Quiz'
+import { AboutPage } from '@/pages/AboutPage.tsx'
 
 function App() {
     useEffect(() => {
@@ -43,6 +44,7 @@ function App() {
         <>
             <Routes>
                 <Route path="" element={<LandingPage />} />
+                <Route path="about" element={<AboutPage />} />
                 <Route path="subjects" element={<SubjectsPage />} />
                 <Route
                     path="questions/:subjectId"

--- a/src/components/layout/landing/LandingHeader.tsx
+++ b/src/components/layout/landing/LandingHeader.tsx
@@ -16,12 +16,8 @@ export function LandingHeader() {
                 link: subjectLink,
             },
             {
-                text: 'Pricing',
-                link: '/',
-            },
-            {
                 text: 'About',
-                link: '/',
+                link: '/about',
             },
         ],
         [subjectLink]

--- a/src/hooks/useGetTopicsBySubjectQuery.ts
+++ b/src/hooks/useGetTopicsBySubjectQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+import { getTopicsBySubjectTopicsSubjectIdGet } from '@/client'
+
+export default function useGetTopicsBySubjectQuery(subjectId: string) {
+    return useQuery({
+        queryFn: async () => {
+            return (
+                await getTopicsBySubjectTopicsSubjectIdGet({
+                    path: { subject_id: subjectId },
+                })
+            ).data
+        },
+        queryKey: ['topics', subjectId],
+        staleTime: 60 * 60 * 1000,
+        refetchOnWindowFocus: false,
+    })
+}

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,0 +1,84 @@
+import { LandingLayout } from '@/components/layout/landing/LandingLayout.tsx'
+import { useNavigate } from 'react-router-dom'
+import { Button } from '@/components/ui/button.tsx'
+import { useEffect } from 'react'
+
+export function AboutPage() {
+    const navigate = useNavigate()
+
+    useEffect(() => {
+        document.title = 'About | JomExam — Free SPM Practice Questions'
+    }, [])
+
+    return (
+        <LandingLayout>
+            <div className="px-4 md:px-[50px] xl:px-[150px] py-12 md:py-20 max-w-4xl">
+
+                {/* Hero statement */}
+                <p className="text-4xl md:text-6xl font-bold mb-6 leading-tight">
+                    SPM practice,{' '}
+                    <span style={{ color: '#799ED1' }}>
+                        anywhere. Free.
+                    </span>
+                </p>
+                <p className="text-lg md:text-xl text-slate-500 mb-12 leading-relaxed">
+                    Every student deserves access to quality exam practice —
+                    not just those who can afford tuition centres or thick
+                    revision books. JomExam puts real past paper questions in
+                    your pocket, organised by topic and difficulty, so you can
+                    drill exactly what you need, whenever you need it.
+                </p>
+
+                {/* Mission block */}
+                <div className="bg-slate-50 rounded-2xl p-8 mb-12 border border-slate-100">
+                    <p className="text-2xl font-bold mb-3">Our mission</p>
+                    <p className="text-slate-600 text-lg leading-relaxed">
+                        Make SPM revision simple, structured, and accessible
+                        to every student in Malaysia — regardless of where
+                        they study or what they can afford.
+                    </p>
+                </div>
+
+                {/* Founders */}
+                <p className="text-2xl font-bold mb-6">Who we are</p>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
+                    <div className="rounded-2xl border border-slate-100 p-8 bg-white shadow-sm">
+                        <p className="text-4xl mb-4">✏️</p>
+                        <p className="text-xl font-bold mb-1">Hazel</p>
+                        <p className="text-slate-500 text-sm mb-3 uppercase tracking-wide font-medium">Content</p>
+                        <p className="text-slate-600 leading-relaxed">
+                            Curates and structures the questions — making sure
+                            every topic is covered, every difficulty level is
+                            right, and the experience feels like a real exam
+                            without the stress.
+                        </p>
+                    </div>
+                    <div className="rounded-2xl border border-slate-100 p-8 bg-white shadow-sm">
+                        <p className="text-4xl mb-4">⚙️</p>
+                        <p className="text-xl font-bold mb-1">Clinton</p>
+                        <p className="text-slate-500 text-sm mb-3 uppercase tracking-wide font-medium">Engineering</p>
+                        <p className="text-slate-600 leading-relaxed">
+                            Built the platform from the ground up — the fast,
+                            reliable backend and the clean interface you're
+                            using right now.
+                        </p>
+                    </div>
+                </div>
+
+                {/* CTA */}
+                <div className="text-center py-10 border-t border-slate-100">
+                    <p className="text-2xl font-bold mb-3">Ready to start?</p>
+                    <p className="text-slate-500 mb-6">
+                        Pick a subject and go. No sign-up required to browse.
+                    </p>
+                    <Button
+                        className="xl:py-6 px-8 cursor-pointer text-base"
+                        onClick={() => navigate('/subjects')}
+                    >
+                        Start practising now
+                    </Button>
+                </div>
+            </div>
+        </LandingLayout>
+    )
+}

--- a/src/pages/SubjectsPage.tsx
+++ b/src/pages/SubjectsPage.tsx
@@ -10,6 +10,7 @@ import { Badge } from '@/components/ui/badge'
 import { ArrowRight, Calculator, TrendingUp } from 'lucide-react'
 import type { ElementType } from 'react'
 import { LandingLayout } from '@/components/layout/landing/LandingLayout.tsx'
+import useGetTopicsBySubjectQuery from '@/hooks/useGetTopicsBySubjectQuery.ts'
 
 interface Topic {
     id: string
@@ -338,6 +339,15 @@ export const subjectsPage: Subject[] = [
     // },
 ]
 
+function TopicCountBadge({ subjectId }: { subjectId: string }) {
+    const { data: topics, isLoading } = useGetTopicsBySubjectQuery(subjectId)
+    return (
+        <Badge variant="secondary">
+            {isLoading ? '...' : (topics?.length ?? 0)} topics
+        </Badge>
+    )
+}
+
 export default function SubjectsPage() {
     return (
         <LandingLayout>
@@ -376,10 +386,7 @@ export default function SubjectsPage() {
                                         </CardHeader>
                                         <CardContent>
                                             <div className="flex items-center justify-between">
-                                                <Badge variant="secondary">
-                                                    {subject.topics.length}{' '}
-                                                    topics
-                                                </Badge>
+                                                <TopicCountBadge subjectId={subject.id} />
                                                 <ArrowRight className="h-5 w-5 text-slate-400 group-hover:text-blue-600 group-hover:translate-x-1 transition-all" />
                                             </div>
                                         </CardContent>


### PR DESCRIPTION
- Remove Pricing from nav (no page existed); wire About link to /about
- New AboutPage with mission, Hazel+Clinton founder cards, CTA
- index.html: proper title, meta description, keywords, og tags, logo favicon
- SubjectsPage: fetch topic counts live from API via useGetTopicsBySubjectQuery instead of hardcoded placeholder arrays