### PR TITLE
Stage 4 (frontend) PR 3: timing/flagging event capture

### DIFF
--- a/src/hooks/diagnostic/useEventCapture.test.tsx
+++ b/src/hooks/diagnostic/useEventCapture.test.tsx
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import useEventCapture from './useEventCapture'
+
+const mockIngest = vi.fn()
+vi.mock('@/client', () => ({
+    ingestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPost: (...args: unknown[]) =>
+        mockIngest(...args),
+}))
+
+const ATTEMPT_ID = 'att-1'
+
+function ok() {
+    return { data: { acceptedCount: 1 }, error: undefined, response: { status: 200, ok: true } }
+}
+function fail() {
+    return { data: undefined, error: { detail: 'boom' }, response: { status: 500, ok: false } }
+}
+
+describe('useEventCapture', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+        mockIngest.mockReset()
+    })
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it('buffers events and flushes them as a batch on the periodic interval', async () => {
+        mockIngest.mockResolvedValue(ok())
+        const { result } = renderHook(() =>
+            useEventCapture({ attemptId: ATTEMPT_ID, currentQuestionId: 'q1' })
+        )
+        act(() => {
+            result.current.recordEvent('q1', 'enter')
+            result.current.recordEvent('q1', 'answer_change')
+        })
+        // Nothing sent until the flush fires.
+        expect(mockIngest).not.toHaveBeenCalled()
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(5000)
+        })
+
+        expect(mockIngest).toHaveBeenCalledTimes(1)
+        const body = mockIngest.mock.calls[0][0].body
+        expect(body.events.map((e: { eventType: string }) => e.eventType)).toEqual([
+            'enter',
+            'answer_change',
+        ])
+        // Each event carries a clientTs captured at record time.
+        expect(body.events[0].clientTs).toBeTruthy()
+        expect(mockIngest.mock.calls[0][0].path).toEqual({ attempt_id: ATTEMPT_ID })
+    })
+
+    it('empties the buffer on a successful flush (no re-send next tick)', async () => {
+        mockIngest.mockResolvedValue(ok())
+        const { result } = renderHook(() =>
+            useEventCapture({ attemptId: ATTEMPT_ID, currentQuestionId: 'q1' })
+        )
+        act(() => result.current.recordEvent('q1', 'enter'))
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(5000)
+        })
+        expect(mockIngest).toHaveBeenCalledTimes(1)
+        // Next tick with an empty buffer sends nothing.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(5000)
+        })
+        expect(mockIngest).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-queues events on a failed flush (at-least-once) so the next flush retries them', async () => {
+        mockIngest.mockResolvedValueOnce(fail()).mockResolvedValueOnce(ok())
+        const { result } = renderHook(() =>
+            useEventCapture({ attemptId: ATTEMPT_ID, currentQuestionId: 'q1' })
+        )
+        act(() => result.current.recordEvent('q1', 'answer_change'))
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(5000)
+        })
+        expect(mockIngest).toHaveBeenCalledTimes(1) // first, failed
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(5000)
+        })
+        expect(mockIngest).toHaveBeenCalledTimes(2) // retried
+        // The retry carries the same event, not a dropped one.
+        expect(mockIngest.mock.calls[1][0].body.events[0].eventType).toBe('answer_change')
+    })
+
+    it('passes keepalive on a forced keepalive flush (unload path)', async () => {
+        mockIngest.mockResolvedValue(ok())
+        const { result } = renderHook(() =>
+            useEventCapture({ attemptId: ATTEMPT_ID, currentQuestionId: 'q1' })
+        )
+        act(() => result.current.recordEvent('q1', 'exit'))
+        await act(async () => {
+            await result.current.flush({ keepalive: true, force: true })
+        })
+        expect(mockIngest.mock.calls[0][0].keepalive).toBe(true)
+    })
+
+    it('records blur on tab-hide (with a keepalive flush) and focus on tab-show', async () => {
+        mockIngest.mockResolvedValue(ok())
+        const visibility = vi.spyOn(document, 'visibilityState', 'get')
+        renderHook(() =>
+            useEventCapture({ attemptId: ATTEMPT_ID, currentQuestionId: 'q7' })
+        )
+
+        visibility.mockReturnValue('hidden')
+        await act(async () => {
+            document.dispatchEvent(new Event('visibilitychange'))
+            // Let the flush's promise settle (avoid waitFor, which polls on
+            // real timers and would deadlock against the fake ones).
+            await vi.advanceTimersByTimeAsync(0)
+        })
+        // A blur event was sent with keepalive on hide.
+        expect(mockIngest).toHaveBeenCalled()
+        const hideBody = mockIngest.mock.calls[0][0]
+        expect(hideBody.body.events[0]).toMatchObject({ questionId: 'q7', eventType: 'blur' })
+        expect(hideBody.keepalive).toBe(true)
+
+        // On show, a focus event is buffered (flushed on the next tick).
+        mockIngest.mockClear()
+        visibility.mockReturnValue('visible')
+        act(() => document.dispatchEvent(new Event('visibilitychange')))
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(5000)
+        })
+        expect(mockIngest.mock.calls[0][0].body.events[0]).toMatchObject({
+            questionId: 'q7',
+            eventType: 'focus',
+        })
+        visibility.mockRestore()
+    })
+})

