### PR TITLE
Stage 5 FE PR 3 — Pacing curve for the report (§6)

### DIFF
--- a/src/components/diagnostic/report/PacingCurve.test.tsx
+++ b/src/components/diagnostic/report/PacingCurve.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { PacingCurve } from './PacingCurve'
+import type { PerQuestionTime } from '@/client'
+
+function t(questionOrderIndex: number, totalTimeSeconds: number, viewCount = 1): PerQuestionTime {
+    return { questionId: `q${questionOrderIndex}`, questionOrderIndex, totalTimeSeconds, viewCount }
+}
+
+describe('PacingCurve', () => {
+    it('distinguishes never-reached from a viewed-briefly question in the table', () => {
+        // Q1 viewed 0s (briefly), Q2 viewed, Q3 never reached (set size 3).
+        render(<PacingCurve perQuestionTime={[t(0, 0), t(1, 20)]} questionCount={3} />)
+        const table = screen.getByRole('table', { name: /time per question/i })
+
+        const q1 = within(table).getByRole('rowheader', { name: 'Question 1' }).closest('tr')!
+        // viewed-briefly reads its real 0:00 — a data point, not absence.
+        expect(within(q1).getAllByRole('cell')[0]).toHaveTextContent('0:00')
+
+        const q3 = within(table).getByRole('rowheader', { name: 'Question 3' }).closest('tr')!
+        // never-reached reads "Not reached", NOT 0:00 — the fabricated-zero
+        // this guards against.
+        expect(within(q3).getAllByRole('cell')[0]).toHaveTextContent('Not reached')
+        expect(within(q3).getAllByRole('cell')[0]).not.toHaveTextContent('0:00')
+    })
+
+    it('draws a filled dot per reached question and a hollow marker per never-reached', () => {
+        const { container } = render(
+            <PacingCurve perQuestionTime={[t(0, 30), t(2, 15)]} questionCount={4} />
+        )
+        // 2 reached -> 2 filled dots; 2 never-reached -> 2 hollow markers.
+        expect(container.querySelectorAll('circle.fill-emerald-500')).toHaveLength(2)
+        expect(container.querySelectorAll('circle.fill-none')).toHaveLength(2)
+    })
+
+    it('breaks the line at a never-reached question — no segment spans the gap', () => {
+        // Q1, Q2 reached & adjacent -> one segment; Q3 never reached; Q4
+        // reached but isolated -> no further segment.
+        const { container } = render(
+            <PacingCurve perQuestionTime={[t(0, 30), t(1, 20), t(3, 10)]} questionCount={4} />
+        )
+        expect(container.querySelectorAll('line.stroke-emerald-500')).toHaveLength(1)
+    })
+
+    it('tags revisited questions with ×N (viewCount as a discrete mark, not height)', () => {
+        const { container } = render(
+            <PacingCurve perQuestionTime={[t(0, 10, 3), t(1, 60, 1)]} questionCount={2} />
+        )
+        // Q1 visited 3× -> "×3" tag; Q2 once -> no tag.
+        const tags = [...container.querySelectorAll('text')].map((n) => n.textContent)
+        expect(tags).toContain('×3')
+        expect(tags).not.toContain('×1')
+    })
+
+    it('reflects the median "typical pace" reference in the SVG', () => {
+        const { container } = render(
+            <PacingCurve perQuestionTime={[t(0, 10), t(1, 20), t(2, 30)]} questionCount={3} />
+        )
+        expect(container.querySelector('text')?.ownerSVGElement).toBeTruthy()
+        expect([...container.querySelectorAll('text')].map((n) => n.textContent)).toContain(
+            'typical pace'
+        )
+    })
+
+    it('hides the decorative SVG from assistive tech', () => {
+        const { container } = render(
+            <PacingCurve perQuestionTime={[t(0, 10)]} questionCount={1} />
+        )
+        expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+    })
+})

