### PR TITLE
Stage 5 FE PR 2 — Skills Radar (SVG) for the report (§6)

### DIFF
--- a/src/components/diagnostic/report/SkillsRadar.test.tsx
+++ b/src/components/diagnostic/report/SkillsRadar.test.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { SkillsRadar } from './SkillsRadar'
+import type { SkillScore } from '@/client'
+
+function skills(scores: Array<number | null>): SkillScore[] {
+    return scores.map((score, i) => ({ skill: `S${i + 1}`, score }))
+}
+
+describe('SkillsRadar', () => {
+    it('exposes an accessible table that reflects null vs. real scores', () => {
+        // S1=2/3, S2=0 (assessed), S3–S7 null.
+        render(<SkillsRadar skills={skills([2 / 3, 0, null, null, null, null, null])} />)
+        const table = screen.getByRole('table')
+        const rows = within(table).getAllByRole('row')
+        // header + 7 skill rows
+        expect(rows).toHaveLength(8)
+
+        const s1 = within(table).getByRole('rowheader', { name: 'S1' }).closest('tr')!
+        expect(within(s1).getByRole('cell')).toHaveTextContent('67%')
+
+        // The regression this whole thread guards against: a null skill must
+        // read "Not assessed", NOT "0%".
+        const s3 = within(table).getByRole('rowheader', { name: 'S3' }).closest('tr')!
+        expect(within(s3).getByRole('cell')).toHaveTextContent('Not assessed')
+        expect(within(s3).getByRole('cell')).not.toHaveTextContent('0%')
+
+        // And an assessed 0 is a real "0%", distinct from "Not assessed".
+        const s2 = within(table).getByRole('rowheader', { name: 'S2' }).closest('tr')!
+        expect(within(s2).getByRole('cell')).toHaveTextContent('0%')
+        expect(within(s2).getByRole('cell')).not.toHaveTextContent('Not assessed')
+    })
+
+    it('draws a data dot only on assessed axes — never on a null one', () => {
+        const { container } = render(
+            <SkillsRadar skills={skills([0.5, null, 0.5, null, 0.5, null, 0.5])} />
+        )
+        // 4 assessed -> 4 dots.
+        expect(container.querySelectorAll('circle')).toHaveLength(4)
+    })
+
+    it('plots an assessed 0 as a dot (kept, not dropped like null)', () => {
+        const { container } = render(
+            <SkillsRadar skills={skills([0, null, null, null, null, null, null])} />
+        )
+        // The single assessed-0 skill still gets its dot.
+        expect(container.querySelectorAll('circle')).toHaveLength(1)
+    })
+
+    it('draws no connecting edge that spans a null axis', () => {
+        // Assessed at 0,2,5 — none adjacent -> zero connecting segments, so
+        // no line can cross a null spoke. (Grid rings are <polygon>, spokes
+        // and any outline are <line>; assert the emerald outline lines.)
+        const { container } = render(
+            <SkillsRadar skills={skills([0.5, null, 0.5, null, null, 0.5, null])} />
+        )
+        const outline = container.querySelectorAll('line.stroke-emerald-500')
+        expect(outline).toHaveLength(0)
+    })
+
+    it('connects adjacent assessed axes with an emerald outline', () => {
+        // All assessed -> 7 connecting edges (closed heptagon).
+        const { container } = render(
+            <SkillsRadar skills={skills([0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5])} />
+        )
+        expect(container.querySelectorAll('line.stroke-emerald-500')).toHaveLength(7)
+    })
+
+    it('hides the decorative SVG from assistive tech', () => {
+        const { container } = render(<SkillsRadar skills={skills([0.5, null, null, null, null, null, null])} />)
+        expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+    })
+})