--- a/src/hooks/diagnostic/useEventCapture.ts
+++ b/src/hooks/diagnostic/useEventCapture.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef } from 'react'
+import {
+    ingestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPost,
+    type DiagnosticQuestionEvent,
+} from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
+
+type EventType = DiagnosticQuestionEvent['eventType']
+
+const FLUSH_INTERVAL_MS = 5000
+
+type FlushOptions = {
+    /** Use fetch keepalive so the request survives tab-close/unload. */
+    keepalive?: boolean
+    /** Bypass the single-in-flight guard — for the final/unload flush,
+     *  where guaranteeing the tail lands matters more than avoiding a
+     *  rare concurrent request. */
+    force?: boolean
+}
+
+/**
+ * Client-side capture of the timing/flagging event log (§4). Owns the
+ * buffer (a ref — no re-render per event), the transport, and the
+ * automatic flush triggers (periodic, tab-hidden, unload). The caller
+ * (ExamPage) drives the semantic events — enter/exit on navigation,
+ * answer_change, flag/unflag — via recordEvent, and the final flush via
+ * flush(); blur/focus are captured here against the current question.
+ *
+ * Delivery is at-least-once, deliberately: a flush snapshots-and-removes
+ * the buffer, and re-queues the snapshot on failure. The event log exists
+ * to reconstruct what happened, so a lost event defeats its purpose,
+ * whereas a rare duplicate (only if the server processed a request the
+ * client saw as failed) is tolerable and could be deduped later. A single
+ * in-flight guard prevents concurrent flushes from sending overlapping
+ * batches.
+ */
+export default function useEventCapture({
+    attemptId,
+    currentQuestionId,
+}: {
+    attemptId: string
+    currentQuestionId: string | undefined
+}) {
+    const bufferRef = useRef<DiagnosticQuestionEvent[]>([])
+    const flushingRef = useRef(false)
+    const attemptIdRef = useRef(attemptId)
+    attemptIdRef.current = attemptId
+    const currentQuestionIdRef = useRef(currentQuestionId)
+    currentQuestionIdRef.current = currentQuestionId
+
+    const recordEvent = useCallback((questionId: string, eventType: EventType) => {
+        // clientTs is captured now, when the event happened — not at flush
+        // time. The server stamps its own server_ts per batch; clientTs
+        // preserves the real per-event moment (§4, never trusted alone).
+        bufferRef.current.push({
+            questionId,
+            eventType,
+            clientTs: new Date().toISOString(),
+        })
+    }, [])
+
+    const flush = useCallback(async (opts?: FlushOptions) => {
+        if (bufferRef.current.length === 0) return
+        if (flushingRef.current && !opts?.force) return
+
+        // Snapshot-and-remove: take the current events out atomically so a
+        // concurrent flush can't re-grab them and new events accumulate
+        // separately.
+        const snapshot = bufferRef.current.splice(0, bufferRef.current.length)
+        flushingRef.current = true
+        try {
+            const result =
+                await ingestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPost({
+                    path: { attempt_id: attemptIdRef.current },
+                    body: { events: snapshot },
+                    headers: getAuthHeaders(),
+                    ...(opts?.keepalive ? { keepalive: true } : {}),
+                })
+            if (result.error !== undefined) {
+                // Re-queue at the front to retry on the next flush.
+                bufferRef.current.unshift(...snapshot)
+            }
+        } catch {
+            bufferRef.current.unshift(...snapshot)
+        } finally {
+            flushingRef.current = false
+        }
+    }, [])
+
+    // Periodic flush — every few seconds (§4).
+    useEffect(() => {
+        const id = setInterval(() => void flush(), FLUSH_INTERVAL_MS)
+        return () => clearInterval(id)
+    }, [flush])
+
+    // Tab-hidden/visible: blur/focus against the question being viewed
+    // (which is what makes "stuck for 3 min" distinguishable from "tabbed
+    // away for 3 min", §4), plus a keepalive flush on hide so a
+    // backgrounded/closing tab doesn't strand the buffer. Independent of
+    // the timer's own visibilitychange listener — addEventListener stacks,
+    // neither overrides the other.
+    useEffect(() => {
+        const onVisibility = () => {
+            const qid = currentQuestionIdRef.current
+            if (qid === undefined) return
+            if (document.visibilityState === 'hidden') {
+                recordEvent(qid, 'blur')
+                void flush({ keepalive: true, force: true })
+            } else {
+                recordEvent(qid, 'focus')
+            }
+        }
+        document.addEventListener('visibilitychange', onVisibility)
+        return () => document.removeEventListener('visibilitychange', onVisibility)
+    }, [flush, recordEvent])
+
+    // pagehide: the definitive unload signal — force a keepalive flush of
+    // whatever remains (visibilitychange→hidden covers most backgrounding,
+    // pagehide covers the actual close/navigation-away).
+    useEffect(() => {
+        const onPageHide = () => void flush({ keepalive: true, force: true })
+        window.addEventListener('pagehide', onPageHide)
+        return () => window.removeEventListener('pagehide', onPageHide)
+    }, [flush])
+
+    return { recordEvent, flush }
+}

