### PR TITLE
Stage 4 (frontend) PR 2: timer + deadline + auto-submit

### DIFF
--- a/src/components/diagnostic/exam/ExamTimer.test.tsx
+++ b/src/components/diagnostic/exam/ExamTimer.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { ExamTimer } from './ExamTimer'
+
+const BASE = new Date('2026-07-11T00:00:00Z')
+const at = (secondsFromBase: number) =>
+    new Date(BASE.getTime() + secondsFromBase * 1000).toISOString()
+
+describe('ExamTimer', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(BASE)
+    })
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it('displays remaining time as M:SS derived from the deadline', () => {
+        render(<ExamTimer serverDeadlineAt={at(90)} onExpire={() => {}} />)
+        expect(screen.getByRole('timer')).toHaveTextContent('1:30')
+    })
+
+    it('ticks down each second, recomputing from the deadline (not an accumulator)', () => {
+        render(<ExamTimer serverDeadlineAt={at(90)} onExpire={() => {}} />)
+        act(() => vi.advanceTimersByTime(1000))
+        expect(screen.getByRole('timer')).toHaveTextContent('1:29')
+        act(() => vi.advanceTimersByTime(5000))
+        expect(screen.getByRole('timer')).toHaveTextContent('1:24')
+    })
+
+    it('stays correct after a gap (recompute-from-deadline survives throttled ticks)', () => {
+        render(<ExamTimer serverDeadlineAt={at(90)} onExpire={() => {}} />)
+        // Simulate the tab being backgrounded: jump the wall clock forward
+        // and let a single tick fire. Only one interval callback runs, so a
+        // decrement-accumulator would read ~1:29 (90 − 1); recompute reads
+        // the true remaining (deadline − now = 90 − 31 = 59s).
+        act(() => {
+            vi.setSystemTime(new Date(BASE.getTime() + 30_000))
+            vi.advanceTimersByTime(1000)
+        })
+        expect(screen.getByRole('timer')).toHaveTextContent('0:59')
+    })
+
+    it('fires onExpire exactly once when the deadline passes, and keeps showing 0:00', () => {
+        const onExpire = vi.fn()
+        render(<ExamTimer serverDeadlineAt={at(3)} onExpire={onExpire} />)
+        expect(onExpire).not.toHaveBeenCalled()
+        act(() => vi.advanceTimersByTime(3000))
+        expect(onExpire).toHaveBeenCalledTimes(1)
+        // Keeps ticking past zero but never re-fires.
+        act(() => vi.advanceTimersByTime(5000))
+        expect(onExpire).toHaveBeenCalledTimes(1)
+        expect(screen.getByRole('timer')).toHaveTextContent('0:00')
+    })
+
+    it('fires onExpire on mount when the deadline is already past', () => {
+        const onExpire = vi.fn()
+        render(<ExamTimer serverDeadlineAt={at(-60)} onExpire={onExpire} />)
+        expect(onExpire).toHaveBeenCalledTimes(1)
+        expect(screen.getByRole('timer')).toHaveTextContent('0:00')
+    })
+})