--- a/src/components/diagnostic/report/SkillsRadar.tsx
+++ b/src/components/diagnostic/report/SkillsRadar.tsx
@@ -1,0 +1,148 @@
+import type { SkillScore } from '@/client'
+import { radarLayout } from '@/lib/skillsRadarGeometry.ts'
+import { skillPercent } from '@/lib/diagnosticReport.ts'
+
+type Props = {
+    skills: SkillScore[]
+    size?: number
+}
+
+/**
+ * The Skills Radar (§6). A heptagon of the seven core skills, each axis
+ * carrying a dot at its score — except a *not-assessed* axis (null score),
+ * which gets no dot and a muted, dashed spoke, and the connecting outline
+ * breaks around it (see radarSegments) so no edge implies a value where
+ * there's no data. Assessed-but-zero still plots a real dot at the centre,
+ * keeping the null-vs-zero distinction in the geometry, not just the label.
+ *
+ * The SVG is decorative (aria-hidden); the data reaches assistive tech
+ * through the visually-hidden <table>, a real semantic element so
+ * "present" and "usable" can't drift apart.
+ */
+export function SkillsRadar({ skills, size = 300 }: Props) {
+    const { center, axes, rings, segments } = radarLayout(skills, { size, padding: 36 })
+
+    const dotByIndex = (i: number) => axes[i].dot
+
+    // Extra horizontal room in the viewBox so the left/right axis labels
+    // (which extend outward from their spoke tips) aren't clipped, without
+    // shrinking the radar itself.
+    const marginX = 52
+
+    return (
+        <figure className="m-0 flex flex-col items-center">
+            <svg
+                aria-hidden="true"
+                viewBox={`${-marginX} 0 ${size + marginX * 2} ${size}`}
+                className="w-full max-w-[22rem]"
+            >
+                {/* grid rings */}
+                {rings.map((points, i) => (
+                    <polygon
+                        key={`ring-${i}`}
+                        points={points}
+                        className="fill-none stroke-gray-200 dark:stroke-gray-700"
+                        strokeWidth={1}
+                    />
+                ))}
+
+                {/* spokes — dashed + muted for not-assessed axes */}
+                {axes.map((axis) => (
+                    <line
+                        key={`spoke-${axis.skill}`}
+                        x1={center.x}
+                        y1={center.y}
+                        x2={axis.axisEnd.x}
+                        y2={axis.axisEnd.y}
+                        className={
+                            axis.assessed
+                                ? 'stroke-gray-200 dark:stroke-gray-700'
+                                : 'stroke-gray-300 dark:stroke-gray-600'
+                        }
+                        strokeWidth={1}
+                        strokeDasharray={axis.assessed ? undefined : '3 3'}
+                    />
+                ))}
+
+                {/* connecting outline — only between adjacent assessed axes */}
+                {segments.map(([i, j]) => {
+                    const a = dotByIndex(i)
+                    const b = dotByIndex(j)
+                    if (!a || !b) return null
+                    return (
+                        <line
+                            key={`seg-${i}-${j}`}
+                            x1={a.x}
+                            y1={a.y}
+                            x2={b.x}
+                            y2={b.y}
+                            className="stroke-emerald-500"
+                            strokeWidth={2}
+                            strokeLinecap="round"
+                        />
+                    )
+                })}
+
+                {/* data dots — assessed axes only */}
+                {axes.map((axis) =>
+                    axis.dot ? (
+                        <circle
+                            key={`dot-${axis.skill}`}
+                            cx={axis.dot.x}
+                            cy={axis.dot.y}
+                            r={4}
+                            className="fill-emerald-500"
+                        />
+                    ) : null
+                )}
+
+                {/* axis labels: skill code + percent, or a muted "n/a" */}
+                {axes.map((axis, i) => {
+                    const percent = skillPercent(skills[i].score)
+                    return (
+                        <text
+                            key={`label-${axis.skill}`}
+                            x={axis.label.x}
+                            y={axis.label.y}
+                            textAnchor={axis.labelAnchor}
+                            dominantBaseline="middle"
+                            className={
+                                axis.assessed
+                                    ? 'fill-gray-700 dark:fill-gray-200'
+                                    : 'fill-gray-400 dark:fill-gray-500'
+                            }
+                            fontSize={11}
+                        >
+                            <tspan fontWeight={600}>{axis.skill}</tspan>
+                            <tspan dx={4} fontSize={10}>
+                                {percent === null ? 'n/a' : `${percent}%`}
+                            </tspan>
+                        </text>
+                    )
+                })}
+            </svg>
+
+            {/* Accessible equivalent — the SVG carries no data to AT. */}
+            <table className="sr-only">
+                <caption>Skills radar — score per core skill</caption>
+                <thead>
+                    <tr>
+                        <th scope="col">Skill</th>
+                        <th scope="col">Score</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {skills.map((s) => {
+                        const percent = skillPercent(s.score)
+                        return (
+                            <tr key={s.skill}>
+                                <th scope="row">{s.skill}</th>
+                                <td>{percent === null ? 'Not assessed' : `${percent}%`}</td>
+                            </tr>
+                        )
+                    })}
+                </tbody>
+            </table>
+        </figure>
+    )
+}