--- a/src/pages/Diagnostic/ExamPage.test.tsx
+++ b/src/pages/Diagnostic/ExamPage.test.tsx
@@ -17,6 +17,11 @@ vi.mock('@/hooks/diagnostic/useUpsertResponseMutation.ts', () => ({
 vi.mock('@/hooks/diagnostic/useSubmitAttemptMutation.ts', () => ({
     default: () => ({ mutate: mockSubmit }),
 }))
+const mockRecordEvent = vi.fn()
+const mockFlush = vi.fn()
+vi.mock('@/hooks/diagnostic/useEventCapture.ts', () => ({
+    default: () => ({ recordEvent: mockRecordEvent, flush: mockFlush }),
+}))
 vi.mock('react-router-dom', async () => {
     const actual =
         await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
@@ -66,6 +71,8 @@ describe('ExamPage', () => {
         mockUseGetAttemptStateQuery.mockReset()
         mockMutate.mockReset()
         mockSubmit.mockReset()
+        mockRecordEvent.mockReset()
+        mockFlush.mockReset()
     })
 
     it('renders the question UI for an in_progress attempt', () => {
@@ -160,5 +167,44 @@ describe('ExamPage', () => {
             questionId: 'qa',
             body: { isFlagged: true },
         })
+    })
+
+    it('records an answer_change event when an answer is selected', () => {
+        mockUseGetAttemptStateQuery.mockReturnValue({ data: state(), isLoading: false, isError: false })
+        renderExam()
+        fireEvent.click(screen.getByRole('radio', { name: /a1/i }))
+        expect(mockRecordEvent).toHaveBeenCalledWith('qa', 'answer_change')
+    })
+
+    it('records flag on flagging and unflag on unflagging', () => {
+        // Q3 starts flagged (isFlagged true in the fixture) — go there and
+        // toggle it off, expecting an unflag event.
+        mockUseGetAttemptStateQuery.mockReturnValue({ data: state(), isLoading: false, isError: false })
+        renderExam()
+
+        // Q1 (unflagged) -> flag.
+        fireEvent.click(screen.getByRole('button', { name: /Flag for review/i }))
+        expect(mockRecordEvent).toHaveBeenCalledWith('qa', 'flag')
+
+        // Jump to Q3 (flagged) -> unflag.
+        fireEvent.click(screen.getByRole('button', { name: /Question 3/i }))
+        fireEvent.click(screen.getByRole('button', { name: /^Flagged$/ }))
+        expect(mockRecordEvent).toHaveBeenCalledWith('qc', 'unflag')
+    })
+
+    it('flushes buffered events before auto-submitting at timer expiry', () => {
+        mockUseGetAttemptStateQuery.mockReturnValue({
+            data: state({
+                attempt: {
+                    ...state().attempt,
+                    serverDeadlineAt: new Date(Date.now() - 1000).toISOString(),
+                },
+            }),
+            isLoading: false,
+            isError: false,
+        })
+        renderExam()
+        expect(mockFlush).toHaveBeenCalled()
+        expect(mockSubmit).toHaveBeenCalledTimes(1)
     })
 })

--- a/src/pages/Diagnostic/ExamPage.tsx
+++ b/src/pages/Diagnostic/ExamPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { LoadingPage } from '@/components/common/FullLoadingPage.tsx'
 import { Button } from '@/components/ui/button.tsx'
@@ -9,6 +9,7 @@ import { ExamTimer } from '@/components/diagnostic/exam/ExamTimer.tsx'
 import useGetAttemptStateQuery from '@/hooks/diagnostic/useGetAttemptStateQuery.ts'
 import useUpsertResponseMutation from '@/hooks/diagnostic/useUpsertResponseMutation.ts'
 import useSubmitAttemptMutation from '@/hooks/diagnostic/useSubmitAttemptMutation.ts'
+import useEventCapture from '@/hooks/diagnostic/useEventCapture.ts'
 
 /**
  * The exam screen. Owns the single source of truth (the attempt-state
@@ -34,6 +35,41 @@ export function ExamPage() {
         attemptId: attemptId ?? '',
     })
 
+    // Computed before the early returns so the event-capture hooks below
+    // stay unconditional (rules of hooks). currentQuestionId is undefined
+    // whenever the attempt isn't in_progress, so the enter/exit effect
+    // naturally fires the final exit when the status flips to terminal.
+    const inProgress = state?.attempt.status === 'in_progress'
+    const questions = state?.questions ?? []
+    const boundedIndex =
+        questions.length > 0 ? Math.min(currentIndex, questions.length - 1) : 0
+    const currentQuestionId =
+        inProgress && questions.length > 0 ? questions[boundedIndex].id : undefined
+
+    const { recordEvent, flush } = useEventCapture({
+        attemptId: attemptId ?? '',
+        currentQuestionId,
+    })
+
+    // Declared BEFORE the enter/exit effect so, on a true unmount (leaving
+    // the page), React runs the enter/exit cleanup first (recording the
+    // final exit) and this forced keepalive flush second — sending it.
+    useEffect(() => {
+        return () => void flush({ force: true, keepalive: true })
+    }, [flush])
+
+    // enter on arrival (+ flush-on-navigation: the flush sends this enter
+    // plus the previous question's exit recorded in the prior cleanup),
+    // exit on leaving. Keyed on currentQuestionId so it fires on nav and on
+    // the in_progress→terminal transition (currentQuestionId → undefined).
+    useEffect(() => {
+        if (currentQuestionId === undefined) return
+        recordEvent(currentQuestionId, 'enter')
+        void flush()
+        return () => recordEvent(currentQuestionId, 'exit')
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [currentQuestionId])
+
     if (isLoading) return <LoadingPage />
 
     if (isError || !state) {
@@ -58,11 +94,9 @@ export function ExamPage() {
         return <AttemptClosedView attempt={state.attempt} />
     }
 
-    const questions = state.questions
     const responseByQuestionId = new Map(
         state.responses.map((r) => [r.questionId, r])
     )
-    const boundedIndex = Math.min(currentIndex, questions.length - 1)
     const currentQuestion = questions[boundedIndex]
     const currentResponse = responseByQuestionId.get(currentQuestion.id)
 
@@ -74,13 +108,25 @@ export function ExamPage() {
             questionId: currentQuestion.id,
             body: { selectedOption: label },
         })
+        recordEvent(currentQuestion.id, 'answer_change')
     }
 
     function handleToggleFlag() {
+        const willBeFlagged = !(currentResponse?.isFlagged ?? false)
         upsertResponse({
             questionId: currentQuestion.id,
-            body: { isFlagged: !(currentResponse?.isFlagged ?? false) },
+            body: { isFlagged: willBeFlagged },
         })
+        recordEvent(currentQuestion.id, willBeFlagged ? 'flag' : 'unflag')
+    }
+
+    function handleExpire() {
+        // Flush what's buffered promptly at exam-end so it lands while the
+        // attempt is still in_progress (accepted outright); the final exit,
+        // recorded when the status flips to timed_out, then lands within
+        // the backend's 30s post-timeout grace via the periodic flush.
+        void flush()
+        submitAttempt()
     }
 
     return (
@@ -118,7 +164,7 @@ export function ExamPage() {
             <aside className="flex flex-col gap-4 md:sticky md:top-8 md:self-start">
                 <ExamTimer
                     serverDeadlineAt={state.attempt.serverDeadlineAt}
-                    onExpire={() => submitAttempt()}
+                    onExpire={handleExpire}
                 />
                 <QuestionNavigator
                     questions={questions}


### PR DESCRIPTION
## Summary

Stage 4 frontend, PR 3 of 4 (§4) — client-side capture of the timing/flagging event log (the raw material for time-management analysis in the report). Wires into the exam screen from PR 1/2.

- **`useEventCapture({ attemptId, currentQuestionId })`** — owns the buffer (a **ref**, no re-render per event), the transport, and the automatic flush triggers (periodic every 5s, tab-hidden with keepalive, `pagehide`). Exposes `recordEvent` + `flush`. Each event carries `clientTs` captured **at record time**; `blur`/`focus` are captured here against the current question (the "stuck vs tabbed-away" distinction).
- **`ExamPage`** drives the semantic events: `enter`/`exit` via an effect keyed on `currentQuestionId` (enter + flush-on-nav on arrival, exit on leave — which also fires the final exit when the status flips to terminal), `answer_change` in `handleAnswer`, `flag`/`unflag` in `handleToggleFlag`.

**The two requested design points:**
- **Final flush at exam-end, not just tab-close.** On auto-submit at zero, the buffer is flushed *before* submit, and the final `exit` (recorded when the status flips to `timed_out`) lands via the periodic flush within the backend's **30s post-timeout grace window** — which is exactly what that grace is for. A forced keepalive flush on unmount is the backstop.
- **Concurrency: at-least-once, deliberately.** A flush **snapshots-and-removes** the buffer and **re-queues on failure** (a lost event defeats the log's purpose; a rare duplicate is tolerable and dedup-able later). A **single in-flight guard** prevents concurrent overlapping sends; the final/unload flush is the one `force` exception, and snapshot-remove means it won't overlap an in-flight periodic flush anyway.

The capture's `visibilitychange` listener is independent of the timer's — `addEventListener` stacks, neither overrides the other.

## Test plan

- [x] 78 unit tests (8 new), `tsc -b` + `eslint` clean. New tests prove: batch-on-interval, empty-on-success, **re-queue-on-failure (at-least-once)**, keepalive passthrough, and blur-on-hide/focus-on-show; plus ExamPage records answer_change/flag/unflag and flushes before auto-submit.
- [x] **Live against prod** (throwaway set, cleaned up + verified gone): drove a real sequence and read `diagnostic_question_events` back — `enter → answer_change → flag → blur → focus → exit → enter` **reconstructed exactly**, blur/focus attributed to the viewed question, per-event `clientTs` preserved, nav flush sending the exit/enter pair.
- [x] **Final-flush-on-end, real 1-minute timeout:** the final `exit` landed ~1s after the deadline via the status-flip → periodic-flush path, **within grace**; attempt `timed_out`.
- Note: re-queue-on-failure is unit-verified (rigorously), not forced live; the hard-browser-navigation path (vs SPA exam-end) is inherently best-effort by design — the exam-end path that matters is the one proven above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)