--- a/src/components/diagnostic/report/PacingCurve.tsx
+++ b/src/components/diagnostic/report/PacingCurve.tsx
@@ -1,0 +1,178 @@
+import type { PerQuestionTime } from '@/client'
+import { buildPacingSeries, pacingLayout } from '@/lib/pacingCurve.ts'
+import { formatDuration } from '@/lib/diagnosticReport.ts'
+
+type Props = {
+    perQuestionTime: PerQuestionTime[]
+    /** The set's full size, for the whole-paper x-axis. Absent while the
+     * set preview is still loading — the curve degrades to the questions it
+     * has rather than blocking. */
+    questionCount?: number
+    width?: number
+    height?: number
+}
+
+/**
+ * Pacing curve (§6): engaged time per question across the paper sequence,
+ * built to make "rushed the back third" legible — a line encodes slope
+ * directly, and the median reference line makes the curve dropping below
+ * typical pace toward the end read at a glance. No fabricated trend: real
+ * points, straight segments, and a flat curve honestly shows no pattern.
+ *
+ * Three distinct states, three treatments that can't blur:
+ *  - time = y-position (lingered = high, brief = low);
+ *  - viewCount = a discrete "×N" revisit tag, never mixed into height, so
+ *    thrice-briefly (low + ×3) can't look like once-at-length (high);
+ *  - never-reached = a hollow marker with the curve broken around it, NOT
+ *    a 0-second point (which would imply rushing, not absence).
+ *
+ * SVG decorative (aria-hidden); data reaches AT via the visually-hidden
+ * <table>.
+ */
+export function PacingCurve({
+    perQuestionTime,
+    questionCount,
+    width = 320,
+    height = 180,
+}: Props) {
+    const series = buildPacingSeries(perQuestionTime, questionCount)
+    const layout = pacingLayout(series, { width, height })
+
+    return (
+        <figure className="m-0 flex flex-col gap-2">
+            <svg
+                aria-hidden="true"
+                viewBox={`0 0 ${width} ${height}`}
+                className="w-full"
+            >
+                {/* baseline */}
+                <line
+                    x1={0}
+                    y1={layout.baselineY}
+                    x2={width}
+                    y2={layout.baselineY}
+                    className="stroke-gray-200 dark:stroke-gray-700"
+                    strokeWidth={1}
+                />
+
+                {/* median "typical pace" reference */}
+                {layout.medianY !== null && (
+                    <>
+                        <line
+                            x1={0}
+                            y1={layout.medianY}
+                            x2={width}
+                            y2={layout.medianY}
+                            className="stroke-gray-300 dark:stroke-gray-600"
+                            strokeWidth={1}
+                            strokeDasharray="4 3"
+                        />
+                        <text
+                            x={width - 2}
+                            y={layout.medianY - 3}
+                            textAnchor="end"
+                            className="fill-gray-400 dark:fill-gray-500"
+                            fontSize={9}
+                        >
+                            typical pace
+                        </text>
+                    </>
+                )}
+
+                {/* the pacing line — only between adjacent reached questions */}
+                {layout.lines.map((l, i) => (
+                    <line
+                        key={`seg-${i}`}
+                        x1={l.x1}
+                        y1={l.y1}
+                        x2={l.x2}
+                        y2={l.y2}
+                        className="stroke-emerald-500"
+                        strokeWidth={2}
+                        strokeLinecap="round"
+                    />
+                ))}
+
+                {/* nodes: filled dot for reached, hollow marker for not */}
+                {layout.nodes.map((node) =>
+                    node.reached ? (
+                        <g key={`node-${node.position}`}>
+                            <circle
+                                cx={node.x}
+                                cy={node.y as number}
+                                r={3.5}
+                                className="fill-emerald-500"
+                            />
+                            {(node.viewCount ?? 0) > 1 && (
+                                <text
+                                    x={node.x}
+                                    y={(node.y as number) - 7}
+                                    textAnchor="middle"
+                                    className="fill-gray-500 dark:fill-gray-400"
+                                    fontSize={8}
+                                >
+                                    ×{node.viewCount}
+                                </text>
+                            )}
+                        </g>
+                    ) : (
+                        // Never reached: hollow marker at the baseline, curve
+                        // broken (no segment touches it). Visibly not a data
+                        // point sitting at 0s.
+                        <circle
+                            key={`node-${node.position}`}
+                            cx={node.x}
+                            cy={node.baselineY}
+                            r={3}
+                            className="fill-none stroke-gray-300 dark:stroke-gray-600"
+                            strokeWidth={1.5}
+                        />
+                    )
+                )}
+
+                {/* x-axis endpoints: start and end of the paper */}
+                <text
+                    x={layout.nodes[0]?.x ?? 0}
+                    y={height - 8}
+                    textAnchor="middle"
+                    className="fill-gray-400 dark:fill-gray-500"
+                    fontSize={9}
+                >
+                    Q1
+                </text>
+                {layout.nodes.length > 1 && (
+                    <text
+                        x={layout.nodes[layout.nodes.length - 1].x}
+                        y={height - 8}
+                        textAnchor="middle"
+                        className="fill-gray-400 dark:fill-gray-500"
+                        fontSize={9}
+                    >
+                        Q{layout.nodes.length}
+                    </text>
+                )}
+            </svg>
+
+            {/* Accessible equivalent — the SVG carries no data to AT. */}
+            <table className="sr-only">
+                <caption>Time per question across the paper</caption>
+                <thead>
+                    <tr>
+                        <th scope="col">Question</th>
+                        <th scope="col">Time</th>
+                        <th scope="col">Visits</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {series.map((p) => (
+                        <tr key={p.position}>
+                            <th scope="row">Question {p.position}</th>
+                            <td>{p.time === null ? 'Not reached' : formatDuration(p.time)}</td>
+                            <td>{p.viewCount === null ? '—' : p.viewCount}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </figure>
+    )
+}

--- a/src/lib/pacingCurve.test.ts
+++ b/src/lib/pacingCurve.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+    buildPacingSeries,
+    medianTime,
+    pacingLayout,
+    pacingSegments,
+    type PacingPoint,
+} from './pacingCurve'
+import type { PerQuestionTime } from '@/client'
+
+function t(questionOrderIndex: number, totalTimeSeconds: number, viewCount = 1): PerQuestionTime {
+    return { questionId: `q${questionOrderIndex}`, questionOrderIndex, totalTimeSeconds, viewCount }
+}
+
+function series(times: Array<number | null>): PacingPoint[] {
+    return times.map((time, i) => ({
+        position: i + 1,
+        time,
+        viewCount: time === null ? null : 1,
+    }))
+}
+
+describe('buildPacingSeries', () => {
+    it('expands entries into the full paper, gaps as never-reached (null, not 0)', () => {
+        // Set of 4; only Q1 and Q3 have entries. Q2 and Q4 were never reached.
+        const s = buildPacingSeries([t(0, 30), t(2, 12)], 4)
+        expect(s.map((p) => p.time)).toEqual([30, null, 12, null])
+        expect(s.map((p) => p.position)).toEqual([1, 2, 3, 4])
+        // never-reached carries null viewCount too (no data at all).
+        expect(s[1].viewCount).toBeNull()
+    })
+
+    it('keeps a viewed-0 question as a real 0, distinct from never-reached null', () => {
+        const s = buildPacingSeries([t(0, 0, 1), t(1, 20)], 2)
+        expect(s[0].time).toBe(0) // viewed briefly, not null
+        expect(s[0].viewCount).toBe(1)
+    })
+
+    it('falls back to the last viewed question when set size is unknown', () => {
+        const s = buildPacingSeries([t(0, 10), t(2, 5)]) // no questionCount
+        expect(s).toHaveLength(3) // through the last entry; still shows the mid gap
+        expect(s[1].time).toBeNull()
+    })
+})
+
+describe('pacingSegments — break at never-reached', () => {
+    it('connects adjacent reached questions and breaks around a gap', () => {
+        // reached, reached, GAP, reached
+        expect(pacingSegments(series([10, 20, null, 30]))).toEqual([[0, 1]])
+    })
+
+    it('connects across a viewed-0 (0s is reached, not a gap)', () => {
+        expect(pacingSegments(series([10, 0, 20]))).toEqual([[0, 1], [1, 2]])
+    })
+
+    it('draws nothing when reached questions are non-adjacent', () => {
+        expect(pacingSegments(series([10, null, 20, null, 30]))).toEqual([])
+    })
+})
+
+describe('medianTime — typical pace, outlier-resistant', () => {
+    it('is the middle of the reached times', () => {
+        expect(medianTime(series([10, 12, 11]))).toBe(11)
+    })
+
+    it('averages the two middle values for an even count', () => {
+        expect(medianTime(series([10, 12, 11, 13]))).toBe(11.5)
+    })
+
+    it('is not dragged up by a single stuck question (unlike a mean)', () => {
+        // One 300s outlier among ~11s questions: median stays ~11.5, where a
+        // mean would jump past 80.
+        const med = medianTime(series([10, 11, 12, 300]))
+        expect(med).toBe(11.5)
+    })
+
+    it('ignores never-reached and is null when nothing was reached', () => {
+        expect(medianTime(series([null, 20, null]))).toBe(20)
+        expect(medianTime(series([null, null]))).toBeNull()
+    })
+})
+
+describe('pacingLayout', () => {
+    const layout = pacingLayout(series([40, null, 10]), { width: 320, height: 180 })
+
+    it('gives reached nodes a y and never-reached nodes none', () => {
+        expect(layout.nodes[0].reached).toBe(true)
+        expect(layout.nodes[0].y).not.toBeNull()
+        expect(layout.nodes[1].reached).toBe(false)
+        expect(layout.nodes[1].y).toBeNull()
+    })
+
+    it('places more time higher (smaller y) than less time', () => {
+        expect(layout.nodes[0].y as number).toBeLessThan(layout.nodes[2].y as number)
+    })
+
+    it('only draws lines between adjacent reached nodes (none across the gap)', () => {
+        expect(layout.lines).toHaveLength(0) // 0 and 2 aren't adjacent
+    })
+
+    it('has a median reference line when something was reached', () => {
+        expect(layout.medianY).not.toBeNull()
+    })
+
+    it('has no median line when nothing was reached', () => {
+        const empty = pacingLayout(series([null, null]))
+        expect(empty.medianY).toBeNull()
+    })
+})

--- a/src/lib/pacingCurve.ts
+++ b/src/lib/pacingCurve.ts
@@ -1,0 +1,165 @@
+import type { PerQuestionTime } from '@/client'
+
+/**
+ * Pure logic + geometry for the pacing curve — no React/SVG, so the
+ * three-state model and the null-break are unit-testable on their own.
+ *
+ * Three genuinely different stories get three treatments and can't be
+ * confused: viewed-and-lingered (a point high on the curve),
+ * viewed-briefly (a point low on the curve, filled), and never-reached
+ * (no data — a broken curve + hollow marker). Never-reached is `time:
+ * null`, NOT 0: drawing it as a 0-second point would imply the student
+ * blazed through in no time (rushed) when they actually never got there —
+ * the same fabricated-value trap the radar's polygon-break avoids, on the
+ * time axis instead of score.
+ */
+
+export type PacingPoint = {
+    /** 1-based question position in the paper sequence. */
+    position: number
+    /** Engaged seconds, or null when the question was never reached. */
+    time: number | null
+    /** Visits, or null when never reached. */
+    viewCount: number | null
+}
+
+/**
+ * Expand the report's per-question times (only questions with a response
+ * row) into the full paper sequence, so the x-axis is the whole paper and
+ * "the back third" is a real region. Positions with no entry are
+ * never-reached (time null), distinct from a viewed question that happens
+ * to be 0s.
+ *
+ * `questionCount` (the set's size) gives the true length; without it (set
+ * preview not loaded yet) we fall back to the last viewed question, so the
+ * curve still renders — degrade, don't block.
+ */
+export function buildPacingSeries(
+    perQuestionTime: PerQuestionTime[],
+    questionCount?: number
+): PacingPoint[] {
+    const byIndex = new Map(perQuestionTime.map((t) => [t.questionOrderIndex, t]))
+    const maxIndex = perQuestionTime.reduce(
+        (m, t) => Math.max(m, t.questionOrderIndex),
+        -1
+    )
+    const length = Math.max(questionCount ?? 0, maxIndex + 1)
+
+    const series: PacingPoint[] = []
+    for (let i = 0; i < length; i += 1) {
+        const entry = byIndex.get(i)
+        series.push({
+            position: i + 1,
+            time: entry ? entry.totalTimeSeconds : null,
+            viewCount: entry ? entry.viewCount : null,
+        })
+    }
+    return series
+}
+
+/**
+ * Index pairs [i, i+1] whose *both* endpoints were reached — the only
+ * edges the curve draws. A never-reached position breaks the line on both
+ * sides, so the curve is never drawn through a gap as if it were 0s. (A
+ * sequence, not a ring — no wrap.)
+ */
+export function pacingSegments(series: PacingPoint[]): Array<[number, number]> {
+    const segments: Array<[number, number]> = []
+    for (let i = 0; i < series.length - 1; i += 1) {
+        if (series[i].time !== null && series[i + 1].time !== null) {
+            segments.push([i, i + 1])
+        }
+    }
+    return segments
+}
+
+/** Median engaged time over *reached* questions — the "typical pace"
+ * reference. Median, not mean, so one genuinely-stuck question can't drag
+ * the line up and make normal pacing look fast. Null when nothing reached. */
+export function medianTime(series: PacingPoint[]): number | null {
+    const times = series
+        .map((p) => p.time)
+        .filter((t): t is number => t !== null)
+        .sort((a, b) => a - b)
+    if (times.length === 0) return null
+    const mid = Math.floor(times.length / 2)
+    return times.length % 2 === 0 ? (times[mid - 1] + times[mid]) / 2 : times[mid]
+}
+
+export type PacingLayout = {
+    width: number
+    height: number
+    baselineY: number
+    /** y of the median reference line, or null if nothing was reached. */
+    medianY: number | null
+    /** One entry per position, in sequence order. */
+    nodes: Array<{
+        position: number
+        x: number
+        /** y of the data point (reached), or null (never reached). */
+        y: number | null
+        baselineY: number
+        time: number | null
+        viewCount: number | null
+        reached: boolean
+    }>
+    /** Line segments between adjacent reached nodes, as coordinate pairs. */
+    lines: Array<{ x1: number; y1: number; x2: number; y2: number }>
+}
+
+export function pacingLayout(
+    series: PacingPoint[],
+    {
+        width = 320,
+        height = 180,
+        padding = { top: 18, right: 16, bottom: 26, left: 16 },
+    }: {
+        width?: number
+        height?: number
+        padding?: { top: number; right: number; bottom: number; left: number }
+    } = {}
+): PacingLayout {
+    const plotLeft = padding.left
+    const plotRight = width - padding.right
+    const plotTop = padding.top
+    const baselineY = height - padding.bottom
+    const plotHeight = baselineY - plotTop
+    const n = series.length
+
+    // Guard maxTime so all-zero (all viewed-briefly) doesn't divide by zero
+    // — every point then sits on the baseline, which is the honest picture.
+    const maxTime = Math.max(
+        1,
+        ...series.map((p) => (p.time !== null ? p.time : 0))
+    )
+    const xFor = (i: number) =>
+        n <= 1 ? (plotLeft + plotRight) / 2 : plotLeft + (i / (n - 1)) * (plotRight - plotLeft)
+    const yFor = (time: number) => baselineY - (time / maxTime) * plotHeight
+
+    const nodes = series.map((p, i) => ({
+        position: p.position,
+        x: xFor(i),
+        y: p.time !== null ? yFor(p.time) : null,
+        baselineY,
+        time: p.time,
+        viewCount: p.viewCount,
+        reached: p.time !== null,
+    }))
+
+    const lines = pacingSegments(series).map(([i, j]) => ({
+        x1: nodes[i].x,
+        y1: nodes[i].y as number,
+        x2: nodes[j].x,
+        y2: nodes[j].y as number,
+    }))
+
+    const median = medianTime(series)
+    return {
+        width,
+        height,
+        baselineY,
+        medianY: median !== null ? yFor(median) : null,
+        nodes,
+        lines,
+    }
+}

--- a/src/pages/Diagnostic/DiagnosticReportPage.test.tsx
+++ b/src/pages/Diagnostic/DiagnosticReportPage.test.tsx
@@ -121,7 +121,7 @@ describe('DiagnosticReportPage', () => {
         renderPage()
         // The radar's accessible table carries the per-skill data: all seven
         // skills, S1 scored, S3 "Not assessed" (not 0%).
-        const table = screen.getByRole('table')
+        const table = screen.getByRole('table', { name: /skills radar/i })
         expect(within(table).getAllByRole('rowheader')).toHaveLength(7)
         const s1 = within(table).getByRole('rowheader', { name: 'S1' }).closest('tr')!
         expect(within(s1).getByRole('cell')).toHaveTextContent('67%')
@@ -138,13 +138,20 @@ describe('DiagnosticReportPage', () => {
         expect(within(flagged).getByText('Question 2')).toBeInTheDocument()
     })
 
-    it('lists per-question pacing with durations and revisit counts', () => {
+    it('renders the pacing curve, zero-filling the paper to the set size', () => {
         mockUseReport.mockReturnValue({ data: report(), isLoading: false, error: null })
         renderPage()
-        const pacing = screen.getByText('Time per question').closest('section')!
-        expect(within(pacing).getByText('0:15')).toBeInTheDocument() // qa 15s
-        expect(within(pacing).getByText('1:05')).toBeInTheDocument() // qb 65s
-        expect(within(pacing).getByText(/2 visits/)).toBeInTheDocument() // qa viewCount 2
+        // Fixture: qa (15s, 2 visits), qb (65s); set has 3 questions, so Q3
+        // was never reached — the curve spans the whole paper via the
+        // set-preview question count.
+        const table = screen.getByRole('table', { name: /time per question/i })
+        const q1 = within(table).getByRole('rowheader', { name: 'Question 1' }).closest('tr')!
+        expect(within(q1).getAllByRole('cell')[0]).toHaveTextContent('0:15')
+        expect(within(q1).getAllByRole('cell')[1]).toHaveTextContent('2')
+        const q2 = within(table).getByRole('rowheader', { name: 'Question 2' }).closest('tr')!
+        expect(within(q2).getAllByRole('cell')[0]).toHaveTextContent('1:05')
+        const q3 = within(table).getByRole('rowheader', { name: 'Question 3' }).closest('tr')!
+        expect(within(q3).getAllByRole('cell')[0]).toHaveTextContent('Not reached')
     })
 
     it('handles a zero-answer attempt without a nonsense 0/0', () => {

--- a/src/pages/Diagnostic/DiagnosticReportPage.tsx
+++ b/src/pages/Diagnostic/DiagnosticReportPage.tsx
@@ -7,8 +7,9 @@ import useGetAttemptReportQuery, {
     AttemptReportError,
 } from '@/hooks/diagnostic/useGetAttemptReportQuery.ts'
 import useGetSetPreviewQuery from '@/hooks/diagnostic/useGetSetPreviewQuery.ts'
-import { formatDuration, questionLabelByIdFrom } from '@/lib/diagnosticReport.ts'
+import { questionLabelByIdFrom } from '@/lib/diagnosticReport.ts'
 import { SkillsRadar } from '@/components/diagnostic/report/SkillsRadar.tsx'
+import { PacingCurve } from '@/components/diagnostic/report/PacingCurve.tsx'
 
 /**
  * Post-exam report screen (§6). Its own route/query, reached from the
@@ -75,9 +76,6 @@ export function DiagnosticReportPage() {
     const totalScore = report.attempt.totalScore ?? 0
     const { answeredCount } = report
     const labelById = questionLabelByIdFrom(report.perQuestionTime)
-    const pacing = [...report.perQuestionTime].sort(
-        (a, b) => a.questionOrderIndex - b.questionOrderIndex
-    )
 
     return (
         <div className="mx-auto mt-12 flex max-w-2xl flex-col gap-6 px-4">
@@ -133,30 +131,15 @@ export function DiagnosticReportPage() {
                 </Card>
             </section>
 
-            {/* Pacing — time per question across the sequence. */}
+            {/* Pacing — time per question across the paper sequence. */}
             <section className="flex flex-col gap-3">
                 <h2 className="text-xl font-medium">Time per question</h2>
                 <Card>
-                    <CardContent className="flex flex-col gap-2 pt-6">
-                        {pacing.map((t) => (
-                            <div
-                                key={t.questionId}
-                                className="flex items-center justify-between text-sm"
-                            >
-                                <span>
-                                    {labelById.get(t.questionId) ??
-                                        `Question ${t.questionOrderIndex + 1}`}
-                                </span>
-                                <span className="text-gray-600 tabular-nums">
-                                    {formatDuration(t.totalTimeSeconds)}
-                                    {t.viewCount > 1 && (
-                                        <span className="ml-2 text-gray-400">
-                                            {t.viewCount} visits
-                                        </span>
-                                    )}
-                                </span>
-                            </div>
-                        ))}
+                    <CardContent className="pt-6">
+                        <PacingCurve
+                            perQuestionTime={report.perQuestionTime}
+                            questionCount={preview?.questionCount}
+                        />
                     </CardContent>
                 </Card>
             </section>


### PR DESCRIPTION
## What
Replaces FE PR 1's plain **time-per-question list** with a **pacing curve** — engaged time across the whole paper sequence. Last piece of Stage 5's report screen; the list is deleted, so **no second display path**.

## Design goal 1 — "rushed the back third" is legible (§4)
A **line encodes slope directly**, where a bar chart makes the reader reconstruct the trend from heights — so a declining back third reads at a glance. A dashed **median** reference line ("typical pace") makes the curve dropping *below typical* toward the end obvious.
- **Median, not mean** — one genuinely-stuck question (a TMUA-stretch item) can't drag the reference up and make normal pacing look artificially fast.
- **No fabricated trend** — straight segments between real points (no smoothing that invents a shape); a flat curve honestly shows *no* pattern.
- **No hard-coded "thirds"** — imposing a fixed boundary onto per-paper-varying data would fabricate structure; the slope + median-crossing convey it without pretending to know where "the back third" starts.

## Design goal 2 — three states, three channels, no blur
- **time → y-position** (lingered high, brief low).
- **viewCount → a discrete "×N" tag**, never mixed into height, so *thrice-briefly* (low + ×3) can't look like *once-at-length* (high).
- **never-reached → a hollow marker with the curve broken around it**, NOT a 0-second point. Plotting it at 0 would imply blazing through in no time (rushed) when the student never got there — the **same fabricated-value break as the radar's null axis**, applied to the time axis. The paper is **zero-filled to the set's question count** (from the existing set-preview query) so "the back third" is a real region; degrades to the questions it has if that count isn't loaded yet.

## Accessibility — proven, not asserted
Decorative `aria-hidden` SVG + a real visually-hidden `<table>` (Question | Time | Visits). A test asserts a never-reached row reads **"Not reached", not "0:00"**, and a viewed-0 row reads "0:00" (distinct).

## Tests
- Pure geometry (`buildPacingSeries`/`pacingSegments`/`medianTime`/`pacingLayout`): the break at never-reached, median outlier-resistance (a 300s outlier leaves median at 11.5), viewed-0 stays a real point, degrade-without-questionCount.
- `PacingCurve`: table distinguishes "Not reached" from "0:00"; filled dots per reached / hollow per never-reached; **no segment spans a gap**; ×N tag for revisits; median line present; SVG `aria-hidden`.
- Page test updated to assert against the pacing table (and that the paper zero-fills to the set size). Full suite green (**140**); `tsc -b` + lint clean.

## Live browser verification (real prod API, seeded terminal attempt, cleaned up + confirmed gone)
A 10-question paper, 7 reached: high front (Q1–Q3), a **×3 brief-thrice** dip (Q4), a **declining back third** (Q5→Q7 below "typical pace"), and a **never-reached tail** (Q8–Q10):
- DOM: **7 filled dots, 3 hollow markers, 6 segments** (curve breaks at the tail), **×3** tag, "typical pace" line, table rows "Not reached" for Q8–10 ✅
- Visual: the decline through the back third below the median line reads immediately; the hollow tail is plainly "not reached," not zero ✅
- no console errors; fixtures deleted and confirmed gone ✅

## Stage 5 complete
With this, the report screen is done: headline (accuracy vs completion), Skills Radar, flagged-never-revisited, and the pacing curve — the full §6 report over real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)