--- a/src/lib/skillsRadarGeometry.test.ts
+++ b/src/lib/skillsRadarGeometry.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { axisAngle, radarLayout, radarSegments } from './skillsRadarGeometry'
+import type { SkillScore } from '@/client'
+
+function skills(scores: Array<number | null>): SkillScore[] {
+    return scores.map((score, i) => ({ skill: `S${i + 1}`, score }))
+}
+
+describe('axisAngle', () => {
+    it('starts at the top (-90°) and steps clockwise', () => {
+        expect(axisAngle(0, 7)).toBeCloseTo(-Math.PI / 2)
+        expect(axisAngle(1, 7)).toBeCloseTo(-Math.PI / 2 + (2 * Math.PI) / 7)
+    })
+})
+
+describe('radarSegments — the null-break', () => {
+    it('connects every adjacent pair (with wrap) when all are assessed', () => {
+        const segs = radarSegments(skills([0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]))
+        expect(segs).toEqual([
+            [0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 0],
+        ])
+    })
+
+    it('breaks the outline around a null axis — no edge spans it', () => {
+        // S4 (index 3) is null: neither [2,3] nor [3,4] may be drawn, so no
+        // edge crosses S4's spoke.
+        const segs = radarSegments(skills([0.5, 0.5, 0.5, null, 0.5, 0.5, 0.5]))
+        expect(segs).toEqual([[0, 1], [1, 2], [4, 5], [5, 6], [6, 0]])
+        expect(segs).not.toContainEqual([2, 3])
+        expect(segs).not.toContainEqual([3, 4])
+    })
+
+    it('draws no segments when assessed axes are non-adjacent (honest dots-only)', () => {
+        // Assessed at 0, 2, 5 — no two are neighbours.
+        const segs = radarSegments(skills([0.5, null, 0.5, null, null, 0.5, null]))
+        expect(segs).toEqual([])
+    })
+
+    it('draws nothing when nothing is assessed', () => {
+        expect(radarSegments(skills([null, null, null, null, null, null, null]))).toEqual([])
+    })
+
+    it('treats an assessed 0 as assessed (it connects), distinct from null', () => {
+        // S1=0 and S2=0.4 are both assessed and adjacent -> connected.
+        const segs = radarSegments(skills([0, 0.4, null, null, null, null, null]))
+        expect(segs).toContainEqual([0, 1])
+    })
+})
+
+describe('radarLayout', () => {
+    const layout = radarLayout(skills([1, 0, null, 0.5, null, null, null]), { size: 300 })
+
+    it('gives an assessed axis a dot and a null axis none', () => {
+        expect(layout.axes[0].dot).not.toBeNull() // S1 assessed
+        expect(layout.axes[2].dot).toBeNull() // S3 null -> no dot
+        expect(layout.axes[0].assessed).toBe(true)
+        expect(layout.axes[2].assessed).toBe(false)
+    })
+
+    it('plots an assessed 0 as a real dot at the centre (not omitted like null)', () => {
+        const s2 = layout.axes[1] // score 0
+        expect(s2.dot).not.toBeNull()
+        expect(s2.dot!.x).toBeCloseTo(layout.center.x)
+        expect(s2.dot!.y).toBeCloseTo(layout.center.y)
+    })
+
+    it('plots a full score at the outer radius on the top axis', () => {
+        const s1 = layout.axes[0] // score 1, axis 0 = straight up
+        expect(s1.dot!.x).toBeCloseTo(layout.center.x)
+        expect(s1.dot!.y).toBeCloseTo(layout.center.y - layout.radius)
+    })
+
+    it('emits one grid ring polygon per level, each with all seven vertices', () => {
+        expect(layout.rings).toHaveLength(4)
+        // 7 "x,y" pairs per ring.
+        expect(layout.rings[0].trim().split(/\s+/)).toHaveLength(7)
+    })
+})

