### PR TITLE
Stage 4 (frontend) PR 4: review screen + manual submit

### DIFF
--- a/src/components/diagnostic/exam/QuestionNavigator.tsx
+++ b/src/components/diagnostic/exam/QuestionNavigator.tsx
@@ -3,6 +3,7 @@ import type {
     StudentDiagnosticQuestionResponse,
 } from '@/client'
 import { cn } from '@/lib/utils.ts'
+import { isAnswered, isFlagged } from '@/lib/diagnosticResponseSummary.ts'
 
 type Props = {
     questions: StudentDiagnosticQuestionResponse[]
@@ -27,10 +28,8 @@ export function QuestionNavigator({ questions, responses, currentIndex, onJump }
             <div className="grid grid-cols-5 gap-2">
                 {questions.map((question, index) => {
                     const response = byQuestionId.get(question.id)
-                    const answered =
-                        response?.selectedOption !== undefined &&
-                        response?.selectedOption !== null
-                    const flagged = response?.isFlagged ?? false
+                    const answered = isAnswered(response)
+                    const flagged = isFlagged(response)
                     const isCurrent = index === currentIndex
 
                     return (

--- a/src/components/diagnostic/exam/ReviewDialog.tsx
+++ b/src/components/diagnostic/exam/ReviewDialog.tsx
@@ -1,0 +1,92 @@
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import type { ResponseSummary } from '@/lib/diagnosticResponseSummary.ts'
+
+type Props = {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    summary: ResponseSummary
+    onConfirm: () => void
+    isSubmitting: boolean
+}
+
+/**
+ * The review-before-submit step (§2). The counts come from
+ * summarizeResponses over the same shared response-state the navigator
+ * colours from, so they can't disagree with the grid. "Keep working"
+ * just dismisses; "Submit" runs the manual-submit path (which flushes the
+ * event buffer before locking the attempt, since a submitted attempt has
+ * no grace window).
+ */
+export function ReviewDialog({
+    open,
+    onOpenChange,
+    summary,
+    onConfirm,
+    isSubmitting,
+}: Props) {
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Submit your diagnostic?</DialogTitle>
+                    <DialogDescription>
+                        Once you submit, you can&apos;t change your answers.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <dl className="grid grid-cols-3 gap-3 py-2">
+                    <div className="flex flex-col items-center rounded-md border p-3">
+                        <dt className="text-xs uppercase text-gray-400">Answered</dt>
+                        <dd className="text-2xl font-semibold">
+                            {summary.answered}
+                            <span className="text-base font-normal text-gray-400">
+                                /{summary.total}
+                            </span>
+                        </dd>
+                    </div>
+                    <div className="flex flex-col items-center rounded-md border p-3">
+                        <dt className="text-xs uppercase text-gray-400">Flagged</dt>
+                        <dd className="text-2xl font-semibold">{summary.flagged}</dd>
+                    </div>
+                    <div className="flex flex-col items-center rounded-md border p-3">
+                        <dt className="text-xs uppercase text-gray-400">
+                            Unanswered
+                        </dt>
+                        <dd className="text-2xl font-semibold">
+                            {summary.unanswered}
+                        </dd>
+                    </div>
+                </dl>
+
+                {summary.unanswered > 0 && (
+                    <p className="text-sm text-amber-700">
+                        You still have {summary.unanswered} unanswered{' '}
+                        {summary.unanswered === 1 ? 'question' : 'questions'}.
+                    </p>
+                )}
+
+                <DialogFooter>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                        disabled={isSubmitting}
+                    >
+                        Keep working
+                    </Button>
+                    <Button type="button" onClick={onConfirm} disabled={isSubmitting}>
+                        {isSubmitting ? 'Submitting…' : 'Submit'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/hooks/diagnostic/useEventCapture.test.tsx
+++ b/src/hooks/diagnostic/useEventCapture.test.tsx
@@ -90,6 +90,40 @@ describe('useEventCapture', () => {
         expect(mockIngest.mock.calls[1][0].body.events[0].eventType).toBe('answer_change')
     })
 
+    it('flushBeforeSubmit drains the buffer in one shot when the send succeeds', async () => {
+        mockIngest.mockResolvedValue(ok())
+        const { result } = renderHook(() =>
+            useEventCapture({ attemptId: ATTEMPT_ID, currentQuestionId: 'q1' })
+        )
+        act(() => result.current.recordEvent('q1', 'exit'))
+        let drained: boolean | undefined
+        await act(async () => {
+            drained = await result.current.flushBeforeSubmit()
+        })
+        expect(drained).toBe(true)
+        expect(mockIngest).toHaveBeenCalledTimes(1)
+    })
+
+    it('flushBeforeSubmit retries a failing send up to the bound, then reports failure', async () => {
+        // Always fails — flushBeforeSubmit should try 3 times and return
+        // false (the caller then submits anyway rather than trapping the
+        // student).
+        mockIngest.mockResolvedValue(fail())
+        const { result } = renderHook(() =>
+            useEventCapture({ attemptId: ATTEMPT_ID, currentQuestionId: 'q1' })
+        )
+        act(() => result.current.recordEvent('q1', 'exit'))
+        let drained: boolean | undefined
+        await act(async () => {
+            const p = result.current.flushBeforeSubmit()
+            // Advance through the inter-attempt backoffs.
+            await vi.advanceTimersByTimeAsync(1000)
+            drained = await p
+        })
+        expect(drained).toBe(false)
+        expect(mockIngest).toHaveBeenCalledTimes(3)
+    })
+
     it('passes keepalive on a forced keepalive flush (unload path)', async () => {
         mockIngest.mockResolvedValue(ok())
         const { result } = renderHook(() =>

--- a/src/hooks/diagnostic/useEventCapture.ts
+++ b/src/hooks/diagnostic/useEventCapture.ts
@@ -87,6 +87,27 @@ export default function useEventCapture({
         }
     }, [])
 
+    // A genuinely blocking flush for the one call site that needs it:
+    // manual submit (PR 4). A submitted attempt has NO post-lock grace
+    // window (unlike timed_out), so the buffer — including the final exit
+    // recorded just before — must land BEFORE the submit locks it. Unlike
+    // every other flush here (fire-and-forget `void flush()`), this is
+    // awaited: bounded retry so a network blip at the moment of submit
+    // gets another shot, then it returns whether the buffer drained. The
+    // caller submits regardless of the result — losing a few seconds of
+    // analytics must never trap a student unable to finish their exam.
+    const flushBeforeSubmit = useCallback(
+        async (maxAttempts = 3): Promise<boolean> => {
+            for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+                await flush({ force: true })
+                if (bufferRef.current.length === 0) return true
+                await new Promise((resolve) => setTimeout(resolve, 300))
+            }
+            return bufferRef.current.length === 0
+        },
+        [flush]
+    )
+
     // Periodic flush — every few seconds (§4).
     useEffect(() => {
         const id = setInterval(() => void flush(), FLUSH_INTERVAL_MS)
@@ -123,5 +144,5 @@ export default function useEventCapture({
         return () => window.removeEventListener('pagehide', onPageHide)
     }, [flush])
 
-    return { recordEvent, flush }
+    return { recordEvent, flush, flushBeforeSubmit }
 }

--- a/src/lib/diagnosticResponseSummary.test.ts
+++ b/src/lib/diagnosticResponseSummary.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import {
+    isAnswered,
+    isFlagged,
+    summarizeResponses,
+} from './diagnosticResponseSummary'
+import type {
+    DiagnosticResponseState,
+    StudentDiagnosticQuestionResponse,
+} from '@/client'
+
+function q(id: string): StudentDiagnosticQuestionResponse {
+    return { id, stem: id, options: [{ label: 'A', text: 'x' }] }
+}
+function resp(
+    questionId: string,
+    over: Partial<DiagnosticResponseState> = {}
+): DiagnosticResponseState {
+    return {
+        questionId,
+        questionOrderIndex: 0,
+        selectedOption: null,
+        isFlagged: false,
+        viewCount: 0,
+        ...over,
+    }
+}
+
+describe('diagnosticResponseSummary', () => {
+    it('treats a null/undefined selectedOption as unanswered', () => {
+        expect(isAnswered(undefined)).toBe(false)
+        expect(isAnswered(resp('a'))).toBe(false)
+        expect(isAnswered(resp('a', { selectedOption: 'A' }))).toBe(true)
+    })
+
+    it('reads isFlagged with a false default', () => {
+        expect(isFlagged(undefined)).toBe(false)
+        expect(isFlagged(resp('a', { isFlagged: true }))).toBe(true)
+    })
+
+    it('summarizes counts over the questions using the shared predicates', () => {
+        const questions = [q('a'), q('b'), q('c'), q('d')]
+        const responses = [
+            resp('a', { selectedOption: 'A' }),
+            resp('b', { selectedOption: 'A', isFlagged: true }),
+            resp('c', { isFlagged: true }), // flagged but unanswered
+        ]
+        expect(summarizeResponses(questions, responses)).toEqual({
+            total: 4,
+            answered: 2, // a, b
+            flagged: 2, // b, c
+            unanswered: 2, // c, d
+        })
+    })
+
+    it('counts everything unanswered when there are no responses yet', () => {
+        const questions = [q('a'), q('b')]
+        expect(summarizeResponses(questions, [])).toEqual({
+            total: 2,
+            answered: 0,
+            flagged: 0,
+            unanswered: 2,
+        })
+    })
+})

--- a/src/lib/diagnosticResponseSummary.ts
+++ b/src/lib/diagnosticResponseSummary.ts
@@ -1,0 +1,47 @@
+import type {
+    DiagnosticResponseState,
+    StudentDiagnosticQuestionResponse,
+} from '@/client'
+
+/**
+ * The single definition of "answered" / "flagged" for a per-question
+ * response. The exam navigator's cell colouring and the review screen's
+ * counts both go through these, so a question the navigator shows green
+ * is a question the review screen counts as answered — they can't
+ * disagree because they read the same predicates over the same shared
+ * response-state (the ['diagnostic-attempt', attemptId] query cache).
+ */
+export function isAnswered(response: DiagnosticResponseState | undefined): boolean {
+    return response?.selectedOption !== undefined && response?.selectedOption !== null
+}
+
+export function isFlagged(response: DiagnosticResponseState | undefined): boolean {
+    return response?.isFlagged ?? false
+}
+
+export type ResponseSummary = {
+    total: number
+    answered: number
+    flagged: number
+    unanswered: number
+}
+
+export function summarizeResponses(
+    questions: StudentDiagnosticQuestionResponse[],
+    responses: DiagnosticResponseState[]
+): ResponseSummary {
+    const byQuestionId = new Map(responses.map((r) => [r.questionId, r]))
+    let answered = 0
+    let flagged = 0
+    for (const question of questions) {
+        const response = byQuestionId.get(question.id)
+        if (isAnswered(response)) answered += 1
+        if (isFlagged(response)) flagged += 1
+    }
+    return {
+        total: questions.length,
+        answered,
+        flagged,
+        unanswered: questions.length - answered,
+    }
+}

--- a/src/pages/Diagnostic/ExamPage.test.tsx
+++ b/src/pages/Diagnostic/ExamPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { ExamPage } from './ExamPage'
 import type { DiagnosticAttemptStateResponse } from '@/client'
@@ -19,8 +19,13 @@ vi.mock('@/hooks/diagnostic/useSubmitAttemptMutation.ts', () => ({
 }))
 const mockRecordEvent = vi.fn()
 const mockFlush = vi.fn()
+const mockFlushBeforeSubmit = vi.fn(() => Promise.resolve(true))
 vi.mock('@/hooks/diagnostic/useEventCapture.ts', () => ({
-    default: () => ({ recordEvent: mockRecordEvent, flush: mockFlush }),
+    default: () => ({
+        recordEvent: mockRecordEvent,
+        flush: mockFlush,
+        flushBeforeSubmit: mockFlushBeforeSubmit,
+    }),
 }))
 vi.mock('react-router-dom', async () => {
     const actual =
@@ -40,8 +45,11 @@ function state(
             id: 'att-1',
             diagnosticSetId: 'set-1',
             status: 'in_progress',
-            startedAt: '2026-07-11T00:00:00Z',
-            serverDeadlineAt: '2026-07-11T01:00:00Z',
+            // Relative to now so the (un-mocked) timer doesn't expire during
+            // tests that aren't about expiry. Tests that DO exercise expiry
+            // override serverDeadlineAt with a past timestamp.
+            startedAt: new Date(Date.now() - 60_000).toISOString(),
+            serverDeadlineAt: new Date(Date.now() + 60 * 60_000).toISOString(),
             submittedAt: null,
             agreedToTerms: true,
             totalScore: null,
@@ -73,6 +81,8 @@ describe('ExamPage', () => {
         mockSubmit.mockReset()
         mockRecordEvent.mockReset()
         mockFlush.mockReset()
+        mockFlushBeforeSubmit.mockReset()
+        mockFlushBeforeSubmit.mockResolvedValue(true)
     })
 
     it('renders the question UI for an in_progress attempt', () => {
@@ -206,5 +216,51 @@ describe('ExamPage', () => {
         renderExam()
         expect(mockFlush).toHaveBeenCalled()
         expect(mockSubmit).toHaveBeenCalledTimes(1)
+    })
+
+    it('opens the review dialog with counts derived from the shared response state', () => {
+        // Fixture: 3 questions, one response (qc answered B + flagged) ->
+        // answered 1/3, flagged 1, unanswered 2 — the same source the
+        // navigator colours from.
+        mockUseGetAttemptStateQuery.mockReturnValue({ data: state(), isLoading: false, isError: false })
+        renderExam()
+        fireEvent.click(screen.getByRole('button', { name: /Finish exam/i }))
+
+        const dialog = screen.getByRole('dialog')
+        expect(within(dialog).getByText('Submit your diagnostic?')).toBeInTheDocument()
+        expect(within(dialog).getByText('/3')).toBeInTheDocument() // answered X/3
+        expect(within(dialog).getByText(/2 unanswered questions/i)).toBeInTheDocument()
+    })
+
+    it('confirming submit records the final exit, awaits the blocking flush, then submits', async () => {
+        mockUseGetAttemptStateQuery.mockReturnValue({ data: state(), isLoading: false, isError: false })
+        renderExam()
+        fireEvent.click(screen.getByRole('button', { name: /Finish exam/i }))
+        const dialog = screen.getByRole('dialog')
+        fireEvent.click(within(dialog).getByRole('button', { name: /^Submit$/ }))
+
+        // Records an exit for the current question (qa) before submitting.
+        expect(mockRecordEvent).toHaveBeenCalledWith('qa', 'exit')
+        // The blocking pre-submit flush runs, and submit only after it settles.
+        expect(mockFlushBeforeSubmit).toHaveBeenCalledTimes(1)
+        await waitFor(() => expect(mockSubmit).toHaveBeenCalledTimes(1))
+    })
+
+    it('submits even if the pre-submit flush reports failure (never traps the student)', async () => {
+        mockFlushBeforeSubmit.mockResolvedValue(false)
+        mockUseGetAttemptStateQuery.mockReturnValue({ data: state(), isLoading: false, isError: false })
+        renderExam()
+        fireEvent.click(screen.getByRole('button', { name: /Finish exam/i }))
+        fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^Submit$/ }))
+
+        await waitFor(() => expect(mockSubmit).toHaveBeenCalledTimes(1))
+    })
+
+    it('"Keep working" dismisses the dialog without submitting', () => {
+        mockUseGetAttemptStateQuery.mockReturnValue({ data: state(), isLoading: false, isError: false })
+        renderExam()
+        fireEvent.click(screen.getByRole('button', { name: /Finish exam/i }))
+        fireEvent.click(screen.getByRole('button', { name: /Keep working/i }))
+        expect(mockSubmit).not.toHaveBeenCalled()
     })
 })

--- a/src/pages/Diagnostic/ExamPage.tsx
+++ b/src/pages/Diagnostic/ExamPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { LoadingPage } from '@/components/common/FullLoadingPage.tsx'
 import { Button } from '@/components/ui/button.tsx'
@@ -6,10 +6,12 @@ import { QuestionNavigator } from '@/components/diagnostic/exam/QuestionNavigato
 import { QuestionPane } from '@/components/diagnostic/exam/QuestionPane.tsx'
 import { AttemptClosedView } from '@/components/diagnostic/exam/AttemptClosedView.tsx'
 import { ExamTimer } from '@/components/diagnostic/exam/ExamTimer.tsx'
+import { ReviewDialog } from '@/components/diagnostic/exam/ReviewDialog.tsx'
 import useGetAttemptStateQuery from '@/hooks/diagnostic/useGetAttemptStateQuery.ts'
 import useUpsertResponseMutation from '@/hooks/diagnostic/useUpsertResponseMutation.ts'
 import useSubmitAttemptMutation from '@/hooks/diagnostic/useSubmitAttemptMutation.ts'
 import useEventCapture from '@/hooks/diagnostic/useEventCapture.ts'
+import { summarizeResponses } from '@/lib/diagnosticResponseSummary.ts'
 
 /**
  * The exam screen. Owns the single source of truth (the attempt-state
@@ -24,6 +26,14 @@ export function ExamPage() {
     const { attemptId } = useParams()
     const navigate = useNavigate()
     const [currentIndex, setCurrentIndex] = useState(0)
+    const [reviewOpen, setReviewOpen] = useState(false)
+    // Set only by the manual-submit path, so the enter/exit effect's
+    // cleanup skips its own exit (already recorded + flushed explicitly
+    // before the lock). Reset on submit failure so a failed manual submit
+    // doesn't suppress subsequent navigation exits. The auto-submit path
+    // never sets it — its cleanup exit still fires and lands within the
+    // timed_out grace window.
+    const examEndingRef = useRef(false)
 
     const { data: state, isLoading, isError } = useGetAttemptStateQuery({
         attemptId: attemptId ?? '',
@@ -31,9 +41,8 @@ export function ExamPage() {
     const { mutate: upsertResponse } = useUpsertResponseMutation({
         attemptId: attemptId ?? '',
     })
-    const { mutate: submitAttempt } = useSubmitAttemptMutation({
-        attemptId: attemptId ?? '',
-    })
+    const { mutate: submitAttempt, isPending: isSubmitting } =
+        useSubmitAttemptMutation({ attemptId: attemptId ?? '' })
 
     // Computed before the early returns so the event-capture hooks below
     // stay unconditional (rules of hooks). currentQuestionId is undefined
@@ -46,7 +55,7 @@ export function ExamPage() {
     const currentQuestionId =
         inProgress && questions.length > 0 ? questions[boundedIndex].id : undefined
 
-    const { recordEvent, flush } = useEventCapture({
+    const { recordEvent, flush, flushBeforeSubmit } = useEventCapture({
         attemptId: attemptId ?? '',
         currentQuestionId,
     })
@@ -66,7 +75,13 @@ export function ExamPage() {
         if (currentQuestionId === undefined) return
         recordEvent(currentQuestionId, 'enter')
         void flush()
-        return () => recordEvent(currentQuestionId, 'exit')
+        return () => {
+            // On a manual submit the final exit was already recorded and
+            // flushed before the lock, so skip this one to avoid a
+            // duplicate that would arrive post-lock (no grace) and fail.
+            if (examEndingRef.current) return
+            recordEvent(currentQuestionId, 'exit')
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentQuestionId])
 
@@ -129,6 +144,28 @@ export function ExamPage() {
         submitAttempt()
     }
 
+    async function handleManualSubmit() {
+        // A manually-submitted attempt becomes 'submitted', which has NO
+        // post-lock grace window (unlike timed_out) — so the final exit and
+        // whatever else is buffered must land BEFORE the submit locks it.
+        examEndingRef.current = true
+        recordEvent(currentQuestion.id, 'exit')
+        // Blocking, bounded-retry flush (distinct from the fire-and-forget
+        // flushes everywhere else). We submit regardless of its result:
+        // losing a few seconds of analytics must never trap a student
+        // unable to finish their exam over an events-ingestion blip.
+        await flushBeforeSubmit()
+        submitAttempt(undefined, {
+            onError: () => {
+                // Submit failed — the attempt is still in_progress, so let
+                // navigation exits resume being recorded.
+                examEndingRef.current = false
+            },
+        })
+    }
+
+    const summary = summarizeResponses(questions, state.responses)
+
     return (
         <div className="mx-auto mt-8 grid max-w-5xl grid-cols-1 gap-8 px-4 md:grid-cols-[1fr_220px]">
             <div className="flex flex-col gap-6">
@@ -172,7 +209,22 @@ export function ExamPage() {
                     currentIndex={boundedIndex}
                     onJump={setCurrentIndex}
                 />
+                <Button
+                    type="button"
+                    className="w-full"
+                    onClick={() => setReviewOpen(true)}
+                >
+                    Finish exam
+                </Button>
             </aside>
+
+            <ReviewDialog
+                open={reviewOpen}
+                onOpenChange={setReviewOpen}
+                summary={summary}
+                onConfirm={handleManualSubmit}
+                isSubmitting={isSubmitting}
+            />
         </div>
     )
 }


### PR DESCRIPTION
## Summary

Stage 4 frontend, PR 4 of 4 (§2) — the last frontend piece. A "Finish exam" button opens a review dialog before a manual submit; the existing status switch then renders the "Attempt submitted" closed view.

- **`summarizeResponses`** (shared lib): the single definition of answered/flagged, used by **both** the review counts and the navigator's cell colouring, over the same `['diagnostic-attempt', id]` cache entry — so the dialog can't disagree with the grid. The navigator was refactored onto these predicates.
- **`ReviewDialog`**: "answered X/Y, flagged Z, unanswered W" + Keep working / Submit.
- **Manual submit handles the no-grace-window problem head-on.** A `submitted` attempt (unlike `timed_out`) has no post-lock grace, so the final exit + buffered events must land **before** the lock:
  - `useEventCapture` gains **`flushBeforeSubmit()`** — a genuinely blocking, awaited, bounded-retry (3×) flush, **distinct** from the fire-and-forget `void flush()` used everywhere else. The handler awaits it, then submits **regardless of the result**: losing a few seconds of analytics must never trap a student unable to finish (a deliberate, commented trade-off).
  - `handleManualSubmit` records the final exit explicitly, awaits the blocking flush, then submits. An `examEndingRef` (set only on manual submit, reset on failure) makes the enter/exit effect skip its own terminal-transition exit — avoiding a duplicate that would arrive post-lock and fail. **The auto-submit path is untouched** (its cleanup exit still lands within the `timed_out` grace).

## Test plan

- [x] 88 unit tests (10 new), `tsc -b` + `eslint` clean. New tests: `summarizeResponses` predicates/counts; `flushBeforeSubmit` drains-on-success and retries-then-reports-failure; ExamPage opens the dialog with shared-source counts, records the final exit + awaits the blocking flush before submit, submits even when the flush fails, and "Keep working" dismisses without submitting.
- [x] **Live against prod** (throwaway set, cleaned up + verified gone):
  - Review dialog counts **matched the navigator** (2/2 answered, 0 flagged, 0 unanswered)
  - Manual submit reached **`submitted`** (not `timed_out`), `submitted_at` = *now*, not the deadline
  - **The final exit landed at server_ts `21:59:35.358` — ~0.45s BEFORE the `submitted_at` lock at `21:59:35.81`** — proving the no-grace ordering holds
  - Exactly one exit per question (no duplicate), and no orphaned/failing events after submit

Also fixed the ExamPage test fixture to use a now-relative deadline so the un-mocked timer doesn't spuriously expire once wall-clock time passes a hardcoded timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)