### PR TITLE
Stage 4 (frontend) PR 1: core exam-taking screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,8 @@ import { StudentProtectedRoute } from '@/components/auth/StudentProtectedRoute.t
 import { DiagnosticQuestionsListPage } from '@/pages/Admin/Diagnostic/DiagnosticQuestionsListPage.tsx'
 import { DiagnosticQuestionCreatePage } from '@/pages/Admin/Diagnostic/DiagnosticQuestionCreatePage.tsx'
 import { DiagnosticQuestionEditPage } from '@/pages/Admin/Diagnostic/DiagnosticQuestionEditPage.tsx'
+import { SetInstructionsPage } from '@/pages/Diagnostic/SetInstructionsPage.tsx'
+import { ExamPage } from '@/pages/Diagnostic/ExamPage.tsx'
 
 function App() {
     useEffect(() => {
@@ -64,6 +66,14 @@ function App() {
                     <Route
                         path="questions/v2/:subjectId/quiz"
                         element={<QuizPage />}
+                    />
+                    <Route
+                        path="diagnostic/sets/:setId"
+                        element={<SetInstructionsPage />}
+                    />
+                    <Route
+                        path="diagnostic/attempts/:attemptId"
+                        element={<ExamPage />}
                     />
                 </Route>
                 <Route path="admin/login" element={<AdminLoginPage />} />

--- a/src/client/sdk.gen.ts
+++ b/src/client/sdk.gen.ts
@@ -2,7 +2,7 @@
 
 import { type Client, formDataBodySerializer, type Options as Options2, type TDataShape } from './client';
 import { client } from './client.gen';
-import type { BulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPostData, BulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPostErrors, BulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPostResponses, ConvertLatexConverterPostData, ConvertLatexConverterPostErrors, ConvertLatexConverterPostResponses, CreateDiagnosticQuestionDiagnosticQuestionsPostData, CreateDiagnosticQuestionDiagnosticQuestionsPostErrors, CreateDiagnosticQuestionDiagnosticQuestionsPostResponses, CreateLevelLevelsPostData, CreateLevelLevelsPostErrors, CreateLevelLevelsPostResponses, CreateOptionQuestionsQuestionIdOptionPostData, CreateOptionQuestionsQuestionIdOptionPostErrors, CreateOptionQuestionsQuestionIdOptionPostResponses, CreatePaperInstancePapersInstancePostData, CreatePaperInstancePapersInstancePostErrors, CreatePaperInstancePapersInstancePostResponses, CreatePaperPapersPostData, CreatePaperPapersPostErrors, CreatePaperPapersPostResponses, CreatePaperVariantPapersVariantPostData, CreatePaperVariantPapersVariantPostErrors, CreatePaperVariantPapersVariantPostResponses, CreateSubjectSubjectsPostData, CreateSubjectSubjectsPostErrors, CreateSubjectSubjectsPostResponses, CreateSyllabusSyllabusPostData, CreateSyllabusSyllabusPostErrors, CreateSyllabusSyllabusPostResponses, CreateTopicTopicsPostData, CreateTopicTopicsPostErrors, CreateTopicTopicsPostResponses, DeleteDiagnosticQuestionDiagnosticQuestionsQuestionIdDeleteData, DeleteDiagnosticQuestionDiagnosticQuestionsQuestionIdDeleteErrors, DeleteDiagnosticQuestionDiagnosticQuestionsQuestionIdDeleteResponses, DeleteLevelLevelsLevelIdDeleteData, DeleteLevelLevelsLevelIdDeleteErrors, DeleteLevelLevelsLevelIdDeleteResponses, DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteData, DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteErrors, DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteResponses, DeletePaperPapersInstanceInstanceIdDeleteData, DeletePaperPapersInstanceInstanceIdDeleteErrors, DeletePaperPapersInstanceInstanceIdDeleteResponses, DeletePaperPapersPaperIdDeleteData, DeletePaperPapersPaperIdDeleteErrors, DeletePaperPapersPaperIdDeleteResponses, DeleteQuestionQuestionsQuestionIdDeleteData, DeleteQuestionQuestionsQuestionIdDeleteErrors, DeleteQuestionQuestionsQuestionIdDeleteResponses, DeleteTopicTopicsTopicIdDeleteData, DeleteTopicTopicsTopicIdDeleteErrors, DeleteTopicTopicsTopicIdDeleteResponses, DeleteVariantPapersVariantVariantIdDeleteData, DeleteVariantPapersVariantVariantIdDeleteErrors, DeleteVariantPapersVariantVariantIdDeleteResponses, GetAllLevelsLevelsGetData, GetAllLevelsLevelsGetResponses, GetAllSyllabusSyllabusGetData, GetAllSyllabusSyllabusGetResponses, GetCurrentUserUsersCurrentGetData, GetCurrentUserUsersCurrentGetResponses, GetDiagnosticQuestionDiagnosticQuestionsQuestionIdGetData, GetDiagnosticQuestionDiagnosticQuestionsQuestionIdGetErrors, GetDiagnosticQuestionDiagnosticQuestionsQuestionIdGetResponses, GetDiagnosticSetDiagnosticSetsSetIdGetData, GetDiagnosticSetDiagnosticSetsSetIdGetErrors, GetDiagnosticSetDiagnosticSetsSetIdGetResponses, GetHintChatHintPostData, GetHintChatHintPostErrors, GetHintChatHintPostResponses, GetPaperInstancePapersInstanceInstanceIdGetData, GetPaperInstancePapersInstanceInstanceIdGetErrors, GetPaperInstancePapersInstanceInstanceIdGetResponses, GetPaperInstancesBySubjectIdPapersInstanceSubjectSubjectIdGetData, GetPaperInstancesBySubjectIdPapersInstanceSubjectSubjectIdGetErrors, GetPaperInstancesBySubjectIdPapersInstanceSubjectSubjectIdGetResponses, GetQuestionOptionsQuestionsQuestionIdOptionsGetData, GetQuestionOptionsQuestionsQuestionIdOptionsGetErrors, GetQuestionOptionsQuestionsQuestionIdOptionsGetResponses, GetQuestionQuestionsQuestionIdGetData, GetQuestionQuestionsQuestionIdGetErrors, GetQuestionQuestionsQuestionIdGetResponses, GetQuestionsByPaperInstanceQuestionsPaperInstancePaperInstanceIdGetData, GetQuestionsByPaperInstanceQuestionsPaperInstancePaperInstanceIdGetErrors, GetQuestionsByPaperInstanceQuestionsPaperInstancePaperInstanceIdGetResponses, GetQuestionsBySubjectPaginatedQuestionsSubjectPaginatedSubjectIdGetData, GetQuestionsBySubjectPaginatedQuestionsSubjectPaginatedSubjectIdGetErrors, GetQuestionsBySubjectPaginatedQuestionsSubjectPaginatedSubjectIdGetResponses, GetQuestionsBySubjectQuestionsSubjectSubjectIdGetData, GetQuestionsBySubjectQuestionsSubjectSubjectIdGetErrors, GetQuestionsBySubjectQuestionsSubjectSubjectIdGetResponses, GetQuestionsByTopicQuestionsTopicsTopicIdGetData, GetQuestionsByTopicQuestionsTopicsTopicIdGetErrors, GetQuestionsByTopicQuestionsTopicsTopicIdGetResponses, GetSubjectSubjectsSubjectIdGetData, GetSubjectSubjectsSubjectIdGetErrors, GetSubjectSubjectsSubjectIdGetResponses, GetSyllabusSyllabusSyllabusIdGetData, GetSyllabusSyllabusSyllabusIdGetErrors, GetSyllabusSyllabusSyllabusIdGetResponses, GetTopicsBySubjectTopicsSubjectIdGetData, GetTopicsBySubjectTopicsSubjectIdGetErrors, GetTopicsBySubjectTopicsSubjectIdGetResponses, ListDiagnosticQuestionsDiagnosticQuestionsGetData, ListDiagnosticQuestionsDiagnosticQuestionsGetErrors, ListDiagnosticQuestionsDiagnosticQuestionsGetResponses, ListDiagnosticSetsDiagnosticSetsGetData, ListDiagnosticSetsDiagnosticSetsGetErrors, ListDiagnosticSetsDiagnosticSetsGetResponses, LoginUsersLoginPostData, LoginUsersLoginPostErrors, LoginUsersLoginPostResponses, MoreInfoUsersMoreInfoPostData, MoreInfoUsersMoreInfoPostErrors, MoreInfoUsersMoreInfoPostResponses, ResendVerificationUsersResendVerificationPostData, ResendVerificationUsersResendVerificationPostErrors, ResendVerificationUsersResendVerificationPostResponses, RootGetData, RootGetResponses, SetQuestionStatusQuestionsSetStatusPostData, SetQuestionStatusQuestionsSetStatusPostErrors, SetQuestionStatusQuestionsSetStatusPostResponses, SignupUsersPostData, SignupUsersPostErrors, SignupUsersPostResponses, UpdateDiagnosticQuestionDiagnosticQuestionsQuestionIdPatchData, UpdateDiagnosticQuestionDiagnosticQuestionsQuestionIdPatchErrors, UpdateDiagnosticQuestionDiagnosticQuestionsQuestionIdPatchResponses, UpdateOptionQuestionsQuestionIdOptionOptionIdPatchData, UpdateOptionQuestionsQuestionIdOptionOptionIdPatchErrors, UpdateOptionQuestionsQuestionIdOptionOptionIdPatchResponses, UpdateQuestionQuestionsQuestionIdPatchData, UpdateQuestionQuestionsQuestionIdPatchErrors, UpdateQuestionQuestionsQuestionIdPatchResponses, UpdateTopicTopicsTopicIdPatchData, UpdateTopicTopicsTopicIdPatchErrors, UpdateTopicTopicsTopicIdPatchResponses, UploadDiagnosticQuestionDiagramDiagnosticQuestionsQuestionIdDiagramPostData, UploadDiagnosticQuestionDiagramDiagnosticQuestionsQuestionIdDiagramPostErrors, UploadDiagnosticQuestionDiagramDiagnosticQuestionsQuestionIdDiagramPostResponses, VerifyEmailUsersVerifyPostData, VerifyEmailUsersVerifyPostErrors, VerifyEmailUsersVerifyPostResponses } from './types.gen';
+import type { BulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPostData, BulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPostErrors, BulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPostResponses, ConvertLatexConverterPostData, ConvertLatexConverterPostErrors, ConvertLatexConverterPostResponses, CreateDiagnosticQuestionDiagnosticQuestionsPostData, CreateDiagnosticQuestionDiagnosticQuestionsPostErrors, CreateDiagnosticQuestionDiagnosticQuestionsPostResponses, CreateLevelLevelsPostData, CreateLevelLevelsPostErrors, CreateLevelLevelsPostResponses, CreateOptionQuestionsQuestionIdOptionPostData, CreateOptionQuestionsQuestionIdOptionPostErrors, CreateOptionQuestionsQuestionIdOptionPostResponses, CreatePaperInstancePapersInstancePostData, CreatePaperInstancePapersInstancePostErrors, CreatePaperInstancePapersInstancePostResponses, CreatePaperPapersPostData, CreatePaperPapersPostErrors, CreatePaperPapersPostResponses, CreatePaperVariantPapersVariantPostData, CreatePaperVariantPapersVariantPostErrors, CreatePaperVariantPapersVariantPostResponses, CreateSubjectSubjectsPostData, CreateSubjectSubjectsPostErrors, CreateSubjectSubjectsPostResponses, CreateSyllabusSyllabusPostData, CreateSyllabusSyllabusPostErrors, CreateSyllabusSyllabusPostResponses, CreateTopicTopicsPostData, CreateTopicTopicsPostErrors, CreateTopicTopicsPostResponses, DeleteDiagnosticQuestionDiagnosticQuestionsQuestionIdDeleteData, DeleteDiagnosticQuestionDiagnosticQuestionsQuestionIdDeleteErrors, DeleteDiagnosticQuestionDiagnosticQuestionsQuestionIdDeleteResponses, DeleteLevelLevelsLevelIdDeleteData, DeleteLevelLevelsLevelIdDeleteErrors, DeleteLevelLevelsLevelIdDeleteResponses, DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteData, DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteErrors, DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteResponses, DeletePaperPapersInstanceInstanceIdDeleteData, DeletePaperPapersInstanceInstanceIdDeleteErrors, DeletePaperPapersInstanceInstanceIdDeleteResponses, DeletePaperPapersPaperIdDeleteData, DeletePaperPapersPaperIdDeleteErrors, DeletePaperPapersPaperIdDeleteResponses, DeleteQuestionQuestionsQuestionIdDeleteData, DeleteQuestionQuestionsQuestionIdDeleteErrors, DeleteQuestionQuestionsQuestionIdDeleteResponses, DeleteTopicTopicsTopicIdDeleteData, DeleteTopicTopicsTopicIdDeleteErrors, DeleteTopicTopicsTopicIdDeleteResponses, DeleteVariantPapersVariantVariantIdDeleteData, DeleteVariantPapersVariantVariantIdDeleteErrors, DeleteVariantPapersVariantVariantIdDeleteResponses, GetAllLevelsLevelsGetData, GetAllLevelsLevelsGetResponses, GetAllSyllabusSyllabusGetData, GetAllSyllabusSyllabusGetResponses, GetAttemptStateDiagnosticAttemptsAttemptIdGetData, GetAttemptStateDiagnosticAttemptsAttemptIdGetErrors, GetAttemptStateDiagnosticAttemptsAttemptIdGetResponses, GetCurrentUserUsersCurrentGetData, GetCurrentUserUsersCurrentGetResponses, GetDiagnosticQuestionDiagnosticQuestionsQuestionIdGetData, GetDiagnosticQuestionDiagnosticQuestionsQuestionIdGetErrors, GetDiagnosticQuestionDiagnosticQuestionsQuestionIdGetResponses, GetDiagnosticSetDiagnosticSetsSetIdGetData, GetDiagnosticSetDiagnosticSetsSetIdGetErrors, GetDiagnosticSetDiagnosticSetsSetIdGetResponses, GetHintChatHintPostData, GetHintChatHintPostErrors, GetHintChatHintPostResponses, GetPaperInstancePapersInstanceInstanceIdGetData, GetPaperInstancePapersInstanceInstanceIdGetErrors, GetPaperInstancePapersInstanceInstanceIdGetResponses, GetPaperInstancesBySubjectIdPapersInstanceSubjectSubjectIdGetData, GetPaperInstancesBySubjectIdPapersInstanceSubjectSubjectIdGetErrors, GetPaperInstancesBySubjectIdPapersInstanceSubjectSubjectIdGetResponses, GetQuestionOptionsQuestionsQuestionIdOptionsGetData, GetQuestionOptionsQuestionsQuestionIdOptionsGetErrors, GetQuestionOptionsQuestionsQuestionIdOptionsGetResponses, GetQuestionQuestionsQuestionIdGetData, GetQuestionQuestionsQuestionIdGetErrors, GetQuestionQuestionsQuestionIdGetResponses, GetQuestionsByPaperInstanceQuestionsPaperInstancePaperInstanceIdGetData, GetQuestionsByPaperInstanceQuestionsPaperInstancePaperInstanceIdGetErrors, GetQuestionsByPaperInstanceQuestionsPaperInstancePaperInstanceIdGetResponses, GetQuestionsBySubjectPaginatedQuestionsSubjectPaginatedSubjectIdGetData, GetQuestionsBySubjectPaginatedQuestionsSubjectPaginatedSubjectIdGetErrors, GetQuestionsBySubjectPaginatedQuestionsSubjectPaginatedSubjectIdGetResponses, GetQuestionsBySubjectQuestionsSubjectSubjectIdGetData, GetQuestionsBySubjectQuestionsSubjectSubjectIdGetErrors, GetQuestionsBySubjectQuestionsSubjectSubjectIdGetResponses, GetQuestionsByTopicQuestionsTopicsTopicIdGetData, GetQuestionsByTopicQuestionsTopicsTopicIdGetErrors, GetQuestionsByTopicQuestionsTopicsTopicIdGetResponses, GetSubjectSubjectsSubjectIdGetData, GetSubjectSubjectsSubjectIdGetErrors, GetSubjectSubjectsSubjectIdGetResponses, GetSyllabusSyllabusSyllabusIdGetData, GetSyllabusSyllabusSyllabusIdGetErrors, GetSyllabusSyllabusSyllabusIdGetResponses, GetTopicsBySubjectTopicsSubjectIdGetData, GetTopicsBySubjectTopicsSubjectIdGetErrors, GetTopicsBySubjectTopicsSubjectIdGetResponses, IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostData, IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostErrors, IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostResponses, ListDiagnosticQuestionsDiagnosticQuestionsGetData, ListDiagnosticQuestionsDiagnosticQuestionsGetErrors, ListDiagnosticQuestionsDiagnosticQuestionsGetResponses, ListDiagnosticSetsDiagnosticSetsGetData, ListDiagnosticSetsDiagnosticSetsGetErrors, ListDiagnosticSetsDiagnosticSetsGetResponses, LoginUsersLoginPostData, LoginUsersLoginPostErrors, LoginUsersLoginPostResponses, MoreInfoUsersMoreInfoPostData, MoreInfoUsersMoreInfoPostErrors, MoreInfoUsersMoreInfoPostResponses, PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetData, PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetErrors, PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetResponses, ResendVerificationUsersResendVerificationPostData, ResendVerificationUsersResendVerificationPostErrors, ResendVerificationUsersResendVerificationPostResponses, RootGetData, RootGetResponses, SetQuestionStatusQuestionsSetStatusPostData, SetQuestionStatusQuestionsSetStatusPostErrors, SetQuestionStatusQuestionsSetStatusPostResponses, SignupUsersPostData, SignupUsersPostErrors, SignupUsersPostResponses, StartOrResumeAttemptDiagnosticAttemptsPostData, StartOrResumeAttemptDiagnosticAttemptsPostErrors, StartOrResumeAttemptDiagnosticAttemptsPostResponses, SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostData, SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostErrors, SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostResponses, UpdateDiagnosticQuestionDiagnosticQuestionsQuestionIdPatchData, UpdateDiagnosticQuestionDiagnosticQuestionsQuestionIdPatchErrors, UpdateDiagnosticQuestionDiagnosticQuestionsQuestionIdPatchResponses, UpdateDiagnosticSetDiagnosticSetsSetIdPatchData, UpdateDiagnosticSetDiagnosticSetsSetIdPatchErrors, UpdateDiagnosticSetDiagnosticSetsSetIdPatchResponses, UpdateOptionQuestionsQuestionIdOptionOptionIdPatchData, UpdateOptionQuestionsQuestionIdOptionOptionIdPatchErrors, UpdateOptionQuestionsQuestionIdOptionOptionIdPatchResponses, UpdateQuestionQuestionsQuestionIdPatchData, UpdateQuestionQuestionsQuestionIdPatchErrors, UpdateQuestionQuestionsQuestionIdPatchResponses, UpdateTopicTopicsTopicIdPatchData, UpdateTopicTopicsTopicIdPatchErrors, UpdateTopicTopicsTopicIdPatchResponses, UploadDiagnosticQuestionDiagramDiagnosticQuestionsQuestionIdDiagramPostData, UploadDiagnosticQuestionDiagramDiagnosticQuestionsQuestionIdDiagramPostErrors, UploadDiagnosticQuestionDiagramDiagnosticQuestionsQuestionIdDiagramPostResponses, UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchData, UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchErrors, UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchResponses, VerifyEmailUsersVerifyPostData, VerifyEmailUsersVerifyPostErrors, VerifyEmailUsersVerifyPostResponses } from './types.gen';
 
 export type Options<TData extends TDataShape = TDataShape, ThrowOnError extends boolean = boolean> = Options2<TData, ThrowOnError> & {
     /**
@@ -508,6 +508,20 @@ export const getCurrentUserUsersCurrentGet = <ThrowOnError extends boolean = fal
 };
 
 /**
+ * Get Hint
+ */
+export const getHintChatHintPost = <ThrowOnError extends boolean = false>(options: Options<GetHintChatHintPostData, ThrowOnError>) => {
+    return (options.client ?? client).post<GetHintChatHintPostResponses, GetHintChatHintPostErrors, ThrowOnError>({
+        url: '/chat/hint',
+        ...options,
+        headers: {
+            'Content-Type': 'application/json',
+            ...options.headers
+        }
+    });
+};
+
+/**
  * List Diagnostic Questions
  */
 export const listDiagnosticQuestionsDiagnosticQuestionsGet = <ThrowOnError extends boolean = false>(options?: Options<ListDiagnosticQuestionsDiagnosticQuestionsGetData, ThrowOnError>) => {
@@ -686,25 +700,194 @@ export const getDiagnosticSetDiagnosticSetsSetIdGet = <ThrowOnError extends bool
 };
 
 /**
+ * Update Diagnostic Set
+ */
+export const updateDiagnosticSetDiagnosticSetsSetIdPatch = <ThrowOnError extends boolean = false>(options: Options<UpdateDiagnosticSetDiagnosticSetsSetIdPatchData, ThrowOnError>) => {
+    return (options.client ?? client).patch<UpdateDiagnosticSetDiagnosticSetsSetIdPatchResponses, UpdateDiagnosticSetDiagnosticSetsSetIdPatchErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
+        url: '/diagnostic/sets/{set_id}',
+        ...options,
+        headers: {
+            'Content-Type': 'application/json',
+            ...options.headers
+        }
+    });
+};
+
+/**
+ * Preview Diagnostic Set
+ * The landing/instructions screen (§2) — any authenticated student,
+ * not just admin, but only for a set that's actually published. An
+ * unpublished (or nonexistent) set looks identical here — 404 either
+ * way, rather than confirming a draft set's existence to a non-admin
+ * caller.
+ */
+export const previewDiagnosticSetDiagnosticSetsSetIdPreviewGet = <ThrowOnError extends boolean = false>(options: Options<PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetData, ThrowOnError>) => {
+    return (options.client ?? client).get<PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetResponses, PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
+        url: '/diagnostic/sets/{set_id}/preview',
+        ...options
+    });
+};
+
+/**
+ * Start Or Resume Attempt
+ * Start-and-resume are the same operation (§7): if the student already
+ * has an in_progress attempt for this set, hand that back unchanged —
+ * the clock never stopped, so there's nothing to "resume" beyond
+ * reloading where things stand. Only genuinely creates a new row when
+ * there's no active one, which is also where the agreement-checkbox and
+ * published-set checks live, since neither applies to just reloading an
+ * attempt that already exists.
+ */
+export const startOrResumeAttemptDiagnosticAttemptsPost = <ThrowOnError extends boolean = false>(options: Options<StartOrResumeAttemptDiagnosticAttemptsPostData, ThrowOnError>) => {
+    return (options.client ?? client).post<StartOrResumeAttemptDiagnosticAttemptsPostResponses, StartOrResumeAttemptDiagnosticAttemptsPostErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
+        url: '/diagnostic/attempts',
+        ...options,
+        headers: {
+            'Content-Type': 'application/json',
+            ...options.headers
+        }
+    });
+};
+
+/**
+ * Get Attempt State
+ * Rehydrates the exam screen after a refresh/reconnect (§7) — the
+ * attempt's own status/deadline, every response recorded so far, and the
+ * (sanitized) question content, all in one call.
+ */
+export const getAttemptStateDiagnosticAttemptsAttemptIdGet = <ThrowOnError extends boolean = false>(options: Options<GetAttemptStateDiagnosticAttemptsAttemptIdGetData, ThrowOnError>) => {
+    return (options.client ?? client).get<GetAttemptStateDiagnosticAttemptsAttemptIdGetResponses, GetAttemptStateDiagnosticAttemptsAttemptIdGetErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
+        url: '/diagnostic/attempts/{attempt_id}',
+        ...options
+    });
+};
+
+/**
+ * Upsert Diagnostic Response
+ * Records an answer selection and/or flag toggle for one question in
+ * an in-progress attempt (§2, §4). Deliberately accepts nothing time- or
+ * view-related — total_time_seconds and view_count are both computed
+ * server-side from the event log at submission, never trusted from the
+ * client here.
+ *
+ * Genuinely idempotent under concurrency: diagnostic_responses rows are
+ * never pre-created (Stage 1's unique(attempt_id, question_id)
+ * constraint already exists, so this is a real INSERT ... ON CONFLICT
+ * DO UPDATE, not a select-then-write — no repeat of the race PR 1 found
+ * and fixed on diagnostic_attempts).
+ */
+export const upsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatch = <ThrowOnError extends boolean = false>(options: Options<UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchData, ThrowOnError>) => {
+    return (options.client ?? client).patch<UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchResponses, UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
+        url: '/diagnostic/attempts/{attempt_id}/responses/{question_id}',
+        ...options,
+        headers: {
+            'Content-Type': 'application/json',
+            ...options.headers
+        }
+    });
+};
+
+/**
+ * Ingest Diagnostic Events
+ * Client-side batched events (§4) — one call per flush (every few
+ * seconds, or on navigation), not one call per event. This endpoint
+ * only appends raw rows to diagnostic_question_events;
+ * total_time_seconds/view_count are computed later, at submission, by
+ * aggregating the full stored event log — never touched here, not even
+ * incrementally.
+ *
+ * Ownership + status checks apply once per batch, not once per event
+ * (matching PATCH .../responses/{question_id}) — but unlike that
+ * endpoint, a just-timed-out attempt still accepts events within a
+ * grace period (_attempt_accepts_event_batch), since these are
+ * analytics only.
+ */
+export const ingestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPost = <ThrowOnError extends boolean = false>(options: Options<IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostData, ThrowOnError>) => {
+    return (options.client ?? client).post<IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostResponses, IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
+        url: '/diagnostic/attempts/{attempt_id}/events',
+        ...options,
+        headers: {
+            'Content-Type': 'application/json',
+            ...options.headers
+        }
+    });
+};
+
+/**
+ * Submit Attempt
+ * Locks an attempt the student chose to finish (§1). Answers and
+ * flags already landed incrementally via PATCH .../responses, so there's
+ * no body — this only flips status to 'submitted' and stamps
+ * submitted_at. Deliberately does NOT score: total_score / per-response
+ * is_correct are Stage 5, computed later from the stored responses and
+ * event log.
+ *
+ * Strict on the deadline, unlike event ingestion's grace period, and
+ * for a different reason: an event is additive analytics (a late one
+ * only adds data), but submit is a state transition — accepting a late
+ * one would overwrite a meaningful 'timed_out' with 'submitted',
+ * erasing the did-they-finish-vs-ran-out distinction §1's statuses
+ * exist to record. _get_owned_attempt runs _apply_lazy_timeout first,
+ * so an attempt whose deadline has passed already reads 'timed_out' by
+ * the time the guard below sees it, and a buzzer-beater that arrives
+ * late is server-authoritatively too late (§1: the backend, not a
+ * client-reported timestamp, is the source of truth).
+ */
+export const submitAttemptDiagnosticAttemptsAttemptIdSubmitPost = <ThrowOnError extends boolean = false>(options: Options<SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostData, ThrowOnError>) => {
+    return (options.client ?? client).post<SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostResponses, SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
+        url: '/diagnostic/attempts/{attempt_id}/submit',
+        ...options
+    });
+};
+
+/**
  * Root
  */
 export const rootGet = <ThrowOnError extends boolean = false>(options?: Options<RootGetData, ThrowOnError>) => {
     return (options?.client ?? client).get<RootGetResponses, unknown, ThrowOnError>({
         url: '/',
         ...options
-    });
-};
-
-/**
- * Get Hint
- */
-export const getHintChatHintPost = <ThrowOnError extends boolean = false>(options: Options<GetHintChatHintPostData, ThrowOnError>) => {
-    return (options.client ?? client).post<GetHintChatHintPostResponses, GetHintChatHintPostErrors, ThrowOnError>({
-        url: '/chat/hint',
-        ...options,
-        headers: {
-            'Content-Type': 'application/json',
-            ...options.headers
-        }
     });
 };

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -484,6 +484,64 @@ export type CreateTopicBody = {
 };
 
 /**
+ * DiagnosticAttemptResponse
+ */
+export type DiagnosticAttemptResponse = {
+    /**
+     * Id
+     */
+    id: string;
+    /**
+     * Diagnosticsetid
+     */
+    diagnosticSetId: string;
+    /**
+     * Status
+     */
+    status: 'in_progress' | 'submitted' | 'timed_out' | 'abandoned';
+    /**
+     * Startedat
+     */
+    startedAt: string;
+    /**
+     * Serverdeadlineat
+     */
+    serverDeadlineAt: string;
+    /**
+     * Submittedat
+     */
+    submittedAt?: string | null;
+    /**
+     * Agreedtoterms
+     */
+    agreedToTerms: boolean;
+    /**
+     * Totalscore
+     */
+    totalScore?: number | null;
+};
+
+/**
+ * DiagnosticAttemptStateResponse
+ * Returned by both POST /diagnostic/attempts (start-or-resume) and GET
+ * /diagnostic/attempts/{id} (rehydrate) — same shape either way, since a
+ * resumed attempt's initial state and a reconnect's rehydrated state are
+ * the same question the frontend is asking: 'where do things stand right
+ * now.'
+ */
+export type DiagnosticAttemptStateResponse = {
+    attempt: DiagnosticAttemptResponse;
+    /**
+     * Questions
+     */
+    questions: Array<StudentDiagnosticQuestionResponse>;
+    /**
+     * Responses
+     */
+    responses: Array<DiagnosticResponseState>;
+};
+
+/**
  * DiagnosticOption
  */
 export type DiagnosticOption = {
@@ -503,6 +561,24 @@ export type DiagnosticOption = {
      * Misconception
      */
     misconception?: string | null;
+};
+
+/**
+ * DiagnosticQuestionEvent
+ */
+export type DiagnosticQuestionEvent = {
+    /**
+     * Questionid
+     */
+    questionId: string;
+    /**
+     * Eventtype
+     */
+    eventType: 'enter' | 'exit' | 'flag' | 'unflag' | 'answer_change' | 'blur' | 'focus';
+    /**
+     * Clientts
+     */
+    clientTs?: string | null;
 };
 
 /**
@@ -556,6 +632,64 @@ export type DiagnosticQuestionResponse = {
 };
 
 /**
+ * DiagnosticResponseState
+ * Per-question progress so far, for rehydrating the exam screen after
+ * a refresh/reconnect (§7) — no is_correct, never populated until the
+ * attempt is scored (Stage 5), and even then never sent mid-attempt.
+ */
+export type DiagnosticResponseState = {
+    /**
+     * Questionid
+     */
+    questionId: string;
+    /**
+     * Questionorderindex
+     */
+    questionOrderIndex: number;
+    /**
+     * Selectedoption
+     */
+    selectedOption?: string | null;
+    /**
+     * Isflagged
+     */
+    isFlagged?: boolean;
+    /**
+     * Viewcount
+     */
+    viewCount?: number;
+};
+
+/**
+ * DiagnosticSetPreviewResponse
+ * Landing/instructions screen, before an attempt exists (§2) — only
+ * what's needed to decide to start, nothing about the questions
+ * themselves.
+ */
+export type DiagnosticSetPreviewResponse = {
+    /**
+     * Id
+     */
+    id: string;
+    /**
+     * Title
+     */
+    title: string;
+    /**
+     * Description
+     */
+    description?: string | null;
+    /**
+     * Timelimitminutes
+     */
+    timeLimitMinutes: number;
+    /**
+     * Questioncount
+     */
+    questionCount: number;
+};
+
+/**
  * DiagnosticSetResponse
  */
 export type DiagnosticSetResponse = {
@@ -601,6 +735,56 @@ export type HttpValidationError = {
      * Detail
      */
     detail?: Array<ValidationError>;
+};
+
+/**
+ * HintRequest
+ */
+export type HintRequest = {
+    /**
+     * Question
+     */
+    question: string;
+    /**
+     * Questionid
+     */
+    questionId: string;
+};
+
+/**
+ * HintResponse
+ */
+export type HintResponse = {
+    /**
+     * Hint
+     */
+    hint: string;
+    /**
+     * Level
+     */
+    level?: number;
+};
+
+/**
+ * IngestDiagnosticEventsBody
+ * One call per client-side flush (every few seconds, or on
+ * navigation) — not one call per event (§4).
+ */
+export type IngestDiagnosticEventsBody = {
+    /**
+     * Events
+     */
+    events: Array<DiagnosticQuestionEvent>;
+};
+
+/**
+ * IngestDiagnosticEventsResponse
+ */
+export type IngestDiagnosticEventsResponse = {
+    /**
+     * Acceptedcount
+     */
+    acceptedCount: number;
 };
 
 /**
@@ -773,6 +957,59 @@ export type SetCompletionResponse = {
 };
 
 /**
+ * StartAttemptBody
+ */
+export type StartAttemptBody = {
+    /**
+     * Diagnosticsetid
+     */
+    diagnosticSetId: string;
+    /**
+     * Agreedtoterms
+     */
+    agreedToTerms?: boolean;
+};
+
+/**
+ * StudentDiagnosticOption
+ */
+export type StudentDiagnosticOption = {
+    /**
+     * Label
+     */
+    label: string;
+    /**
+     * Text
+     */
+    text: string;
+};
+
+/**
+ * StudentDiagnosticQuestionResponse
+ * The exam-screen view of a question — no correct_option, no
+ * per-option is_correct/misconception. Scoring is server-side only
+ * (§3); this is what makes sure a client can never see it mid-attempt.
+ */
+export type StudentDiagnosticQuestionResponse = {
+    /**
+     * Id
+     */
+    id: string;
+    /**
+     * Stem
+     */
+    stem: string;
+    /**
+     * Options
+     */
+    options: Array<StudentDiagnosticOption>;
+    /**
+     * Diagramurl
+     */
+    diagramUrl?: string | null;
+};
+
+/**
  * Syllabus
  */
 export type Syllabus = {
@@ -845,6 +1082,32 @@ export type UpdateDiagnosticQuestionBody = {
 };
 
 /**
+ * UpdateDiagnosticSetBody
+ */
+export type UpdateDiagnosticSetBody = {
+    /**
+     * Title
+     */
+    title?: string | null;
+    /**
+     * Description
+     */
+    description?: string | null;
+    /**
+     * Timelimitminutes
+     */
+    timeLimitMinutes?: number | null;
+    /**
+     * Isfree
+     */
+    isFree?: boolean | null;
+    /**
+     * Status
+     */
+    status?: 'draft' | 'published' | null;
+};
+
+/**
  * UpdateOptionBody
  */
 export type UpdateOptionBody = {
@@ -897,6 +1160,26 @@ export type UpdateTopicBody = {
      * Sortorder
      */
     sortOrder?: number | null;
+};
+
+/**
+ * UpsertDiagnosticResponseBody
+ * Both fields optional (exclude_unset governs the write, same
+ * omit/explicit-null convention as UpdateDiagnosticQuestionBody) so a
+ * flag-only toggle doesn't require resending the current answer and
+ * vice versa. Deliberately no total_time_seconds or view_count field —
+ * both are computed server-side from the event log at submission (§4),
+ * never accepted from the client on this endpoint.
+ */
+export type UpsertDiagnosticResponseBody = {
+    /**
+     * Selectedoption
+     */
+    selectedOption?: string | null;
+    /**
+     * Isflagged
+     */
+    isFlagged?: boolean | null;
 };
 
 /**
@@ -1030,34 +1313,6 @@ export type ValidationError = {
      * Error Type
      */
     type: string;
-};
-
-/**
- * HintRequest
- */
-export type HintRequest = {
-    /**
-     * Question
-     */
-    question: string;
-    /**
-     * Questionid
-     */
-    questionId: string;
-};
-
-/**
- * HintResponse
- */
-export type HintResponse = {
-    /**
-     * Hint
-     */
-    hint: string;
-    /**
-     * Level
-     */
-    level?: number;
 };
 
 export type ConvertLatexConverterPostData = {
@@ -2145,6 +2400,31 @@ export type GetCurrentUserUsersCurrentGetResponses = {
 
 export type GetCurrentUserUsersCurrentGetResponse = GetCurrentUserUsersCurrentGetResponses[keyof GetCurrentUserUsersCurrentGetResponses];
 
+export type GetHintChatHintPostData = {
+    body: HintRequest;
+    path?: never;
+    query?: never;
+    url: '/chat/hint';
+};
+
+export type GetHintChatHintPostErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type GetHintChatHintPostError = GetHintChatHintPostErrors[keyof GetHintChatHintPostErrors];
+
+export type GetHintChatHintPostResponses = {
+    /**
+     * Successful Response
+     */
+    200: HintResponse;
+};
+
+export type GetHintChatHintPostResponse = GetHintChatHintPostResponses[keyof GetHintChatHintPostResponses];
+
 export type ListDiagnosticQuestionsDiagnosticQuestionsGetData = {
     body?: never;
     path?: never;
@@ -2409,6 +2689,215 @@ export type GetDiagnosticSetDiagnosticSetsSetIdGetResponses = {
 
 export type GetDiagnosticSetDiagnosticSetsSetIdGetResponse = GetDiagnosticSetDiagnosticSetsSetIdGetResponses[keyof GetDiagnosticSetDiagnosticSetsSetIdGetResponses];
 
+export type UpdateDiagnosticSetDiagnosticSetsSetIdPatchData = {
+    body: UpdateDiagnosticSetBody;
+    path: {
+        /**
+         * Set Id
+         */
+        set_id: string;
+    };
+    query?: never;
+    url: '/diagnostic/sets/{set_id}';
+};
+
+export type UpdateDiagnosticSetDiagnosticSetsSetIdPatchErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type UpdateDiagnosticSetDiagnosticSetsSetIdPatchError = UpdateDiagnosticSetDiagnosticSetsSetIdPatchErrors[keyof UpdateDiagnosticSetDiagnosticSetsSetIdPatchErrors];
+
+export type UpdateDiagnosticSetDiagnosticSetsSetIdPatchResponses = {
+    /**
+     * Successful Response
+     */
+    200: DiagnosticSetResponse;
+};
+
+export type UpdateDiagnosticSetDiagnosticSetsSetIdPatchResponse = UpdateDiagnosticSetDiagnosticSetsSetIdPatchResponses[keyof UpdateDiagnosticSetDiagnosticSetsSetIdPatchResponses];
+
+export type PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetData = {
+    body?: never;
+    path: {
+        /**
+         * Set Id
+         */
+        set_id: string;
+    };
+    query?: never;
+    url: '/diagnostic/sets/{set_id}/preview';
+};
+
+export type PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetError = PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetErrors[keyof PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetErrors];
+
+export type PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetResponses = {
+    /**
+     * Successful Response
+     */
+    200: DiagnosticSetPreviewResponse;
+};
+
+export type PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetResponse = PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetResponses[keyof PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetResponses];
+
+export type StartOrResumeAttemptDiagnosticAttemptsPostData = {
+    body: StartAttemptBody;
+    path?: never;
+    query?: never;
+    url: '/diagnostic/attempts';
+};
+
+export type StartOrResumeAttemptDiagnosticAttemptsPostErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type StartOrResumeAttemptDiagnosticAttemptsPostError = StartOrResumeAttemptDiagnosticAttemptsPostErrors[keyof StartOrResumeAttemptDiagnosticAttemptsPostErrors];
+
+export type StartOrResumeAttemptDiagnosticAttemptsPostResponses = {
+    /**
+     * Successful Response
+     */
+    200: DiagnosticAttemptStateResponse;
+};
+
+export type StartOrResumeAttemptDiagnosticAttemptsPostResponse = StartOrResumeAttemptDiagnosticAttemptsPostResponses[keyof StartOrResumeAttemptDiagnosticAttemptsPostResponses];
+
+export type GetAttemptStateDiagnosticAttemptsAttemptIdGetData = {
+    body?: never;
+    path: {
+        /**
+         * Attempt Id
+         */
+        attempt_id: string;
+    };
+    query?: never;
+    url: '/diagnostic/attempts/{attempt_id}';
+};
+
+export type GetAttemptStateDiagnosticAttemptsAttemptIdGetErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type GetAttemptStateDiagnosticAttemptsAttemptIdGetError = GetAttemptStateDiagnosticAttemptsAttemptIdGetErrors[keyof GetAttemptStateDiagnosticAttemptsAttemptIdGetErrors];
+
+export type GetAttemptStateDiagnosticAttemptsAttemptIdGetResponses = {
+    /**
+     * Successful Response
+     */
+    200: DiagnosticAttemptStateResponse;
+};
+
+export type GetAttemptStateDiagnosticAttemptsAttemptIdGetResponse = GetAttemptStateDiagnosticAttemptsAttemptIdGetResponses[keyof GetAttemptStateDiagnosticAttemptsAttemptIdGetResponses];
+
+export type UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchData = {
+    body: UpsertDiagnosticResponseBody;
+    path: {
+        /**
+         * Attempt Id
+         */
+        attempt_id: string;
+        /**
+         * Question Id
+         */
+        question_id: string;
+    };
+    query?: never;
+    url: '/diagnostic/attempts/{attempt_id}/responses/{question_id}';
+};
+
+export type UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchError = UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchErrors[keyof UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchErrors];
+
+export type UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchResponses = {
+    /**
+     * Successful Response
+     */
+    200: DiagnosticResponseState;
+};
+
+export type UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchResponse = UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchResponses[keyof UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchResponses];
+
+export type IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostData = {
+    body: IngestDiagnosticEventsBody;
+    path: {
+        /**
+         * Attempt Id
+         */
+        attempt_id: string;
+    };
+    query?: never;
+    url: '/diagnostic/attempts/{attempt_id}/events';
+};
+
+export type IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostError = IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostErrors[keyof IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostErrors];
+
+export type IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostResponses = {
+    /**
+     * Successful Response
+     */
+    200: IngestDiagnosticEventsResponse;
+};
+
+export type IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostResponse = IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostResponses[keyof IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostResponses];
+
+export type SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostData = {
+    body?: never;
+    path: {
+        /**
+         * Attempt Id
+         */
+        attempt_id: string;
+    };
+    query?: never;
+    url: '/diagnostic/attempts/{attempt_id}/submit';
+};
+
+export type SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostError = SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostErrors[keyof SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostErrors];
+
+export type SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostResponses = {
+    /**
+     * Successful Response
+     */
+    200: DiagnosticAttemptStateResponse;
+};
+
+export type SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostResponse = SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostResponses[keyof SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostResponses];
+
 export type RootGetData = {
     body?: never;
     path?: never;
@@ -2422,28 +2911,3 @@ export type RootGetResponses = {
      */
     200: unknown;
 };
-
-export type GetHintChatHintPostData = {
-    body: HintRequest;
-    path?: never;
-    query?: never;
-    url: '/chat/hint';
-};
-
-export type GetHintChatHintPostErrors = {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-};
-
-export type GetHintChatHintPostError = GetHintChatHintPostErrors[keyof GetHintChatHintPostErrors];
-
-export type GetHintChatHintPostResponses = {
-    /**
-     * Successful Response
-     */
-    200: HintResponse;
-};
-
-export type GetHintChatHintPostResponse = GetHintChatHintPostResponses[keyof GetHintChatHintPostResponses];

--- a/src/components/diagnostic/exam/AttemptClosedView.tsx
+++ b/src/components/diagnostic/exam/AttemptClosedView.tsx
@@ -1,0 +1,38 @@
+import type { DiagnosticAttemptResponse } from '@/client'
+import { Button } from '@/components/ui/button.tsx'
+import { useNavigate } from 'react-router-dom'
+
+type Props = {
+    attempt: DiagnosticAttemptResponse
+}
+
+/**
+ * Terminal state for a non-in_progress attempt. ExamPage switches to this
+ * whenever attempt.status !== 'in_progress' — reached today only via a 409
+ * on a write (the attempt timed out mid-exam), and in PR 2 also when the
+ * countdown hits zero and auto-submits. Deliberately a minimal placeholder
+ * for now: PR 4 turns this into the real review/summary, and Stage 5 adds
+ * the Skills Radar report. The point of building it in PR 1 is that the
+ * status switch it hangs off exists from the start, so PR 2/PR 4 extend
+ * one shape rather than introduce a new one.
+ */
+export function AttemptClosedView({ attempt }: Props) {
+    const navigate = useNavigate()
+    const timedOut = attempt.status === 'timed_out'
+
+    return (
+        <div className="mx-auto mt-16 flex max-w-md flex-col items-center gap-4 text-center">
+            <h1 className="text-2xl font-semibold">
+                {timedOut ? "Time's up" : 'Attempt submitted'}
+            </h1>
+            <p className="text-gray-600">
+                {timedOut
+                    ? 'The time limit for this diagnostic has passed, so it was submitted automatically. Your report will be available once scoring is added.'
+                    : 'Your answers have been submitted. Your report will be available once scoring is added.'}
+            </p>
+            <Button type="button" variant="outline" onClick={() => navigate('/')}>
+                Back to home
+            </Button>
+        </div>
+    )
+}

--- a/src/components/diagnostic/exam/QuestionNavigator.test.tsx
+++ b/src/components/diagnostic/exam/QuestionNavigator.test.tsx
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { QuestionNavigator } from './QuestionNavigator'
+import type {
+    DiagnosticResponseState,
+    StudentDiagnosticQuestionResponse,
+} from '@/client'
+
+function q(id: string): StudentDiagnosticQuestionResponse {
+    return { id, stem: `stem ${id}`, options: [{ label: 'A', text: 'x' }] }
+}
+
+function resp(
+    questionId: string,
+    over: Partial<DiagnosticResponseState> = {}
+): DiagnosticResponseState {
+    return {
+        questionId,
+        questionOrderIndex: 0,
+        selectedOption: null,
+        isFlagged: false,
+        viewCount: 0,
+        ...over,
+    }
+}
+
+const QUESTIONS = [q('qa'), q('qb'), q('qc')]
+
+describe('QuestionNavigator', () => {
+    it('colours each cell straight from the responses array (answered vs unanswered), no fetch', () => {
+        render(
+            <QuestionNavigator
+                questions={QUESTIONS}
+                responses={[resp('qa', { selectedOption: 'A' })]}
+                currentIndex={0}
+                onJump={() => {}}
+            />
+        )
+        // qa answered, qb/qc not — reflected in aria-labels derived purely
+        // from the shared responses.
+        expect(
+            screen.getByRole('button', { name: /Question 1, answered/i })
+        ).toBeInTheDocument()
+        expect(
+            screen.getByRole('button', { name: /Question 2, unanswered/i })
+        ).toBeInTheDocument()
+    })
+
+    it('marks a flagged question as flagged even when unanswered', () => {
+        render(
+            <QuestionNavigator
+                questions={QUESTIONS}
+                responses={[resp('qc', { isFlagged: true })]}
+                currentIndex={0}
+                onJump={() => {}}
+            />
+        )
+        expect(
+            screen.getByRole('button', { name: /Question 3, unanswered, flagged/i })
+        ).toBeInTheDocument()
+    })
+
+    it('re-colours synchronously when the responses prop changes (no refetch)', () => {
+        const { rerender } = render(
+            <QuestionNavigator
+                questions={QUESTIONS}
+                responses={[]}
+                currentIndex={0}
+                onJump={() => {}}
+            />
+        )
+        expect(
+            screen.getByRole('button', { name: /Question 1, unanswered/i })
+        ).toBeInTheDocument()
+
+        // Simulate the optimistic cache patch flowing back in as a new prop.
+        rerender(
+            <QuestionNavigator
+                questions={QUESTIONS}
+                responses={[resp('qa', { selectedOption: 'A' })]}
+                currentIndex={0}
+                onJump={() => {}}
+            />
+        )
+        expect(
+            screen.getByRole('button', { name: /Question 1, answered/i })
+        ).toBeInTheDocument()
+    })
+
+    it('jumps directly to any question on click (free navigation)', () => {
+        const onJump = vi.fn()
+        render(
+            <QuestionNavigator
+                questions={QUESTIONS}
+                responses={[]}
+                currentIndex={0}
+                onJump={onJump}
+            />
+        )
+        fireEvent.click(screen.getByRole('button', { name: /Question 3/i }))
+        expect(onJump).toHaveBeenCalledWith(2)
+    })
+})

--- a/src/components/diagnostic/exam/QuestionNavigator.tsx
+++ b/src/components/diagnostic/exam/QuestionNavigator.tsx
@@ -1,0 +1,79 @@
+import type {
+    DiagnosticResponseState,
+    StudentDiagnosticQuestionResponse,
+} from '@/client'
+import { cn } from '@/lib/utils.ts'
+
+type Props = {
+    questions: StudentDiagnosticQuestionResponse[]
+    responses: DiagnosticResponseState[]
+    currentIndex: number
+    onJump: (index: number) => void
+}
+
+/**
+ * Pure derivation from the shared attempt-state entry — no fetch, no local
+ * state. Each cell's colour comes straight from the responses array, so an
+ * optimistic answer/flag write re-colours the cell on the same render.
+ * Standard CBT navigator: click any number to jump directly (free
+ * navigation, §2), and the target renders its already-saved state because
+ * both content and response come from the one source.
+ */
+export function QuestionNavigator({ questions, responses, currentIndex, onJump }: Props) {
+    const byQuestionId = new Map(responses.map((r) => [r.questionId, r]))
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="grid grid-cols-5 gap-2">
+                {questions.map((question, index) => {
+                    const response = byQuestionId.get(question.id)
+                    const answered =
+                        response?.selectedOption !== undefined &&
+                        response?.selectedOption !== null
+                    const flagged = response?.isFlagged ?? false
+                    const isCurrent = index === currentIndex
+
+                    return (
+                        <button
+                            key={question.id}
+                            type="button"
+                            onClick={() => onJump(index)}
+                            aria-label={`Question ${index + 1}${answered ? ', answered' : ', unanswered'}${flagged ? ', flagged' : ''}`}
+                            aria-current={isCurrent ? 'true' : undefined}
+                            className={cn(
+                                'relative h-10 rounded-md border text-sm font-medium transition-colors',
+                                answered
+                                    ? 'border-emerald-300 bg-emerald-50 text-emerald-800'
+                                    : 'border-gray-200 bg-white text-gray-600',
+                                isCurrent && 'ring-2 ring-offset-1 ring-blue-500'
+                            )}
+                        >
+                            {index + 1}
+                            {flagged && (
+                                <span
+                                    aria-hidden
+                                    className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full bg-amber-500"
+                                />
+                            )}
+                        </button>
+                    )
+                })}
+            </div>
+
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
+                <span className="flex items-center gap-1.5">
+                    <span className="h-3 w-3 rounded-sm border border-emerald-300 bg-emerald-50" />
+                    Answered
+                </span>
+                <span className="flex items-center gap-1.5">
+                    <span className="h-3 w-3 rounded-sm border border-gray-200 bg-white" />
+                    Unanswered
+                </span>
+                <span className="flex items-center gap-1.5">
+                    <span className="h-2.5 w-2.5 rounded-full bg-amber-500" />
+                    Flagged
+                </span>
+            </div>
+        </div>
+    )
+}

--- a/src/components/diagnostic/exam/QuestionPane.tsx
+++ b/src/components/diagnostic/exam/QuestionPane.tsx
@@ -1,0 +1,111 @@
+import type {
+    DiagnosticResponseState,
+    StudentDiagnosticQuestionResponse,
+} from '@/client'
+import { LatexText } from '@/components/diagnostic/LatexText.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { cn } from '@/lib/utils.ts'
+import { Flag } from 'lucide-react'
+
+type Props = {
+    question: StudentDiagnosticQuestionResponse
+    response: DiagnosticResponseState | undefined
+    questionNumber: number
+    totalQuestions: number
+    onAnswer: (label: string) => void
+    onToggleFlag: () => void
+}
+
+/**
+ * Pure render of one question. The selected option and flag come straight
+ * from the `response` prop (derived from the shared attempt-state entry) —
+ * there is deliberately no per-question local state, so jumping to a
+ * question always shows its persisted answer/flag, never a blank render,
+ * regardless of how it was reached (Next/Prev or a direct navigator jump).
+ * Uses the same LatexText component as the admin preview (§9's one shared
+ * renderer). Diagram, when present, is a signed-URL <img>.
+ */
+export function QuestionPane({
+    question,
+    response,
+    questionNumber,
+    totalQuestions,
+    onAnswer,
+    onToggleFlag,
+}: Props) {
+    const selected = response?.selectedOption ?? null
+    const flagged = response?.isFlagged ?? false
+
+    return (
+        <div className="flex flex-col gap-5">
+            <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-gray-500">
+                    Question {questionNumber} of {totalQuestions}
+                </span>
+                <Button
+                    type="button"
+                    variant={flagged ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={onToggleFlag}
+                    aria-pressed={flagged}
+                >
+                    <Flag className="h-4 w-4" />
+                    {flagged ? 'Flagged' : 'Flag for review'}
+                </Button>
+            </div>
+
+            <div className="text-lg leading-relaxed">
+                <LatexText text={question.stem} />
+            </div>
+
+            {question.diagramUrl && (
+                <div className="rounded-md border p-3 bg-gray-50">
+                    <img
+                        src={question.diagramUrl}
+                        alt="Question diagram"
+                        className="max-h-80"
+                    />
+                </div>
+            )}
+
+            <div
+                role="radiogroup"
+                aria-label="Answer options"
+                className="flex flex-col gap-2"
+            >
+                {question.options.map((option) => {
+                    const isSelected = selected === option.label
+                    return (
+                        <button
+                            key={option.label}
+                            type="button"
+                            role="radio"
+                            aria-checked={isSelected}
+                            onClick={() => onAnswer(option.label)}
+                            className={cn(
+                                'flex items-start gap-3 rounded-md border px-4 py-3 text-left transition-colors',
+                                isSelected
+                                    ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500'
+                                    : 'border-gray-200 bg-white hover:border-gray-300'
+                            )}
+                        >
+                            <span
+                                className={cn(
+                                    'mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-sm font-semibold',
+                                    isSelected
+                                        ? 'border-blue-500 bg-blue-500 text-white'
+                                        : 'border-gray-300 text-gray-600'
+                                )}
+                            >
+                                {option.label}
+                            </span>
+                            <span className="pt-0.5">
+                                <LatexText text={option.text} />
+                            </span>
+                        </button>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}

--- a/src/hooks/diagnostic/useGetAttemptStateQuery.ts
+++ b/src/hooks/diagnostic/useGetAttemptStateQuery.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query'
+import { getAttemptStateDiagnosticAttemptsAttemptIdGet } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
+import { diagnosticAttemptQueryKey } from '@/lib/diagnosticAttemptQueryKey.ts'
+
+type Props = {
+    attemptId: string
+    enabled?: boolean
+}
+
+/**
+ * The exam screen's single source of truth (§7 crash-tolerance: this is
+ * also the reconnect/refresh rehydration path — a reload re-fetches the
+ * full attempt state and lands the student back where they were). The
+ * navigator and question pane both read this one cache entry; the answer/
+ * flag mutation patches it optimistically.
+ */
+export default function useGetAttemptStateQuery({ attemptId, enabled = true }: Props) {
+    return useQuery({
+        queryKey: diagnosticAttemptQueryKey(attemptId),
+        queryFn: async () =>
+            (
+                await getAttemptStateDiagnosticAttemptsAttemptIdGet({
+                    path: { attempt_id: attemptId },
+                    headers: getAuthHeaders(),
+                })
+            ).data,
+        enabled: enabled && attemptId !== '',
+    })
+}

--- a/src/hooks/diagnostic/useGetSetPreviewQuery.ts
+++ b/src/hooks/diagnostic/useGetSetPreviewQuery.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query'
+import { previewDiagnosticSetDiagnosticSetsSetIdPreviewGet } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
+
+type Props = {
+    setId: string
+    enabled?: boolean
+}
+
+/**
+ * The landing/instructions screen (§2), before an attempt exists — title,
+ * description, time limit, question count only. A draft or nonexistent set
+ * 404s identically here (the backend never confirms a draft set's
+ * existence to a non-admin), so the caller treats a failed query as
+ * "not available."
+ */
+export default function useGetSetPreviewQuery({ setId, enabled = true }: Props) {
+    return useQuery({
+        queryKey: ['diagnostic-set-preview', setId],
+        queryFn: async () =>
+            (
+                await previewDiagnosticSetDiagnosticSetsSetIdPreviewGet({
+                    path: { set_id: setId },
+                    headers: getAuthHeaders(),
+                })
+            ).data,
+        enabled: enabled && setId !== '',
+    })
+}

--- a/src/hooks/diagnostic/useStartOrResumeAttemptMutation.ts
+++ b/src/hooks/diagnostic/useStartOrResumeAttemptMutation.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query'
+import {
+    startOrResumeAttemptDiagnosticAttemptsPost,
+    type StartAttemptBody,
+} from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
+
+/**
+ * Start-or-resume (§7): the backend endpoint is idempotent per
+ * student+set, so this is the single "begin" action — if an in_progress
+ * attempt already exists it comes back unchanged, otherwise a new one is
+ * created. The caller reads the returned attempt id and navigates to the
+ * stable /diagnostic/attempts/{id} URL; a reload there re-fetches via
+ * useGetAttemptStateQuery rather than re-POSTing.
+ */
+export default function useStartOrResumeAttemptMutation() {
+    return useMutation({
+        mutationFn: async (body: StartAttemptBody) =>
+            (
+                await startOrResumeAttemptDiagnosticAttemptsPost({
+                    body,
+                    headers: getAuthHeaders(),
+                })
+            ).data,
+    })
+}

--- a/src/hooks/diagnostic/useUpsertResponseMutation.test.tsx
+++ b/src/hooks/diagnostic/useUpsertResponseMutation.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { PropsWithChildren } from 'react'
+import type { DiagnosticAttemptStateResponse } from '@/client'
+import { diagnosticAttemptQueryKey } from '@/lib/diagnosticAttemptQueryKey.ts'
+import useUpsertResponseMutation from './useUpsertResponseMutation'
+
+const mockUpsert = vi.fn()
+vi.mock('@/client', () => ({
+    upsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatch: (
+        ...args: unknown[]
+    ) => mockUpsert(...args),
+}))
+
+const ATTEMPT_ID = 'att-1'
+const KEY = diagnosticAttemptQueryKey(ATTEMPT_ID)
+
+function seedState(): DiagnosticAttemptStateResponse {
+    return {
+        attempt: {
+            id: ATTEMPT_ID,
+            diagnosticSetId: 'set-1',
+            status: 'in_progress',
+            startedAt: '2026-07-11T00:00:00Z',
+            serverDeadlineAt: '2026-07-11T01:00:00Z',
+            submittedAt: null,
+            agreedToTerms: true,
+            totalScore: null,
+        },
+        questions: [
+            { id: 'qa', stem: 'qa', options: [{ label: 'A', text: 'a' }] },
+            { id: 'qb', stem: 'qb', options: [{ label: 'A', text: 'a' }] },
+        ],
+        responses: [],
+    }
+}
+
+function makeClientAndWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    queryClient.setQueryData(KEY, seedState())
+    const wrapper = ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    return { queryClient, wrapper }
+}
+
+function cachedResponses(queryClient: QueryClient) {
+    return queryClient.getQueryData<DiagnosticAttemptStateResponse>(KEY)!.responses
+}
+
+describe('useUpsertResponseMutation', () => {
+    beforeEach(() => mockUpsert.mockReset())
+
+    it('optimistically appends a new response before the server confirms', async () => {
+        mockUpsert.mockResolvedValue({
+            data: { questionId: 'qa', questionOrderIndex: 0, selectedOption: 'A', isFlagged: false, viewCount: 0 },
+            error: undefined,
+            response: { status: 200, ok: true },
+        })
+        const { queryClient, wrapper } = makeClientAndWrapper()
+        const { result } = renderHook(() => useUpsertResponseMutation({ attemptId: ATTEMPT_ID }), { wrapper })
+
+        result.current.mutate({ questionId: 'qa', body: { selectedOption: 'A' } })
+
+        // Optimistic patch is synchronous within onMutate — the cache shows
+        // the answer immediately, keyed by questionOrderIndex derived from
+        // the questions array (qa is index 0).
+        await waitFor(() => {
+            const r = cachedResponses(queryClient).find((x) => x.questionId === 'qa')
+            expect(r?.selectedOption).toBe('A')
+            expect(r?.questionOrderIndex).toBe(0)
+        })
+    })
+
+    it('rolls back to the previous responses on a non-409 failure', async () => {
+        mockUpsert.mockResolvedValue({
+            data: undefined,
+            error: { detail: 'boom' },
+            response: { status: 500, ok: false },
+        })
+        const { queryClient, wrapper } = makeClientAndWrapper()
+        const { result } = renderHook(() => useUpsertResponseMutation({ attemptId: ATTEMPT_ID }), { wrapper })
+
+        result.current.mutate({ questionId: 'qa', body: { selectedOption: 'A' } })
+
+        await waitFor(() => expect(result.current.isError).toBe(true))
+        // The optimistic append was rolled back — responses is empty again.
+        expect(cachedResponses(queryClient)).toHaveLength(0)
+    })
+
+    it('on a 409 (timed out mid-click) rolls back and invalidates so the terminal state refetches', async () => {
+        mockUpsert.mockResolvedValue({
+            data: undefined,
+            error: { detail: "Attempt is 'timed_out' and cannot be submitted." },
+            response: { status: 409, ok: false },
+        })
+        const { queryClient, wrapper } = makeClientAndWrapper()
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+        const { result } = renderHook(() => useUpsertResponseMutation({ attemptId: ATTEMPT_ID }), { wrapper })
+
+        result.current.mutate({ questionId: 'qa', body: { selectedOption: 'A' } })
+
+        await waitFor(() => expect(result.current.isError).toBe(true))
+        // Rolled back...
+        expect(cachedResponses(queryClient)).toHaveLength(0)
+        // ...and the attempt query was invalidated, so ExamPage's status
+        // switch will flip to the terminal view on refetch.
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: KEY })
+    })
+})

--- a/src/hooks/diagnostic/useUpsertResponseMutation.ts
+++ b/src/hooks/diagnostic/useUpsertResponseMutation.ts
@@ -1,0 +1,131 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+    upsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatch,
+    type DiagnosticAttemptStateResponse,
+    type UpsertDiagnosticResponseBody,
+} from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
+import { diagnosticAttemptQueryKey } from '@/lib/diagnosticAttemptQueryKey.ts'
+
+/** Carries the HTTP status so onError can distinguish a 409 (attempt no
+ * longer in_progress — the buzzer-race case) from any other failure. */
+export class AttemptWriteError extends Error {
+    status: number
+    constructor(status: number) {
+        super(`Attempt write failed with status ${status}`)
+        this.status = status
+    }
+}
+
+type Variables = {
+    questionId: string
+    body: UpsertDiagnosticResponseBody
+}
+
+type Context = {
+    previous: DiagnosticAttemptStateResponse | undefined
+}
+
+/**
+ * Optimistic answer/flag write, following the exact recipe already in the
+ * codebase (useUpdateQuestionStatusMutation): onMutate cancels + snapshots
+ * + patches the single shared attempt-state entry so the click (answer
+ * select, flag toggle) and the navigator re-color feel instant; onError
+ * rolls back.
+ *
+ * The 409 case is handled deliberately, not as a raw error: if the attempt
+ * timed out between render and click, the write 409s — we roll back (it
+ * didn't land) and invalidate the attempt query, so the refetch returns
+ * status='timed_out' and ExamPage's status switch flips to the terminal
+ * view. Same mechanism PR 2's timer will reach; there's no error toast for
+ * this — running out of time is an expected outcome, not a failure.
+ */
+export default function useUpsertResponseMutation({ attemptId }: { attemptId: string }) {
+    const queryClient = useQueryClient()
+    const queryKey = diagnosticAttemptQueryKey(attemptId)
+
+    return useMutation<
+        DiagnosticAttemptStateResponse['responses'][number] | undefined,
+        AttemptWriteError,
+        Variables,
+        Context
+    >({
+        mutationFn: async ({ questionId, body }) => {
+            const result =
+                await upsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatch(
+                    {
+                        path: { attempt_id: attemptId, question_id: questionId },
+                        body,
+                        headers: getAuthHeaders(),
+                    }
+                )
+            if (result.error !== undefined) {
+                throw new AttemptWriteError(result.response.status)
+            }
+            return result.data
+        },
+        onMutate: async ({ questionId, body }): Promise<Context> => {
+            await queryClient.cancelQueries({ queryKey })
+            const previous =
+                queryClient.getQueryData<DiagnosticAttemptStateResponse>(queryKey)
+
+            // Normalize the body into the state's shape once. The body
+            // permits isFlagged:null (the PATCH contract), but a stored
+            // response's isFlagged is a plain boolean — only apply fields
+            // that were actually sent, coercing a null flag to false.
+            const patch: Partial<DiagnosticAttemptStateResponse['responses'][number]> = {}
+            if (body.selectedOption !== undefined) {
+                patch.selectedOption = body.selectedOption
+            }
+            if (body.isFlagged !== undefined && body.isFlagged !== null) {
+                patch.isFlagged = body.isFlagged
+            }
+
+            queryClient.setQueryData<DiagnosticAttemptStateResponse>(queryKey, (prev) => {
+                if (prev === undefined) return prev
+                const existing = prev.responses.find((r) => r.questionId === questionId)
+                if (existing) {
+                    return {
+                        ...prev,
+                        responses: prev.responses.map((r) =>
+                            r.questionId === questionId ? { ...r, ...patch } : r
+                        ),
+                    }
+                }
+                // First touch of this question — append a new response-state
+                // entry. questionOrderIndex is derived from the set's own
+                // question order (the questions array), matching what the
+                // server computes, so the optimistic row is consistent even
+                // before the refetch.
+                const orderIndex = prev.questions.findIndex((q) => q.id === questionId)
+                return {
+                    ...prev,
+                    responses: [
+                        ...prev.responses,
+                        {
+                            questionId,
+                            questionOrderIndex: orderIndex,
+                            selectedOption: patch.selectedOption ?? null,
+                            isFlagged: patch.isFlagged ?? false,
+                            viewCount: 0,
+                        },
+                    ],
+                }
+            })
+
+            return { previous }
+        },
+        onError: (error, _variables, context) => {
+            // Roll back the optimistic patch first, unconditionally.
+            if (context?.previous !== undefined) {
+                queryClient.setQueryData(queryKey, context.previous)
+            }
+            // A 409 means the attempt is no longer in_progress (timed out
+            // mid-click) — refetch so the terminal state renders via
+            // ExamPage's status switch, rather than surfacing an error.
+            if (error.status === 409) {
+                queryClient.invalidateQueries({ queryKey })
+            }
+        },
+    })
+}

--- a/src/lib/diagnosticAttemptQueryKey.ts
+++ b/src/lib/diagnosticAttemptQueryKey.ts
@@ -1,0 +1,12 @@
+/**
+ * The single query key for an attempt's full state (attempt + questions +
+ * responses), as returned by GET /diagnostic/attempts/{id}. Every part of
+ * the exam screen — navigator, question pane, timer (PR 2), event capture
+ * (PR 3) — reads from this one cache entry so nothing can drift; the
+ * optimistic answer/flag write patches this same entry. One helper so the
+ * key is spelled identically everywhere (a typo'd key is a silent
+ * second-source-of-truth bug).
+ */
+export function diagnosticAttemptQueryKey(attemptId: string): [string, string] {
+    return ['diagnostic-attempt', attemptId]
+}

--- a/src/pages/Diagnostic/ExamPage.test.tsx
+++ b/src/pages/Diagnostic/ExamPage.test.tsx
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ExamPage } from './ExamPage'
+import type { DiagnosticAttemptStateResponse } from '@/client'
+
+const mockUseGetAttemptStateQuery = vi.fn()
+const mockMutate = vi.fn()
+
+vi.mock('@/hooks/diagnostic/useGetAttemptStateQuery.ts', () => ({
+    default: (...args: unknown[]) => mockUseGetAttemptStateQuery(...args),
+}))
+vi.mock('@/hooks/diagnostic/useUpsertResponseMutation.ts', () => ({
+    default: () => ({ mutate: mockMutate }),
+}))
+vi.mock('react-router-dom', async () => {
+    const actual =
+        await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+    return {
+        ...actual,
+        useParams: () => ({ attemptId: 'att-1' }),
+        useNavigate: () => vi.fn(),
+    }
+})
+
+function state(
+    over: Partial<DiagnosticAttemptStateResponse> = {}
+): DiagnosticAttemptStateResponse {
+    return {
+        attempt: {
+            id: 'att-1',
+            diagnosticSetId: 'set-1',
+            status: 'in_progress',
+            startedAt: '2026-07-11T00:00:00Z',
+            serverDeadlineAt: '2026-07-11T01:00:00Z',
+            submittedAt: null,
+            agreedToTerms: true,
+            totalScore: null,
+        },
+        questions: [
+            { id: 'qa', stem: 'First question', options: [{ label: 'A', text: 'a1' }, { label: 'B', text: 'b1' }] },
+            { id: 'qb', stem: 'Second question', options: [{ label: 'A', text: 'a2' }, { label: 'B', text: 'b2' }] },
+            { id: 'qc', stem: 'Third question', options: [{ label: 'A', text: 'a3' }, { label: 'B', text: 'b3' }] },
+        ],
+        responses: [
+            { questionId: 'qc', questionOrderIndex: 2, selectedOption: 'B', isFlagged: true, viewCount: 1 },
+        ],
+        ...over,
+    }
+}
+
+function renderExam() {
+    return render(
+        <MemoryRouter initialEntries={['/diagnostic/attempts/att-1']}>
+            <ExamPage />
+        </MemoryRouter>
+    )
+}
+
+describe('ExamPage', () => {
+    beforeEach(() => {
+        mockUseGetAttemptStateQuery.mockReset()
+        mockMutate.mockReset()
+    })
+
+    it('renders the question UI for an in_progress attempt', () => {
+        mockUseGetAttemptStateQuery.mockReturnValue({ data: state(), isLoading: false, isError: false })
+        renderExam()
+        expect(screen.getByText('First question')).toBeInTheDocument()
+        expect(screen.getByText('Question 1 of 3')).toBeInTheDocument()
+    })
+
+    it('renders the closed view (not the question UI) for a timed_out attempt — the status switch', () => {
+        mockUseGetAttemptStateQuery.mockReturnValue({
+            data: state({ attempt: { ...state().attempt, status: 'timed_out' } }),
+            isLoading: false,
+            isError: false,
+        })
+        renderExam()
+        expect(screen.getByText(/Time's up/i)).toBeInTheDocument()
+        expect(screen.queryByText('First question')).not.toBeInTheDocument()
+    })
+
+    it('jumping directly to a question renders its already-saved answer and flag (Q5)', () => {
+        mockUseGetAttemptStateQuery.mockReturnValue({ data: state(), isLoading: false, isError: false })
+        renderExam()
+
+        // Jump straight to Q3 (skipping 2), which has selectedOption 'B'
+        // and isFlagged true saved on it.
+        fireEvent.click(screen.getByRole('button', { name: /Question 3/i }))
+
+        expect(screen.getByText('Third question')).toBeInTheDocument()
+        // Its saved answer B is rendered as selected, from the shared
+        // responses — not a blank render.
+        const optionB = screen
+            .getAllByRole('radio')
+            .find((el) => el.getAttribute('aria-checked') === 'true')
+        expect(optionB).toHaveTextContent('B')
+        // And its saved flag shows as active (anchored name so it doesn't
+        // also match navigator cells whose label contains "flagged").
+        expect(screen.getByRole('button', { name: /^Flagged$/ })).toHaveAttribute(
+            'aria-pressed',
+            'true'
+        )
+    })
+
+    it('selecting an option fires the upsert with that label', () => {
+        mockUseGetAttemptStateQuery.mockReturnValue({ data: state(), isLoading: false, isError: false })
+        renderExam()
+        fireEvent.click(screen.getByRole('radio', { name: /a1/i }))
+        expect(mockMutate).toHaveBeenCalledWith({
+            questionId: 'qa',
+            body: { selectedOption: 'A' },
+        })
+    })
+
+    it('does not fire a redundant write when re-selecting the already-selected option', () => {
+        mockUseGetAttemptStateQuery.mockReturnValue({ data: state(), isLoading: false, isError: false })
+        renderExam()
+        // Go to Q3 where B is already selected, click B again.
+        fireEvent.click(screen.getByRole('button', { name: /Question 3/i }))
+        fireEvent.click(screen.getByRole('radio', { name: /b3/i }))
+        expect(mockMutate).not.toHaveBeenCalled()
+    })
+
+    it('toggling the flag fires the upsert with the negated flag', () => {
+        mockUseGetAttemptStateQuery.mockReturnValue({ data: state(), isLoading: false, isError: false })
+        renderExam()
+        // Q1 is unflagged -> toggling sends isFlagged true.
+        fireEvent.click(screen.getByRole('button', { name: /Flag for review/i }))
+        expect(mockMutate).toHaveBeenCalledWith({
+            questionId: 'qa',
+            body: { isFlagged: true },
+        })
+    })
+})

--- a/src/pages/Diagnostic/ExamPage.tsx
+++ b/src/pages/Diagnostic/ExamPage.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { LoadingPage } from '@/components/common/FullLoadingPage.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { QuestionNavigator } from '@/components/diagnostic/exam/QuestionNavigator.tsx'
+import { QuestionPane } from '@/components/diagnostic/exam/QuestionPane.tsx'
+import { AttemptClosedView } from '@/components/diagnostic/exam/AttemptClosedView.tsx'
+import useGetAttemptStateQuery from '@/hooks/diagnostic/useGetAttemptStateQuery.ts'
+import useUpsertResponseMutation from '@/hooks/diagnostic/useUpsertResponseMutation.ts'
+
+/**
+ * The exam screen. Owns the single source of truth (the attempt-state
+ * query) and the one piece of genuinely-local view state (currentIndex —
+ * a pointer into the questions array, which can't drift from server data
+ * because it isn't server data). Switches on attempt.status: in_progress
+ * renders the question UI; any terminal status renders AttemptClosedView.
+ * A reload of this URL re-runs the query and rehydrates — the reconnect
+ * path (§7).
+ */
+export function ExamPage() {
+    const { attemptId } = useParams()
+    const navigate = useNavigate()
+    const [currentIndex, setCurrentIndex] = useState(0)
+
+    const { data: state, isLoading, isError } = useGetAttemptStateQuery({
+        attemptId: attemptId ?? '',
+    })
+    const { mutate: upsertResponse } = useUpsertResponseMutation({
+        attemptId: attemptId ?? '',
+    })
+
+    if (isLoading) return <LoadingPage />
+
+    if (isError || !state) {
+        return (
+            <div className="mx-auto mt-16 flex max-w-md flex-col items-center gap-4 text-center">
+                <h1 className="text-2xl font-semibold">Attempt not available</h1>
+                <p className="text-gray-600">
+                    This attempt couldn&apos;t be loaded. It may not exist or may
+                    not be yours.
+                </p>
+                <Button variant="outline" onClick={() => navigate('/')}>
+                    Back to home
+                </Button>
+            </div>
+        )
+    }
+
+    // Terminal states (submitted / timed_out / abandoned) render the closed
+    // view rather than the question UI — the same switch PR 2's timer and
+    // the 409-on-write handler both flip into.
+    if (state.attempt.status !== 'in_progress') {
+        return <AttemptClosedView attempt={state.attempt} />
+    }
+
+    const questions = state.questions
+    const responseByQuestionId = new Map(
+        state.responses.map((r) => [r.questionId, r])
+    )
+    const boundedIndex = Math.min(currentIndex, questions.length - 1)
+    const currentQuestion = questions[boundedIndex]
+    const currentResponse = responseByQuestionId.get(currentQuestion.id)
+
+    function handleAnswer(label: string) {
+        // No-op if unchanged — clicking the already-selected option
+        // shouldn't fire a redundant write (radios don't deselect here).
+        if (currentResponse?.selectedOption === label) return
+        upsertResponse({
+            questionId: currentQuestion.id,
+            body: { selectedOption: label },
+        })
+    }
+
+    function handleToggleFlag() {
+        upsertResponse({
+            questionId: currentQuestion.id,
+            body: { isFlagged: !(currentResponse?.isFlagged ?? false) },
+        })
+    }
+
+    return (
+        <div className="mx-auto mt-8 grid max-w-5xl grid-cols-1 gap-8 px-4 md:grid-cols-[1fr_220px]">
+            <div className="flex flex-col gap-6">
+                <QuestionPane
+                    question={currentQuestion}
+                    response={currentResponse}
+                    questionNumber={boundedIndex + 1}
+                    totalQuestions={questions.length}
+                    onAnswer={handleAnswer}
+                    onToggleFlag={handleToggleFlag}
+                />
+
+                <div className="flex items-center justify-between border-t pt-4">
+                    <Button
+                        type="button"
+                        variant="outline"
+                        disabled={boundedIndex === 0}
+                        onClick={() => setCurrentIndex(boundedIndex - 1)}
+                    >
+                        Previous
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        disabled={boundedIndex === questions.length - 1}
+                        onClick={() => setCurrentIndex(boundedIndex + 1)}
+                    >
+                        Next
+                    </Button>
+                </div>
+            </div>
+
+            <aside className="md:sticky md:top-8 md:self-start">
+                <QuestionNavigator
+                    questions={questions}
+                    responses={state.responses}
+                    currentIndex={boundedIndex}
+                    onJump={setCurrentIndex}
+                />
+            </aside>
+        </div>
+    )
+}

--- a/src/pages/Diagnostic/SetInstructionsPage.tsx
+++ b/src/pages/Diagnostic/SetInstructionsPage.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { LoadingPage } from '@/components/common/FullLoadingPage.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { Card, CardContent } from '@/components/ui/card.tsx'
+import { Checkbox } from '@/components/ui/checkbox.tsx'
+import useGetSetPreviewQuery from '@/hooks/diagnostic/useGetSetPreviewQuery.ts'
+import useStartOrResumeAttemptMutation from '@/hooks/diagnostic/useStartOrResumeAttemptMutation.ts'
+import { toast } from 'sonner'
+
+/**
+ * Landing/instructions screen (§2), before an attempt exists. Shows the
+ * set's time limit and question count, and the agreement checkbox that
+ * gives the traceability layer (§5, Stage 7) its contractual basis.
+ * "Start" calls the idempotent start-or-resume endpoint and navigates to
+ * the stable attempt URL — so a student who already has an in_progress
+ * attempt for this set is dropped straight back into it, clock still
+ * ticking (§7).
+ */
+export function SetInstructionsPage() {
+    const { setId } = useParams()
+    const navigate = useNavigate()
+    const [agreed, setAgreed] = useState(false)
+
+    const { data: preview, isLoading, isError } = useGetSetPreviewQuery({
+        setId: setId ?? '',
+    })
+    const { mutate: startAttempt, isPending } = useStartOrResumeAttemptMutation()
+
+    function handleStart() {
+        if (!setId) return
+        startAttempt(
+            { diagnosticSetId: setId, agreedToTerms: agreed },
+            {
+                onSuccess: (state) => {
+                    if (state) navigate(`/diagnostic/attempts/${state.attempt.id}`)
+                },
+                onError: () =>
+                    toast.error('Could not start the diagnostic. Please try again.'),
+            }
+        )
+    }
+
+    if (isLoading) return <LoadingPage />
+
+    if (isError || !preview) {
+        return (
+            <div className="mx-auto mt-16 flex max-w-md flex-col items-center gap-4 text-center">
+                <h1 className="text-2xl font-semibold">Diagnostic not available</h1>
+                <p className="text-gray-600">
+                    This diagnostic doesn&apos;t exist or isn&apos;t currently
+                    published.
+                </p>
+                <Button variant="outline" onClick={() => navigate('/')}>
+                    Back to home
+                </Button>
+            </div>
+        )
+    }
+
+    return (
+        <div className="mx-auto mt-12 flex max-w-2xl flex-col gap-6 px-4">
+            <div className="flex flex-col gap-2">
+                <h1 className="text-3xl font-semibold">{preview.title}</h1>
+                {preview.description && (
+                    <p className="text-gray-600">{preview.description}</p>
+                )}
+            </div>
+
+            <Card>
+                <CardContent className="grid grid-cols-2 gap-4 pt-6">
+                    <div className="flex flex-col">
+                        <span className="text-sm text-gray-500">Time limit</span>
+                        <span className="text-xl font-medium">
+                            {preview.timeLimitMinutes} minutes
+                        </span>
+                    </div>
+                    <div className="flex flex-col">
+                        <span className="text-sm text-gray-500">Questions</span>
+                        <span className="text-xl font-medium">
+                            {preview.questionCount}
+                        </span>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <div className="rounded-md border bg-amber-50 border-amber-200 px-4 py-3 text-sm text-amber-900">
+                Once you start, the timer runs continuously and cannot be paused —
+                the clock keeps going even if you close the tab. Make sure you can
+                finish in one sitting.
+            </div>
+
+            <label className="flex items-start gap-3 text-sm">
+                <Checkbox
+                    checked={agreed}
+                    onCheckedChange={(v) => setAgreed(v === true)}
+                    className="mt-0.5"
+                />
+                <span>
+                    I agree not to reproduce, share, or distribute any of this
+                    diagnostic&apos;s content.
+                </span>
+            </label>
+
+            <div>
+                <Button
+                    type="button"
+                    size="lg"
+                    disabled={!agreed || isPending}
+                    onClick={handleStart}
+                >
+                    {isPending ? 'Starting…' : 'Start diagnostic'}
+                </Button>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary

Stage 4 frontend, PR 1 of 4 (§2) — the core exam-taking screen: render a question, navigate, answer/flag. No timer, no auto-submit, no event capture yet (those are PR 2 and PR 3). Reviewed/approved turn-by-turn; the state architecture was settled up front specifically because PR 2 and PR 3 build on it.

**Screens:**
- `SetInstructionsPage` (`/diagnostic/sets/:setId`) — set preview (title, time limit, question count) + the agreement checkbox; Start calls the idempotent start-or-resume endpoint and redirects to the stable attempt URL.
- `ExamPage` (`/diagnostic/attempts/:attemptId`) — single-question-per-screen using the shared `LatexText` renderer (§9's one component) and a signed-URL `<img>` for diagrams, a colour-coded navigator (answered/flagged/unanswered), free navigation, Prev/Next. Both under `StudentProtectedRoute`, unlisted.

**State architecture** (the part worth reviewing closely):
- **One source of truth** — the `['diagnostic-attempt', attemptId]` query cache entry. Navigator and pane both read it; the only local state is `currentIndex` (a pointer that can't drift from server data).
- **Optimistic writes** with `onMutate` patch + `onError` rollback (the codebase's existing recipe). A **409** (attempt timed out mid-click) rolls back + invalidates → refetch's terminal status flips `ExamPage`'s status switch to `AttemptClosedView` (a clean "time's up", not an error). That switch is built now so PR 2's timer and PR 4's review extend one shape.
- Content fetched **once up front**; jumping to any question renders its persisted answer/flag from the shared source.

## Test plan

- [x] 61 unit tests (13 new), `tsc -b` + `eslint` clean. New tests specifically prove: navigator colours re-derive synchronously from the responses prop, free-nav renders saved answer+flag (Q5), and the optimistic-patch / rollback / 409→invalidate paths.
- [x] **Live end-to-end against the deployed prod backend** (throwaway student + published 3-question set with LaTeX and a diagram, cleaned up + independently verified gone):
  - Instructions preview renders (30 min, 3 questions); Start gated on the agreement checkbox
  - Start → stable `/diagnostic/attempts/{id}` URL
  - KaTeX-rendered stems and options; signed-URL SVG diagram renders
  - Answer + flag → **synchronous** navigator re-colour; writes confirmed **persisted** via a direct GET (`selectedOption: "A"`, `isFlagged: true`)
  - Jump directly to Q3 then back to Q1 → Q1's saved answer + flag render (not blank)
  - Full page reload → state rehydrates (navigator + selected answer intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)