--- a/src/lib/skillsRadarGeometry.ts
+++ b/src/lib/skillsRadarGeometry.ts
@@ -1,0 +1,115 @@
+import type { SkillScore } from '@/client'
+
+/**
+ * Pure geometry for the Skills Radar — no React, no SVG, so the layout
+ * math (and, critically, the null-handling) is unit-testable on its own.
+ *
+ * The one correctness-load-bearing decision lives in `radarSegments`: the
+ * connecting outline is *broken* at any not-assessed axis, so no edge ever
+ * spans a null axis. A straight edge drawn from S3 to S5 across a null S4
+ * would cross S4's spoke at some radius and read as a fabricated S4 score;
+ * omitting that edge is what keeps "not assessed" from implying a value.
+ * When assessed axes aren't adjacent, there are simply no segments and the
+ * radar honestly degrades to dots-on-axes.
+ */
+
+export type Point = { x: number; y: number }
+
+export type RadarAxis = {
+    skill: string
+    /** null score === not assessed by this paper (distinct from a real 0). */
+    assessed: boolean
+    /** Spoke tip, at full radius — always present (the axis always exists). */
+    axisEnd: Point
+    /** Data point at radius ∝ score. Null for a not-assessed axis — no dot. */
+    dot: Point | null
+    /** Where the axis label sits, just outside the spoke tip. */
+    label: Point
+    /** Horizontal text-anchor for the label, from its side of the circle. */
+    labelAnchor: 'start' | 'middle' | 'end'
+}
+
+export type RadarLayout = {
+    size: number
+    center: Point
+    radius: number
+    axes: RadarAxis[]
+    /** Concentric grid polygons (one point string per level). */
+    rings: string[]
+    /** Index pairs [i, j] whose data dots should be connected. */
+    segments: Array<[number, number]>
+}
+
+/** Angle of axis `i` of `count`, starting at the top and going clockwise. */
+export function axisAngle(index: number, count: number): number {
+    return -Math.PI / 2 + (index * 2 * Math.PI) / count
+}
+
+function pointAt(center: Point, radius: number, angle: number, fraction: number): Point {
+    return {
+        x: center.x + radius * fraction * Math.cos(angle),
+        y: center.y + radius * fraction * Math.sin(angle),
+    }
+}
+
+/**
+ * Adjacent pairs (in ring order, wrapping) whose *both* endpoints are
+ * assessed — the only edges the outline draws. A null axis breaks the ring
+ * on both sides, so no drawn edge ever crosses it.
+ */
+export function radarSegments(skills: SkillScore[]): Array<[number, number]> {
+    const n = skills.length
+    const assessed = (i: number) =>
+        skills[i].score !== null && skills[i].score !== undefined
+    const segments: Array<[number, number]> = []
+    for (let i = 0; i < n; i += 1) {
+        const j = (i + 1) % n
+        if (n > 1 && assessed(i) && assessed(j)) segments.push([i, j])
+    }
+    return segments
+}
+
+/**
+ * Full layout for `skills` in a `size`×`size` box. `padding` reserves room
+ * for the labels outside the outer ring.
+ */
+export function radarLayout(
+    skills: SkillScore[],
+    { size = 300, padding = 44, levels = 4 }: { size?: number; padding?: number; levels?: number } = {}
+): RadarLayout {
+    const center: Point = { x: size / 2, y: size / 2 }
+    const radius = size / 2 - padding
+    const n = skills.length
+
+    const axes: RadarAxis[] = skills.map((s, i) => {
+        const angle = axisAngle(i, n)
+        const assessed = s.score !== null && s.score !== undefined
+        const label = pointAt(center, radius, angle, 1.18)
+        const cos = Math.cos(angle)
+        const labelAnchor: RadarAxis['labelAnchor'] =
+            Math.abs(cos) < 0.34 ? 'middle' : cos > 0 ? 'start' : 'end'
+        return {
+            skill: s.skill,
+            assessed,
+            axisEnd: pointAt(center, radius, angle, 1),
+            dot: assessed ? pointAt(center, radius, angle, s.score as number) : null,
+            label,
+            labelAnchor,
+        }
+    })
+
+    const rings: string[] = []
+    for (let level = 1; level <= levels; level += 1) {
+        const fraction = level / levels
+        rings.push(
+            skills
+                .map((_, i) => {
+                    const p = pointAt(center, radius, axisAngle(i, n), fraction)
+                    return `${p.x.toFixed(2)},${p.y.toFixed(2)}`
+                })
+                .join(' ')
+        )
+    }
+
+    return { size, center, radius, axes, rings, segments: radarSegments(skills) }
+}