--- a/src/components/diagnostic/exam/ExamTimer.tsx
+++ b/src/components/diagnostic/exam/ExamTimer.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from 'react'
+import { cn } from '@/lib/utils.ts'
+
+type Props = {
+    serverDeadlineAt: string
+    onExpire: () => void
+}
+
+function formatRemaining(ms: number): string {
+    const totalSeconds = Math.max(0, Math.ceil(ms / 1000))
+    const minutes = Math.floor(totalSeconds / 60)
+    const seconds = totalSeconds % 60
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`
+}
+
+/**
+ * Always-visible, non-hideable countdown (§2). Displays only — the server
+ * is the source of truth for actual expiry (§1); if the client wall clock
+ * is skewed, the display is off by that skew but the server still enforces
+ * the real deadline.
+ *
+ * Deliberately recomputes remaining = deadline − now() on every tick,
+ * never decrements an accumulator: browsers throttle/pause setInterval in
+ * backgrounded tabs, so an accumulator would drift, but a recompute is
+ * always correct whenever it runs — and it also fires on
+ * visibilitychange→visible, so it snaps right the instant the tab is
+ * refocused.
+ *
+ * Fires onExpire exactly once when it crosses zero (the ref guard), even
+ * though it keeps ticking at 0. onExpire is held in a ref so a new inline
+ * callback from the parent doesn't tear down and rebuild the interval each
+ * render.
+ */
+export function ExamTimer({ serverDeadlineAt, onExpire }: Props) {
+    const deadlineMs = new Date(serverDeadlineAt).getTime()
+    const [remainingMs, setRemainingMs] = useState(() => deadlineMs - Date.now())
+
+    const onExpireRef = useRef(onExpire)
+    onExpireRef.current = onExpire
+    const expiredRef = useRef(false)
+
+    useEffect(() => {
+        function tick() {
+            const remaining = deadlineMs - Date.now()
+            setRemainingMs(remaining)
+            if (remaining <= 0 && !expiredRef.current) {
+                expiredRef.current = true
+                onExpireRef.current()
+            }
+        }
+        tick() // immediate, so an already-past deadline expires on mount
+        const intervalId = setInterval(tick, 1000)
+        const onVisibility = () => {
+            if (document.visibilityState === 'visible') tick()
+        }
+        document.addEventListener('visibilitychange', onVisibility)
+        return () => {
+            clearInterval(intervalId)
+            document.removeEventListener('visibilitychange', onVisibility)
+        }
+    }, [deadlineMs])
+
+    const urgent = remainingMs <= 60_000
+
+    return (
+        <div
+            role="timer"
+            aria-label="Time remaining"
+            className={cn(
+                'inline-flex items-center gap-2 rounded-md border px-3 py-1.5 font-mono text-lg tabular-nums',
+                urgent
+                    ? 'border-red-300 bg-red-50 text-red-700'
+                    : 'border-gray-200 bg-white text-gray-800'
+            )}
+        >
+            <span className="text-xs font-sans uppercase tracking-wide text-gray-400">
+                Time left
+            </span>
+            {formatRemaining(remainingMs)}
+        </div>
+    )
+}

--- a/src/hooks/diagnostic/useSubmitAttemptMutation.test.tsx
+++ b/src/hooks/diagnostic/useSubmitAttemptMutation.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { PropsWithChildren } from 'react'
+import { diagnosticAttemptQueryKey } from '@/lib/diagnosticAttemptQueryKey.ts'
+import useSubmitAttemptMutation from './useSubmitAttemptMutation'
+
+const mockSubmit = vi.fn()
+vi.mock('@/client', () => ({
+    submitAttemptDiagnosticAttemptsAttemptIdSubmitPost: (...args: unknown[]) =>
+        mockSubmit(...args),
+}))
+
+const ATTEMPT_ID = 'att-1'
+const KEY = diagnosticAttemptQueryKey(ATTEMPT_ID)
+
+function makeClientAndWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+    })
+    const wrapper = ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    return { queryClient, wrapper }
+}
+
+describe('useSubmitAttemptMutation', () => {
+    beforeEach(() => mockSubmit.mockReset())
+
+    it('invalidates the attempt query on a successful submit (so the terminal state refetches)', async () => {
+        mockSubmit.mockResolvedValue({
+            data: { attempt: { status: 'submitted' } },
+            error: undefined,
+            response: { status: 200, ok: true },
+        })
+        const { queryClient, wrapper } = makeClientAndWrapper()
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+        const { result } = renderHook(
+            () => useSubmitAttemptMutation({ attemptId: ATTEMPT_ID }),
+            { wrapper }
+        )
+
+        result.current.mutate()
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: KEY })
+    })
+
+    it('still invalidates on a 409 (already timed out) — same terminal outcome, no special-casing', async () => {
+        // With throwOnError=false the client resolves; the hook returns
+        // data:undefined but onSettled fires regardless, which is what we
+        // rely on to flip ExamPage to the closed view either way.
+        mockSubmit.mockResolvedValue({
+            data: undefined,
+            error: { detail: "Attempt is 'timed_out' and cannot be submitted." },
+            response: { status: 409, ok: false },
+        })
+        const { queryClient, wrapper } = makeClientAndWrapper()
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+        const { result } = renderHook(
+            () => useSubmitAttemptMutation({ attemptId: ATTEMPT_ID }),
+            { wrapper }
+        )
+
+        result.current.mutate()
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: KEY })
+    })
+})

--- a/src/hooks/diagnostic/useSubmitAttemptMutation.ts
+++ b/src/hooks/diagnostic/useSubmitAttemptMutation.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { submitAttemptDiagnosticAttemptsAttemptIdSubmitPost } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
+import { diagnosticAttemptQueryKey } from '@/lib/diagnosticAttemptQueryKey.ts'
+
+/**
+ * Submits (locks) the attempt — the action behind both the auto-submit at
+ * timer-zero (this PR) and, later, the manual submit from the review
+ * screen (PR 4). No body; answers/flags already landed via the response
+ * upsert.
+ *
+ * Treats 200 (submitted) and 409 (already timed_out) identically: both
+ * mean "the exam is over." Rather than branch on the status, it always
+ * invalidates the attempt query on settle, so the refetch returns the
+ * real terminal status and ExamPage's status switch renders
+ * AttemptClosedView — the same mechanism the 409-on-write path already
+ * uses. No error toast for the 409: running out of time is an expected
+ * outcome, not a failure.
+ */
+export default function useSubmitAttemptMutation({ attemptId }: { attemptId: string }) {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: async () =>
+            (
+                await submitAttemptDiagnosticAttemptsAttemptIdSubmitPost({
+                    path: { attempt_id: attemptId },
+                    headers: getAuthHeaders(),
+                })
+            ).data,
+        onSettled: () => {
+            queryClient.invalidateQueries({
+                queryKey: diagnosticAttemptQueryKey(attemptId),
+            })
+        },
+    })
+}

--- a/src/pages/Diagnostic/ExamPage.test.tsx
+++ b/src/pages/Diagnostic/ExamPage.test.tsx
@@ -6,12 +6,16 @@ import type { DiagnosticAttemptStateResponse } from '@/client'
 
 const mockUseGetAttemptStateQuery = vi.fn()
 const mockMutate = vi.fn()
+const mockSubmit = vi.fn()
 
 vi.mock('@/hooks/diagnostic/useGetAttemptStateQuery.ts', () => ({
     default: (...args: unknown[]) => mockUseGetAttemptStateQuery(...args),
 }))
 vi.mock('@/hooks/diagnostic/useUpsertResponseMutation.ts', () => ({
     default: () => ({ mutate: mockMutate }),
+}))
+vi.mock('@/hooks/diagnostic/useSubmitAttemptMutation.ts', () => ({
+    default: () => ({ mutate: mockSubmit }),
 }))
 vi.mock('react-router-dom', async () => {
     const actual =
@@ -61,6 +65,7 @@ describe('ExamPage', () => {
     beforeEach(() => {
         mockUseGetAttemptStateQuery.mockReset()
         mockMutate.mockReset()
+        mockSubmit.mockReset()
     })
 
     it('renders the question UI for an in_progress attempt', () => {
@@ -68,6 +73,29 @@ describe('ExamPage', () => {
         renderExam()
         expect(screen.getByText('First question')).toBeInTheDocument()
         expect(screen.getByText('Question 1 of 3')).toBeInTheDocument()
+    })
+
+    it('renders the always-visible countdown timer during an in_progress attempt', () => {
+        mockUseGetAttemptStateQuery.mockReturnValue({ data: state(), isLoading: false, isError: false })
+        renderExam()
+        expect(screen.getByRole('timer')).toBeInTheDocument()
+    })
+
+    it('auto-submits when the timer expires (deadline already past on mount)', () => {
+        // A deadline in the past: ExamTimer fires onExpire on mount, which
+        // must call the submit mutation exactly once.
+        mockUseGetAttemptStateQuery.mockReturnValue({
+            data: state({
+                attempt: {
+                    ...state().attempt,
+                    serverDeadlineAt: new Date(Date.now() - 1000).toISOString(),
+                },
+            }),
+            isLoading: false,
+            isError: false,
+        })
+        renderExam()
+        expect(mockSubmit).toHaveBeenCalledTimes(1)
     })
 
     it('renders the closed view (not the question UI) for a timed_out attempt — the status switch', () => {

--- a/src/pages/Diagnostic/ExamPage.tsx
+++ b/src/pages/Diagnostic/ExamPage.tsx
@@ -5,8 +5,10 @@ import { Button } from '@/components/ui/button.tsx'
 import { QuestionNavigator } from '@/components/diagnostic/exam/QuestionNavigator.tsx'
 import { QuestionPane } from '@/components/diagnostic/exam/QuestionPane.tsx'
 import { AttemptClosedView } from '@/components/diagnostic/exam/AttemptClosedView.tsx'
+import { ExamTimer } from '@/components/diagnostic/exam/ExamTimer.tsx'
 import useGetAttemptStateQuery from '@/hooks/diagnostic/useGetAttemptStateQuery.ts'
 import useUpsertResponseMutation from '@/hooks/diagnostic/useUpsertResponseMutation.ts'
+import useSubmitAttemptMutation from '@/hooks/diagnostic/useSubmitAttemptMutation.ts'
 
 /**
  * The exam screen. Owns the single source of truth (the attempt-state
@@ -26,6 +28,9 @@ export function ExamPage() {
         attemptId: attemptId ?? '',
     })
     const { mutate: upsertResponse } = useUpsertResponseMutation({
+        attemptId: attemptId ?? '',
+    })
+    const { mutate: submitAttempt } = useSubmitAttemptMutation({
         attemptId: attemptId ?? '',
     })
 
@@ -110,7 +115,11 @@ export function ExamPage() {
                 </div>
             </div>
 
-            <aside className="md:sticky md:top-8 md:self-start">
+            <aside className="flex flex-col gap-4 md:sticky md:top-8 md:self-start">
+                <ExamTimer
+                    serverDeadlineAt={state.attempt.serverDeadlineAt}
+                    onExpire={() => submitAttempt()}
+                />
                 <QuestionNavigator
                     questions={questions}
                     responses={state.responses}


### PR DESCRIPTION
## Summary

Stage 4 frontend, PR 2 of 4 (§1, §2) — the countdown timer, deadline handling, and auto-submit at zero. Builds on PR 1's status switch (the terminal view already existed). Pure frontend; the submit endpoint (#7) already exists.

- **`ExamTimer`** — always-visible, non-hideable M:SS countdown from `serverDeadlineAt`. **Recomputes `remaining = deadline − now()` every tick** (never a decrement-accumulator) and on `visibilitychange→visible`, so a throttled/paused background tab doesn't drift and snaps correct on refocus. Fires `onExpire` **exactly once** at zero (ref guard); `onExpire` held in a ref so an inline parent callback doesn't tear down the interval. Display only — the server stays the source of truth for actual expiry (§1); client clock skew affects the display, not enforcement.
- **`useSubmitAttemptMutation`** — submit (no body), invalidates the attempt query on settle. Treats **200 (submitted) and 409 (already timed_out) identically** — both mean "exam over"; the refetch's terminal status flips `ExamPage` to `AttemptClosedView`. No error toast.
- **`ExamPage`** — renders the timer; `onExpire` auto-submits. The two expiry paths stay complementary: present-at-zero → client auto-submit; returned-after-deadline → the GET's server-side lazy timeout already renders the closed view (timer never mounts). Server is the backstop; we don't try to guarantee client auto-submit for backgrounded/closed tabs.

## Test plan

- [x] 70 unit tests (9 new), `tsc -b` + `eslint` clean. New tests prove: M:SS display, tick-down, **recompute-survives-a-gap** (accumulator would drift, recompute doesn't), fire-once-at-zero, fire-on-mount-if-already-past, and submit-invalidates-on-both-200-and-409.
- [x] **Live end-to-end against prod** (1-minute throwaway set, cleaned up + verified gone):
  - Timer counts down live (0:55→0:43…), urgent red styling under the threshold
  - At zero, auto-submit fires; arriving past the deadline the server returns `timed_out` (`submitted_at` = the deadline — strict boundary, confirmed in the DB), and the UI transitions to **"Time's up"**
  - Reload after the deadline lands on the closed view (lazy-timeout on GET)
  - Reload mid-exam resumes the countdown from the still-ticking deadline (**0:43 → 0:30** across a reload, not reset to 1:00)

🤖 Generated with [Claude Code](https://claude.com/claude-code)