--- a/src/pages/Diagnostic/DiagnosticReportPage.test.tsx
+++ b/src/pages/Diagnostic/DiagnosticReportPage.test.tsx
@@ -116,16 +116,18 @@ describe('DiagnosticReportPage', () => {
         expect(screen.queryByText('1/3 correct')).not.toBeInTheDocument()
     })
 
-    it('renders all seven skills, with "not assessed" distinct from a low score', () => {
+    it('renders the Skills Radar, with "not assessed" distinct from a low score', () => {
         mockUseReport.mockReturnValue({ data: report(), isLoading: false, error: null })
         renderPage()
-        for (const s of ['S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7']) {
-            expect(screen.getByText(s)).toBeInTheDocument()
-        }
-        expect(screen.getByText('67%')).toBeInTheDocument() // S1
-        expect(screen.getByText('0%')).toBeInTheDocument() // S2 assessed, scored 0
-        // S3–S7 are "not assessed" (five of them), not rendered as 0%.
-        expect(screen.getAllByText(/not assessed by this paper/i)).toHaveLength(5)
+        // The radar's accessible table carries the per-skill data: all seven
+        // skills, S1 scored, S3 "Not assessed" (not 0%).
+        const table = screen.getByRole('table')
+        expect(within(table).getAllByRole('rowheader')).toHaveLength(7)
+        const s1 = within(table).getByRole('rowheader', { name: 'S1' }).closest('tr')!
+        expect(within(s1).getByRole('cell')).toHaveTextContent('67%')
+        const s3 = within(table).getByRole('rowheader', { name: 'S3' }).closest('tr')!
+        expect(within(s3).getByRole('cell')).toHaveTextContent('Not assessed')
+        expect(within(s3).getByRole('cell')).not.toHaveTextContent('0%')
     })
 
     it('names flagged-never-revisited questions by position', () => {

--- a/src/pages/Diagnostic/DiagnosticReportPage.tsx
+++ b/src/pages/Diagnostic/DiagnosticReportPage.tsx
@@ -7,11 +7,8 @@ import useGetAttemptReportQuery, {
     AttemptReportError,
 } from '@/hooks/diagnostic/useGetAttemptReportQuery.ts'
 import useGetSetPreviewQuery from '@/hooks/diagnostic/useGetSetPreviewQuery.ts'
-import {
-    formatDuration,
-    questionLabelByIdFrom,
-    skillPercent,
-} from '@/lib/diagnosticReport.ts'
+import { formatDuration, questionLabelByIdFrom } from '@/lib/diagnosticReport.ts'
+import { SkillsRadar } from '@/components/diagnostic/report/SkillsRadar.tsx'
 
 /**
  * Post-exam report screen (§6). Its own route/query, reached from the
@@ -108,43 +105,8 @@ export function DiagnosticReportPage() {
             <section className="flex flex-col gap-3">
                 <h2 className="text-xl font-medium">Skills</h2>
                 <Card>
-                    <CardContent className="flex flex-col gap-3 pt-6">
-                        {report.skillsRadar.map((s) => {
-                            const percent = skillPercent(s.score)
-                            return (
-                                <div
-                                    key={s.skill}
-                                    className="grid grid-cols-[3rem_1fr_3rem] items-center gap-3"
-                                >
-                                    <span className="text-sm font-medium">{s.skill}</span>
-                                    {percent === null ? (
-                                        <>
-                                            <span className="text-sm italic text-gray-400">
-                                                Not assessed by this paper
-                                            </span>
-                                            <span />
-                                        </>
-                                    ) : (
-                                        <>
-                                            <div className="h-2 rounded-full bg-gray-100">
-                                                <div
-                                                    className="h-2 rounded-full bg-emerald-500"
-                                                    style={{ width: `${percent}%` }}
-                                                    role="meter"
-                                                    aria-valuenow={percent}
-                                                    aria-valuemin={0}
-                                                    aria-valuemax={100}
-                                                    aria-label={`${s.skill} score`}
-                                                />
-                                            </div>
-                                            <span className="text-right text-sm tabular-nums text-gray-600">
-                                                {percent}%
-                                            </span>
-                                        </>
-                                    )}
-                                </div>
-                            )
-                        })}
+                    <CardContent className="pt-6">
+                        <SkillsRadar skills={report.skillsRadar} />
                     </CardContent>
                 </Card>
             </section>


### PR DESCRIPTION
## What
Replaces FE PR 1's skills **bar-list** with an **SVG Skills Radar** of the seven core skills. Same data, different visual form — the bar-list is deleted, not left alongside, so there's **no second skills display path**.

## The null problem, solved at the geometry layer
A connected radar polygon that just skipped nulls would draw a straight edge across a not-assessed axis — crossing its spoke at *some* radius and reading as a fabricated score. So:
- **The outline breaks at null axes.** `radarSegments` connects only **adjacent assessed** axes (with wrap), so **no drawn edge ever spans a null axis**. When assessed axes aren't adjacent, the shape honestly degrades to **dots-on-axes**.
- A **null axis** → dashed, muted spoke, **no dot**. An **assessed 0** → a real dot **at the centre**. The null-vs-zero distinction lives in the geometry, not just the label.

## Accessibility — proven, not asserted
The SVG is decorative (`aria-hidden`); the data reaches assistive tech through a real, **visually-hidden `<table>`** (a semantic element, so "present" and "usable" can't drift apart). A test asserts a null skill's row reads **"Not assessed", not "0%"** — the exact regression this whole thread exists to prevent — and an assessed-0 row reads "0%", not "Not assessed".

## Scope
Full replacement of the skills section only. Headline, flagged-never-revisited, and pacing list are untouched. The **pacing curve is PR 3**, separate.

## Tests
- Pure geometry (`skillsRadarGeometry`): the null-break (excludes edges touching a null axis), non-adjacent → no segments, assessed-0 connects and plots at centre, full-ring → 7 segments, ring/label layout.
- `SkillsRadar`: the sr-only table reflects null-vs-real correctly; a dot only on assessed axes (never null); assessed-0 keeps its dot; **no emerald edge when assessed axes are non-adjacent**; 7 edges when all assessed; SVG is `aria-hidden`.
- Page skills test updated to assert against the radar's table.
- Full suite green (**119**); `tsc -b` + lint clean on changed files.

## Live browser verification (real prod API, seeded terminal attempt, cleaned up + confirmed gone)
Seeded a deliberate mix — S1/S6/S7 assessed (adjacent, connected), **S2 assessed-0** (dot at centre), **S3 & S5 null** (dashed, no dot), **S4 assessed but isolated** (S3/S5 null neighbours):
- DOM: **5 dots, 3 connecting segments** (S6–S7, S7–S1, S1–S2), **2 dashed null spokes** — no edge crosses a null axis, S4 is a lone dot ✅
- Table: S2 **"0%"** vs S3/S5 **"Not assessed"** ✅
- Labels fit (fixed an initial right-edge clip by widening the viewBox horizontal margin); no console errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)