### PR TITLE
Phase 1 PR B — Diagnostic Sets admin screen + topic-code combobox

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { AboutPage } from '@/pages/AboutPage.tsx'
 import { EsatTmuaPage } from '@/pages/EsatTmuaPage.tsx'
 import { StudentProtectedRoute } from '@/components/auth/StudentProtectedRoute.tsx'
 import { DiagnosticQuestionsListPage } from '@/pages/Admin/Diagnostic/DiagnosticQuestionsListPage.tsx'
+import { DiagnosticSetsListPage } from '@/pages/Admin/Diagnostic/DiagnosticSetsListPage.tsx'
 import { DiagnosticQuestionCreatePage } from '@/pages/Admin/Diagnostic/DiagnosticQuestionCreatePage.tsx'
 import { DiagnosticQuestionEditPage } from '@/pages/Admin/Diagnostic/DiagnosticQuestionEditPage.tsx'
 import { SetInstructionsPage } from '@/pages/Diagnostic/SetInstructionsPage.tsx'
@@ -120,6 +121,7 @@ function App() {
                         path="admin/questions/:questionId"
                         element={<DiagnosticQuestionEditPage />}
                     />
+                    <Route path="admin/sets" element={<DiagnosticSetsListPage />} />
                 </Route>
             </Routes>
         </>

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -286,6 +286,10 @@ export type BulkImportSetMeta = {
      */
     isFree?: boolean;
     /**
+     * Subject
+     */
+    subject?: string | null;
+    /**
      * Questionorder
      */
     questionOrder: Array<string>;
@@ -748,6 +752,10 @@ export type DiagnosticSetResponse = {
      */
     status: 'draft' | 'published';
     /**
+     * Subject
+     */
+    subject?: string | null;
+    /**
      * Createdat
      */
     createdAt: string;
@@ -1173,6 +1181,10 @@ export type UpdateDiagnosticSetBody = {
      * Status
      */
     status?: 'draft' | 'published' | null;
+    /**
+     * Subject
+     */
+    subject?: string | null;
 };
 
 /**

--- a/src/components/diagnostic/DiagnosticQuestionForm.test.tsx
+++ b/src/components/diagnostic/DiagnosticQuestionForm.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { setTopicCode } from '@/test/setTopicCode.ts'
 import {
     DiagnosticQuestionForm,
     getCorrectOptionLabel,
@@ -199,10 +200,7 @@ describe('DiagnosticQuestionForm', () => {
             />
         )
 
-        fireEvent.change(
-            screen.getByPlaceholderText(/e.g. MM1.6/i),
-            { target: { value: 'MM1.1' } }
-        )
+        setTopicCode('MM1.1')
         fireEvent.click(screen.getByText('Create'))
 
         // Required-field validation (core skill, stem, option text all

--- a/src/components/diagnostic/DiagnosticQuestionForm.tsx
+++ b/src/components/diagnostic/DiagnosticQuestionForm.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/components/ui/button.tsx'
 import { Card, CardContent } from '@/components/ui/card.tsx'
 import { Plus, Trash2 } from 'lucide-react'
 import { LatexText } from '@/components/diagnostic/LatexText.tsx'
+import { Combobox } from '@/components/ui/combobox.tsx'
 import type { DiagnosticQuestionResponse } from '@/client'
 
 const CORE_SKILLS = ['S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7'] as const
@@ -100,6 +101,14 @@ type Props = {
     onSubmit: (values: DiagnosticQuestionFormValues) => void
     isSubmitting: boolean
     submitLabel: string
+    /**
+     * Topic codes already in use, offered in the topic-code combobox so the
+     * common case is picking an existing one rather than retyping it (a typo
+     * silently mis-tags a question). Passed in rather than fetched here so
+     * this stays a presentational form; a new code can always be typed, so an
+     * empty list degrades to free entry rather than blocking.
+     */
+    topicCodeOptions?: string[]
 }
 
 function labelForIndex(index: number): string {
@@ -150,6 +159,7 @@ export function DiagnosticQuestionForm({
     onSubmit,
     isSubmitting,
     submitLabel,
+    topicCodeOptions = [],
 }: Props) {
     const form = useForm<DiagnosticQuestionFormValues>({
         defaultValues: defaultValues(initialData),
@@ -235,10 +245,23 @@ export function DiagnosticQuestionForm({
         >
             <div className="grid grid-cols-2 gap-4">
                 <div className="flex flex-col gap-1.5">
-                    <label className="text-sm font-medium">Topic code</label>
-                    <Input
-                        placeholder="e.g. MM1.6"
-                        {...form.register('topicCode', { required: true })}
+                    <label className="text-sm font-medium" htmlFor="topic-code">
+                        Topic code
+                    </label>
+                    <Controller
+                        control={form.control}
+                        name="topicCode"
+                        rules={{ required: true }}
+                        render={({ field }) => (
+                            <Combobox
+                                id="topic-code"
+                                value={field.value || null}
+                                onChange={(v) => field.onChange(v ?? '')}
+                                options={topicCodeOptions}
+                                placeholder="e.g. MM1.6"
+                                searchPlaceholder="Search or type a new topic code…"
+                            />
+                        )}
                     />
                 </div>
 

--- a/src/components/diagnostic/EditSetDialog.tsx
+++ b/src/components/diagnostic/EditSetDialog.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button.tsx'
+import { Checkbox } from '@/components/ui/checkbox.tsx'
+import { Combobox } from '@/components/ui/combobox.tsx'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog.tsx'
+import { Input } from '@/components/ui/input.tsx'
+import { Label } from '@/components/ui/label.tsx'
+import useUpdateDiagnosticSetMutation from '@/hooks/diagnostic/useUpdateDiagnosticSetMutation.ts'
+import {
+    DIAGNOSTIC_SUBJECTS,
+    UNCATEGORISED_LABEL,
+} from '@/lib/diagnosticSubjects.ts'
+import type { DiagnosticSetResponse } from '@/client'
+
+type Props = {
+    set: DiagnosticSetResponse
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    onSaved: () => void
+}
+
+/**
+ * Edit a set's metadata — most importantly its subject, which is what the
+ * list groups by and what a per-subject student view would key off.
+ *
+ * Deliberately doesn't touch status: publishing is its own explicit button
+ * with its own confirmation, not something to trip over while renaming a
+ * set. Nor question membership — a set's questions come from its import,
+ * and there's no endpoint to change them (that's the next piece of work).
+ */
+export function EditSetDialog({ set, open, onOpenChange, onSaved }: Props) {
+    const [title, setTitle] = useState(set.title)
+    const [subject, setSubject] = useState<string | null>(set.subject ?? null)
+    const [timeLimit, setTimeLimit] = useState(String(set.timeLimitMinutes))
+    const [isFree, setIsFree] = useState(set.isFree)
+
+    const { mutate: updateSet, isPending } = useUpdateDiagnosticSetMutation({
+        setId: set.id,
+    })
+
+    const minutes = Number(timeLimit)
+    const timeLimitValid = Number.isInteger(minutes) && minutes > 0
+    const titleValid = title.trim() !== ''
+
+    function handleSave() {
+        if (!titleValid || !timeLimitValid) return
+        updateSet(
+            {
+                title: title.trim(),
+                // Explicit null is a real "uncategorise" here, not an omission
+                // — the backend body distinguishes the two.
+                subject,
+                timeLimitMinutes: minutes,
+                isFree,
+            },
+            {
+                onSuccess: () => onSaved(),
+                onError: () => toast.error('Failed to update set'),
+            }
+        )
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Edit set</DialogTitle>
+                    <DialogDescription>
+                        {set.questionIds.length} questions · created from a bulk
+                        import
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="flex flex-col gap-4">
+                    <div className="flex flex-col gap-1.5">
+                        <Label htmlFor="set-title">Title</Label>
+                        <Input
+                            id="set-title"
+                            value={title}
+                            onChange={(e) => setTitle(e.target.value)}
+                        />
+                    </div>
+
+                    <div className="flex flex-col gap-1.5">
+                        <Label htmlFor="set-subject">Subject</Label>
+                        <Combobox
+                            id="set-subject"
+                            value={subject}
+                            onChange={setSubject}
+                            options={DIAGNOSTIC_SUBJECTS}
+                            placeholder={UNCATEGORISED_LABEL}
+                            clearLabel={UNCATEGORISED_LABEL}
+                        />
+                    </div>
+
+                    <div className="flex flex-col gap-1.5">
+                        <Label htmlFor="set-time">Time limit (minutes)</Label>
+                        <Input
+                            id="set-time"
+                            type="number"
+                            min={1}
+                            value={timeLimit}
+                            onChange={(e) => setTimeLimit(e.target.value)}
+                        />
+                        {!timeLimitValid && (
+                            <span className="text-sm text-red-600">
+                                Must be a whole number of minutes, greater than 0.
+                            </span>
+                        )}
+                    </div>
+
+                    <label className="flex items-center gap-2 text-sm">
+                        <Checkbox
+                            checked={isFree}
+                            onCheckedChange={(v) => setIsFree(v === true)}
+                        />
+                        Free tier
+                    </label>
+                </div>
+
+                <DialogFooter>
+                    <Button variant="outline" onClick={() => onOpenChange(false)}>
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={handleSave}
+                        disabled={isPending || !titleValid || !timeLimitValid}
+                    >
+                        {isPending ? 'Saving…' : 'Save'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/components/diagnostic/SetPublishButton.test.tsx
+++ b/src/components/diagnostic/SetPublishButton.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SetPublishButton } from './SetPublishButton'
+import type { DiagnosticSetResponse } from '@/client'
+
+const mockMutate = vi.fn()
+vi.mock('@/hooks/diagnostic/useUpdateDiagnosticSetMutation.ts', () => ({
+    default: () => ({ mutate: mockMutate, isPending: false }),
+}))
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+function set(over: Partial<DiagnosticSetResponse> = {}): DiagnosticSetResponse {
+    return {
+        id: 'set-1',
+        title: 'ESAT Maths II — Set A',
+        description: null,
+        timeLimitMinutes: 40,
+        questionIds: ['q1'],
+        isFree: true,
+        status: 'draft',
+        subject: 'ESAT Maths II',
+        createdAt: '2026-07-13T00:00:00Z',
+        ...over,
+    }
+}
+
+describe('SetPublishButton', () => {
+    beforeEach(() => mockMutate.mockReset())
+    afterEach(() => vi.unstubAllGlobals())
+
+    it('publishes a draft set without a confirmation prompt', () => {
+        const confirmSpy = vi.fn(() => true)
+        vi.stubGlobal('confirm', confirmSpy)
+        render(<SetPublishButton set={set({ status: 'draft' })} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Publish' }))
+        // Publishing is recoverable (just unpublish), so it isn't gated.
+        expect(confirmSpy).not.toHaveBeenCalled()
+        expect(mockMutate.mock.calls[0][0]).toEqual({ status: 'published' })
+    })
+
+    it('confirms before unpublishing — it can strand a live attempt', () => {
+        vi.stubGlobal('confirm', vi.fn(() => true))
+        render(<SetPublishButton set={set({ status: 'published' })} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Unpublish' }))
+        expect(mockMutate.mock.calls[0][0]).toEqual({ status: 'draft' })
+    })
+
+    it('does not unpublish when the confirmation is declined', () => {
+        vi.stubGlobal('confirm', vi.fn(() => false))
+        render(<SetPublishButton set={set({ status: 'published' })} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Unpublish' }))
+        expect(mockMutate).not.toHaveBeenCalled()
+    })
+})

--- a/src/components/diagnostic/SetPublishButton.tsx
+++ b/src/components/diagnostic/SetPublishButton.tsx
@@ -1,0 +1,56 @@
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button.tsx'
+import useUpdateDiagnosticSetMutation from '@/hooks/diagnostic/useUpdateDiagnosticSetMutation.ts'
+import type { DiagnosticSetResponse } from '@/client'
+
+type Props = {
+    set: DiagnosticSetResponse
+}
+
+/**
+ * Publish/unpublish a set — the single gate between a set existing and
+ * students being able to take it (the start-attempt endpoint only accepts a
+ * published set; its questions' own status is irrelevant to that).
+ *
+ * Unpublishing is confirmed, publishing isn't: publishing an unfinished set
+ * is recoverable by unpublishing it, but unpublishing is what yanks a live
+ * diagnostic out from under students who may be mid-attempt.
+ */
+export function SetPublishButton({ set }: Props) {
+    const { mutate: updateSet, isPending } = useUpdateDiagnosticSetMutation({
+        setId: set.id,
+    })
+    const published = set.status === 'published'
+
+    function handleClick() {
+        if (published) {
+            const ok = confirm(
+                `Unpublish "${set.title}"? Students won't be able to start it, ` +
+                    `and anyone part-way through won't be able to finish.`
+            )
+            if (!ok) return
+        }
+        updateSet(
+            { status: published ? 'draft' : 'published' },
+            {
+                onError: () =>
+                    toast.error(
+                        published ? 'Failed to unpublish set' : 'Failed to publish set'
+                    ),
+                onSuccess: () =>
+                    toast.success(published ? 'Set unpublished' : 'Set published'),
+            }
+        )
+    }
+
+    return (
+        <Button
+            variant={published ? 'outline' : 'default'}
+            size="sm"
+            disabled={isPending}
+            onClick={handleClick}
+        >
+            {published ? 'Unpublish' : 'Publish'}
+        </Button>
+    )
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
 import {
     FlaskConical,
     Inbox,
+    Layers,
     LucideCodesandbox,
     PencilIcon,
     Settings,
@@ -46,6 +47,11 @@ const ITEMS = [
         title: 'Diagnostic Questions',
         url: '/admin/questions',
         icon: FlaskConical,
+    },
+    {
+        title: 'Diagnostic Sets',
+        url: '/admin/sets',
+        icon: Layers,
     },
 ]
 

--- a/src/components/ui/combobox.test.tsx
+++ b/src/components/ui/combobox.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Combobox } from './combobox'
+
+function renderCombobox(
+    value: string | null = null,
+    onChange = vi.fn(),
+    options: string[] = ['ESAT Maths I', 'ESAT Maths II', 'ESAT Physics']
+) {
+    render(
+        <Combobox
+            value={value}
+            onChange={onChange}
+            options={options}
+            placeholder="Select…"
+            clearLabel="Uncategorised"
+        />
+    )
+    return onChange
+}
+
+describe('Combobox', () => {
+    it('shows the placeholder when nothing is selected, and the value when it is', () => {
+        const { rerender } = render(
+            <Combobox value={null} onChange={vi.fn()} options={['A']} placeholder="Select…" />
+        )
+        expect(screen.getByRole('combobox')).toHaveTextContent('Select…')
+        rerender(
+            <Combobox value="A" onChange={vi.fn()} options={['A']} placeholder="Select…" />
+        )
+        expect(screen.getByRole('combobox')).toHaveTextContent('A')
+    })
+
+    it('picks an existing option', () => {
+        const onChange = renderCombobox()
+        fireEvent.click(screen.getByRole('combobox'))
+        fireEvent.click(screen.getByText('ESAT Physics'))
+        expect(onChange).toHaveBeenCalledWith('ESAT Physics')
+    })
+
+    it('accepts a typed-in value that is not in the list (free entry)', () => {
+        const onChange = renderCombobox()
+        fireEvent.click(screen.getByRole('combobox'))
+        fireEvent.change(screen.getByPlaceholderText(/search or type/i), {
+            target: { value: 'ESAT Chemistry' },
+        })
+        fireEvent.click(screen.getByText(/Use “ESAT Chemistry”/))
+        expect(onChange).toHaveBeenCalledWith('ESAT Chemistry')
+    })
+
+    it('does not offer free entry when the typed text is already an option', () => {
+        renderCombobox()
+        fireEvent.click(screen.getByRole('combobox'))
+        fireEvent.change(screen.getByPlaceholderText(/search or type/i), {
+            target: { value: 'ESAT Physics' },
+        })
+        // The existing option is offered; a duplicate "Use ..." entry is not.
+        expect(screen.getByText('ESAT Physics')).toBeInTheDocument()
+        expect(screen.queryByText(/Use “ESAT Physics”/)).not.toBeInTheDocument()
+    })
+
+    it('clears to null via the clear entry', () => {
+        const onChange = renderCombobox('ESAT Physics')
+        fireEvent.click(screen.getByRole('combobox'))
+        fireEvent.click(screen.getByText('Uncategorised'))
+        expect(onChange).toHaveBeenCalledWith(null)
+    })
+})

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react'
+import { Check, ChevronsUpDown } from 'lucide-react'
+import { Button } from '@/components/ui/button.tsx'
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from '@/components/ui/command.tsx'
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@/components/ui/popover.tsx'
+import { cn } from '@/lib/utils.ts'
+
+type Props = {
+    value: string | null
+    onChange: (value: string | null) => void
+    options: readonly string[]
+    placeholder?: string
+    searchPlaceholder?: string
+    /** Offers an explicit "clear" entry (e.g. uncategorise a set). */
+    clearLabel?: string
+    id?: string
+}
+
+/**
+ * A pick-from-known-values-or-type-a-new-one input.
+ *
+ * Both places this is used (a set's subject, a question's topic code) have
+ * the same shape of problem: a list that's known-but-growing. A plain text
+ * input invites typos that silently mis-tag content; a hard <Select> means
+ * a new subject or topic can't be added without a code change. This offers
+ * the existing values first and still accepts a new one, so the common case
+ * is a click and the new case isn't blocked.
+ */
+export function Combobox({
+    value,
+    onChange,
+    options,
+    placeholder = 'Select…',
+    searchPlaceholder = 'Search or type a new one…',
+    clearLabel,
+    id,
+}: Props) {
+    const [open, setOpen] = useState(false)
+    const [search, setSearch] = useState('')
+
+    const trimmed = search.trim()
+    const isExisting = options.some(
+        (o) => o.toLowerCase() === trimmed.toLowerCase()
+    )
+
+    function select(next: string | null) {
+        onChange(next)
+        setSearch('')
+        setOpen(false)
+    }
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+                <Button
+                    id={id}
+                    type="button"
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={open}
+                    className="w-full justify-between font-normal"
+                >
+                    <span className={cn(!value && 'text-gray-400')}>
+                        {value ?? placeholder}
+                    </span>
+                    <ChevronsUpDown className="h-4 w-4 opacity-50" />
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
+                <Command>
+                    <CommandInput
+                        placeholder={searchPlaceholder}
+                        value={search}
+                        onValueChange={setSearch}
+                    />
+                    <CommandList>
+                        <CommandEmpty>Nothing matches.</CommandEmpty>
+                        <CommandGroup>
+                            {clearLabel && (
+                                <CommandItem
+                                    value={clearLabel}
+                                    onSelect={() => select(null)}
+                                >
+                                    <span className="text-gray-500">{clearLabel}</span>
+                                    {value === null && (
+                                        <Check className="ml-auto h-4 w-4" />
+                                    )}
+                                </CommandItem>
+                            )}
+                            {options.map((option) => (
+                                <CommandItem
+                                    key={option}
+                                    value={option}
+                                    onSelect={() => select(option)}
+                                >
+                                    {option}
+                                    {value === option && (
+                                        <Check className="ml-auto h-4 w-4" />
+                                    )}
+                                </CommandItem>
+                            ))}
+                            {/* Free entry: only when what's typed isn't already
+                                an option, so it can't shadow an exact match. */}
+                            {trimmed !== '' && !isExisting && (
+                                <CommandItem
+                                    value={trimmed}
+                                    onSelect={() => select(trimmed)}
+                                >
+                                    Use “{trimmed}”
+                                </CommandItem>
+                            )}
+                        </CommandGroup>
+                    </CommandList>
+                </Command>
+            </PopoverContent>
+        </Popover>
+    )
+}

--- a/src/hooks/diagnostic/useListDiagnosticSetsQuery.ts
+++ b/src/hooks/diagnostic/useListDiagnosticSetsQuery.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query'
+import { listDiagnosticSetsDiagnosticSetsGet } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
+
+type Props = {
+    status?: 'draft' | 'published'
+}
+
+/**
+ * Every diagnostic set, for the admin sets screen — admin-only (the
+ * endpoint is gated by require_admin), and distinct from the student-facing
+ * preview query, which only ever serves a single published set.
+ */
+export default function useListDiagnosticSetsQuery({ status }: Props = {}) {
+    return useQuery({
+        queryKey: ['diagnostic-sets', status ?? null],
+        queryFn: async () =>
+            (
+                await listDiagnosticSetsDiagnosticSetsGet({
+                    query: { status },
+                    headers: getAuthHeaders(),
+                })
+            ).data,
+    })
+}

--- a/src/hooks/diagnostic/useTopicCodeOptions.ts
+++ b/src/hooks/diagnostic/useTopicCodeOptions.ts
@@ -1,0 +1,19 @@
+import { useMemo } from 'react'
+import useListDiagnosticQuestionsQuery from './useListDiagnosticQuestionsQuery.ts'
+
+/**
+ * The distinct topic codes already in use, for the question form's
+ * topic-code combobox. Derived from the existing questions rather than a
+ * separate endpoint or a hardcoded list: the codes in use *are* the list,
+ * and it stays correct as content grows without anything to maintain.
+ */
+export default function useTopicCodeOptions(): string[] {
+    const { data: questions } = useListDiagnosticQuestionsQuery()
+
+    return useMemo(() => {
+        const codes = (questions ?? [])
+            .map((q) => q.topicCode)
+            .filter((c): c is string => !!c)
+        return [...new Set(codes)].sort()
+    }, [questions])
+}

--- a/src/hooks/diagnostic/useUpdateDiagnosticSetMutation.test.tsx
+++ b/src/hooks/diagnostic/useUpdateDiagnosticSetMutation.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import useUpdateDiagnosticSetMutation from './useUpdateDiagnosticSetMutation'
+
+const mockPatch = vi.fn()
+vi.mock('@/client', () => ({
+    updateDiagnosticSetDiagnosticSetsSetIdPatch: (...args: unknown[]) => mockPatch(...args),
+}))
+vi.mock('@/lib/authHeaders.ts', () => ({ getAuthHeaders: () => ({ Authorization: 'Bearer x' }) }))
+
+function wrapper({ children }: { children: ReactNode }) {
+    const client = new QueryClient({
+        defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+    })
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+describe('useUpdateDiagnosticSetMutation', () => {
+    beforeEach(() => mockPatch.mockReset())
+
+    it('resolves with the updated set on success', async () => {
+        mockPatch.mockResolvedValue({
+            data: { id: 'set-1', status: 'published' },
+            error: undefined,
+            response: { status: 200 },
+        })
+        const { result } = renderHook(() => useUpdateDiagnosticSetMutation({ setId: 'set-1' }), {
+            wrapper,
+        })
+        act(() => result.current.mutate({ status: 'published' }))
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+        expect(result.current.data).toEqual({ id: 'set-1', status: 'published' })
+    })
+
+    it('rejects when the request fails, rather than reporting a false success', async () => {
+        // The generated client resolves with { data: undefined, error } on an
+        // HTTP error. If this hook returned .data blindly, react-query would
+        // call this a success and the UI would toast "Set published" while
+        // nothing changed — the exact failure live testing surfaced (401 from
+        // an expired token).
+        mockPatch.mockResolvedValue({
+            data: undefined,
+            error: { detail: 'Could not validate credentials' },
+            response: { status: 401 },
+        })
+        const { result } = renderHook(() => useUpdateDiagnosticSetMutation({ setId: 'set-1' }), {
+            wrapper,
+        })
+        act(() => result.current.mutate({ status: 'published' }))
+
+        await waitFor(() => expect(result.current.isError).toBe(true))
+        expect(result.current.isSuccess).toBe(false)
+        expect((result.current.error as { status?: number }).status).toBe(401)
+    })
+})

--- a/src/hooks/diagnostic/useUpdateDiagnosticSetMutation.ts
+++ b/src/hooks/diagnostic/useUpdateDiagnosticSetMutation.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { updateDiagnosticSetDiagnosticSetsSetIdPatch } from '@/client'
+import type { UpdateDiagnosticSetBody } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
+
+type Props = {
+    setId: string
+}
+
+/**
+ * The one write the admin sets screen needs: publish/unpublish, and edit a
+ * set's metadata (title, subject, time limit, free-tier). The backend body
+ * is exclude_unset, so sending only the field being changed leaves the rest
+ * untouched — an explicit null on `subject` is a deliberate "uncategorise",
+ * not the same as omitting it.
+ */
+export class UpdateDiagnosticSetError extends Error {
+    status?: number
+    constructor(status?: number) {
+        super(`Failed to update set${status ? ` (${status})` : ''}`)
+        this.name = 'UpdateDiagnosticSetError'
+        this.status = status
+    }
+}
+
+export default function useUpdateDiagnosticSetMutation({ setId }: Props) {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: async (body: UpdateDiagnosticSetBody) => {
+            const result = await updateDiagnosticSetDiagnosticSetsSetIdPatch({
+                path: { set_id: setId },
+                body,
+                headers: getAuthHeaders(),
+            })
+            // The generated client does NOT throw on an HTTP error — it
+            // resolves with { data: undefined, error }. Returning `.data`
+            // blindly makes a 401/422 look like a successful mutation:
+            // onSuccess fires, a "Set published" toast appears, and nothing
+            // has changed. Caught in live testing, where an expired token
+            // produced exactly that lie. Throw so onError is what runs.
+            if (result.error !== undefined) {
+                throw new UpdateDiagnosticSetError(result.response?.status)
+            }
+            return result.data
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['diagnostic-sets'] })
+            // The student-facing preview reads the same row (title, time
+            // limit, and crucially whether it's published at all), so a
+            // publish here must not leave a stale preview cached.
+            queryClient.invalidateQueries({ queryKey: ['diagnostic-set-preview', setId] })
+        },
+    })
+}

--- a/src/lib/diagnosticSubjects.test.ts
+++ b/src/lib/diagnosticSubjects.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import {
+    DIAGNOSTIC_SUBJECTS,
+    UNCATEGORISED_LABEL,
+    groupSetsBySubject,
+} from './diagnosticSubjects'
+
+function s(title: string, subject?: string | null) {
+    return { title, subject: subject ?? null }
+}
+
+describe('groupSetsBySubject', () => {
+    it('lists the known subjects in a stable order, even when empty', () => {
+        const groups = groupSetsBySubject([])
+        // Every known subject still gets a heading — an empty "ESAT Physics"
+        // says "nothing imported yet", rather than the paper vanishing.
+        expect(groups.map((g) => g.subject)).toEqual([...DIAGNOSTIC_SUBJECTS])
+        expect(groups.every((g) => g.sets.length === 0)).toBe(true)
+    })
+
+    it('files each set under its subject', () => {
+        const groups = groupSetsBySubject([
+            s('M2 A', 'ESAT Maths II'),
+            s('M2 B', 'ESAT Maths II'),
+            s('Phys A', 'ESAT Physics'),
+        ])
+        const byName = Object.fromEntries(groups.map((g) => [g.subject, g.sets]))
+        expect(byName['ESAT Maths II'].map((x) => x.title)).toEqual(['M2 A', 'M2 B'])
+        expect(byName['ESAT Physics'].map((x) => x.title)).toEqual(['Phys A'])
+        expect(byName['ESAT Maths I']).toEqual([])
+    })
+
+    it('puts uncategorised last, and only when something is uncategorised', () => {
+        expect(groupSetsBySubject([s('A', 'ESAT Maths I')]).map((g) => g.subject)).not.toContain(
+            UNCATEGORISED_LABEL
+        )
+        const groups = groupSetsBySubject([s('A', 'ESAT Maths I'), s('B', null)])
+        expect(groups[groups.length - 1].subject).toBe(UNCATEGORISED_LABEL)
+        expect(groups[groups.length - 1].sets.map((x) => x.title)).toEqual(['B'])
+    })
+
+    it('shows a typed-in subject that is not a known one, after the known ones', () => {
+        const groups = groupSetsBySubject([
+            s('Chem A', 'ESAT Chemistry'),
+            s('M1 A', 'ESAT Maths I'),
+            s('Bio A', 'ESAT Biology'),
+        ])
+        const names = groups.map((g) => g.subject)
+        // Known first (in their fixed order), then custom alphabetically.
+        expect(names.slice(0, 3)).toEqual([...DIAGNOSTIC_SUBJECTS])
+        expect(names.slice(3)).toEqual(['ESAT Biology', 'ESAT Chemistry'])
+    })
+
+    it('does not duplicate a set across groups', () => {
+        const groups = groupSetsBySubject([s('A', 'ESAT Physics'), s('B', null)])
+        expect(groups.reduce((n, g) => n + g.sets.length, 0)).toBe(2)
+    })
+})

--- a/src/lib/diagnosticSubjects.ts
+++ b/src/lib/diagnosticSubjects.ts
@@ -1,0 +1,61 @@
+/**
+ * The subjects a diagnostic set can belong to.
+ *
+ * Deliberately a frontend list, not a DB enum or a backend constant: the
+ * column is plain `text` (see migration 20260713080000) precisely so adding
+ * a paper is a product decision, not a migration. These are the known
+ * values offered in the UI; the subject input still accepts a new one typed
+ * in, so this list never blocks anyone.
+ */
+export const DIAGNOSTIC_SUBJECTS = [
+    'ESAT Maths I',
+    'ESAT Maths II',
+    'ESAT Physics',
+] as const
+
+/** Label for a set whose subject is null — not a guess, just absence. */
+export const UNCATEGORISED_LABEL = 'Uncategorised'
+
+type HasSubject = { subject?: string | null }
+
+/**
+ * Groups sets under subject headings for the admin list.
+ *
+ * Ordering is deliberate: the known subjects first, in DIAGNOSTIC_SUBJECTS
+ * order (so the list reads the same every visit rather than reshuffling as
+ * sets are added), then any subject typed in that isn't in that list
+ * (alphabetical), then Uncategorised last — absence belongs at the bottom,
+ * not interleaved. A known subject with no sets yet is still shown, so an
+ * empty "ESAT Physics" heading tells you it's empty rather than the subject
+ * silently not existing.
+ */
+export function groupSetsBySubject<T extends HasSubject>(
+    sets: T[]
+): Array<{ subject: string; sets: T[] }> {
+    const known = DIAGNOSTIC_SUBJECTS.map((subject) => ({
+        subject,
+        sets: sets.filter((s) => s.subject === subject),
+    }))
+
+    const knownNames = new Set<string>(DIAGNOSTIC_SUBJECTS)
+    const customNames = [
+        ...new Set(
+            sets
+                .map((s) => s.subject)
+                .filter((s): s is string => !!s && !knownNames.has(s))
+        ),
+    ].sort()
+    const custom = customNames.map((subject) => ({
+        subject,
+        sets: sets.filter((s) => s.subject === subject),
+    }))
+
+    const uncategorised = sets.filter((s) => !s.subject)
+    return [
+        ...known,
+        ...custom,
+        ...(uncategorised.length > 0
+            ? [{ subject: UNCATEGORISED_LABEL, sets: uncategorised }]
+            : []),
+    ]
+}

--- a/src/pages/Admin/Diagnostic/DiagnosticQuestionCreatePage.test.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticQuestionCreatePage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { setTopicCode } from '@/test/setTopicCode.ts'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { DiagnosticQuestionCreatePage } from './DiagnosticQuestionCreatePage'
 
@@ -15,6 +16,12 @@ vi.mock('react-router-dom', async () => {
     return { ...actual, useNavigate: () => mockNavigate }
 })
 
+vi.mock('@/hooks/diagnostic/useTopicCodeOptions.ts', () => ({
+    // The combobox's option list is irrelevant to these tests (they're about
+    // the two-step diagram upload); stubbed so the page doesn't need a
+    // QueryClientProvider just to render.
+    default: () => [],
+}))
 vi.mock('@/hooks/diagnostic/useCreateDiagnosticQuestionMutation.ts', () => ({
     default: () => ({
         mutate: mockCreateMutate,
@@ -43,9 +50,7 @@ function renderCreatePage() {
 }
 
 function fillRequiredFields() {
-    fireEvent.change(screen.getByPlaceholderText(/e.g. MM1.6/i), {
-        target: { value: 'MM1.1' },
-    })
+    setTopicCode('MM1.1')
     const combo = screen
         .getAllByRole('combobox')
         .find((c) => c.textContent?.includes('Select a skill'))!

--- a/src/pages/Admin/Diagnostic/DiagnosticQuestionCreatePage.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticQuestionCreatePage.tsx
@@ -6,12 +6,14 @@ import {
     getDiagramSvgForCreate,
     type DiagnosticQuestionFormValues,
 } from '@/components/diagnostic/DiagnosticQuestionForm.tsx'
+import useTopicCodeOptions from '@/hooks/diagnostic/useTopicCodeOptions.ts'
 import useCreateDiagnosticQuestionMutation from '@/hooks/diagnostic/useCreateDiagnosticQuestionMutation.ts'
 import useUploadDiagnosticQuestionDiagramMutation from '@/hooks/diagnostic/useUploadDiagnosticQuestionDiagramMutation.ts'
 import { toast } from 'sonner'
 
 export function DiagnosticQuestionCreatePage() {
     const navigate = useNavigate()
+    const topicCodeOptions = useTopicCodeOptions()
     const { mutate: createQuestion, isPending } =
         useCreateDiagnosticQuestionMutation()
     const { mutateAsync: uploadDiagram, isPending: isUploadingDiagram } =
@@ -88,6 +90,7 @@ export function DiagnosticQuestionCreatePage() {
                     New Diagnostic Question
                 </h1>
                 <DiagnosticQuestionForm
+                    topicCodeOptions={topicCodeOptions}
                     onSubmit={handleSubmit}
                     isSubmitting={isPending || isUploadingDiagram}
                     submitLabel="Create question"

--- a/src/pages/Admin/Diagnostic/DiagnosticQuestionEditPage.test.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticQuestionEditPage.test.tsx
@@ -33,6 +33,12 @@ vi.mock('@/hooks/diagnostic/useGetDiagnosticQuestionQuery.ts', () => ({
     }),
 }))
 
+vi.mock('@/hooks/diagnostic/useTopicCodeOptions.ts', () => ({
+    // The combobox's option list is irrelevant to these tests (they're about
+    // the two-step diagram upload); stubbed so the page doesn't need a
+    // QueryClientProvider just to render.
+    default: () => [],
+}))
 vi.mock('@/hooks/diagnostic/useUpdateDiagnosticQuestionMutation.ts', () => ({
     default: () => ({
         mutate: mockUpdateMutate,

--- a/src/pages/Admin/Diagnostic/DiagnosticQuestionEditPage.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticQuestionEditPage.tsx
@@ -9,6 +9,7 @@ import {
     getDiagramSvgForUpdate,
     type DiagnosticQuestionFormValues,
 } from '@/components/diagnostic/DiagnosticQuestionForm.tsx'
+import useTopicCodeOptions from '@/hooks/diagnostic/useTopicCodeOptions.ts'
 import useGetDiagnosticQuestionQuery from '@/hooks/diagnostic/useGetDiagnosticQuestionQuery.ts'
 import useUpdateDiagnosticQuestionMutation from '@/hooks/diagnostic/useUpdateDiagnosticQuestionMutation.ts'
 import useUploadDiagnosticQuestionDiagramMutation from '@/hooks/diagnostic/useUploadDiagnosticQuestionDiagramMutation.ts'
@@ -20,6 +21,7 @@ type LocationState = {
 
 export function DiagnosticQuestionEditPage() {
     const navigate = useNavigate()
+    const topicCodeOptions = useTopicCodeOptions()
     const location = useLocation()
     const { questionId } = useParams()
     const { data: question, isLoading } = useGetDiagnosticQuestionQuery({
@@ -148,6 +150,7 @@ export function DiagnosticQuestionEditPage() {
                     </div>
                 )}
                 <DiagnosticQuestionForm
+                    topicCodeOptions={topicCodeOptions}
                     initialData={question}
                     onSubmit={handleSubmit}
                     isSubmitting={isPending || isUploadingDiagram}

--- a/src/pages/Admin/Diagnostic/DiagnosticSetsListPage.test.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticSetsListPage.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { DiagnosticSetsListPage } from './DiagnosticSetsListPage'
+import type { DiagnosticSetResponse } from '@/client'
+
+const mockUseListSets = vi.fn()
+const mockUpdateMutate = vi.fn()
+
+vi.mock('@/hooks/diagnostic/useListDiagnosticSetsQuery.ts', () => ({
+    default: () => mockUseListSets(),
+}))
+vi.mock('@/hooks/diagnostic/useUpdateDiagnosticSetMutation.ts', () => ({
+    default: () => ({ mutate: mockUpdateMutate, isPending: false }),
+}))
+vi.mock('@/components/layout/AdminLayout.tsx', () => ({
+    // The sidebar pulls in auth/router context that isn't what's under test.
+    AdminLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+function set(over: Partial<DiagnosticSetResponse> = {}): DiagnosticSetResponse {
+    return {
+        id: 'set-1',
+        title: 'ESAT Maths II — Set A',
+        description: null,
+        timeLimitMinutes: 40,
+        questionIds: Array.from({ length: 27 }, (_, i) => `q${i}`),
+        isFree: true,
+        status: 'draft',
+        subject: 'ESAT Maths II',
+        createdAt: '2026-07-13T00:00:00Z',
+        ...over,
+    }
+}
+
+describe('DiagnosticSetsListPage', () => {
+    beforeEach(() => {
+        mockUseListSets.mockReset()
+        mockUpdateMutate.mockReset()
+    })
+
+    it('tells you where sets come from when there are none', () => {
+        mockUseListSets.mockReturnValue({ data: [], isLoading: false })
+        render(<DiagnosticSetsListPage />)
+        expect(screen.getByText(/no diagnostic sets yet/i)).toBeInTheDocument()
+    })
+
+    it('groups sets under their subject, and shows the real set details', () => {
+        mockUseListSets.mockReturnValue({ data: [set()], isLoading: false })
+        render(<DiagnosticSetsListPage />)
+
+        // Grouped under its subject heading, with the question count and time.
+        expect(screen.getByRole('heading', { name: /ESAT Maths II/ })).toBeInTheDocument()
+        expect(screen.getByText('ESAT Maths II — Set A')).toBeInTheDocument()
+        expect(screen.getByText('27')).toBeInTheDocument()
+        expect(screen.getByText('40 min')).toBeInTheDocument()
+        expect(screen.getByText('draft')).toBeInTheDocument()
+    })
+
+    it('shows an empty known subject rather than hiding the paper', () => {
+        mockUseListSets.mockReturnValue({ data: [set()], isLoading: false })
+        render(<DiagnosticSetsListPage />)
+        // Nothing imported for Physics yet — the heading still appears.
+        expect(screen.getByRole('heading', { name: /ESAT Physics/ })).toBeInTheDocument()
+        expect(screen.getAllByText(/no sets for this subject yet/i).length).toBeGreaterThan(0)
+    })
+
+    it('files an uncategorised set under Uncategorised', () => {
+        mockUseListSets.mockReturnValue({
+            data: [set({ subject: null, title: 'Legacy set' })],
+            isLoading: false,
+        })
+        render(<DiagnosticSetsListPage />)
+        const heading = screen.getByRole('heading', { name: /Uncategorised/ })
+        expect(heading).toBeInTheDocument()
+        expect(screen.getByText('Legacy set')).toBeInTheDocument()
+    })
+
+    it('publishes a draft set from the list', () => {
+        mockUseListSets.mockReturnValue({ data: [set({ status: 'draft' })], isLoading: false })
+        render(<DiagnosticSetsListPage />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Publish' }))
+        expect(mockUpdateMutate.mock.calls[0][0]).toEqual({ status: 'published' })
+    })
+
+    it('opens the edit dialog with the set loaded', () => {
+        mockUseListSets.mockReturnValue({ data: [set()], isLoading: false })
+        render(<DiagnosticSetsListPage />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+        const dialog = screen.getByRole('dialog')
+        expect(within(dialog).getByLabelText('Title')).toHaveValue('ESAT Maths II — Set A')
+        // The subject combobox is pre-filled from the set.
+        expect(
+            within(dialog).getByRole('combobox', { name: /subject/i })
+        ).toHaveTextContent('ESAT Maths II')
+    })
+})

--- a/src/pages/Admin/Diagnostic/DiagnosticSetsListPage.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticSetsListPage.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { AdminLayout } from '@/components/layout/AdminLayout.tsx'
+import { Badge } from '@/components/ui/badge.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table.tsx'
+import useListDiagnosticSetsQuery from '@/hooks/diagnostic/useListDiagnosticSetsQuery.ts'
+import { groupSetsBySubject } from '@/lib/diagnosticSubjects.ts'
+import { EditSetDialog } from '@/components/diagnostic/EditSetDialog.tsx'
+import { SetPublishButton } from '@/components/diagnostic/SetPublishButton.tsx'
+import type { DiagnosticSetResponse } from '@/client'
+
+/**
+ * Admin screen for diagnostic sets — the counterpart to the questions list.
+ * Sets are created by bulk import (each import file is one set); this screen
+ * is where they get categorised, published, and their metadata corrected,
+ * none of which had any UI before (publishing was a hand-run API call).
+ *
+ * Grouped by subject rather than a flat list, since the point is running
+ * several sets per paper — an empty known-subject heading is deliberate: it
+ * says "nothing imported for this paper yet" rather than the paper silently
+ * not appearing.
+ */
+export function DiagnosticSetsListPage() {
+    const { data: sets, isLoading } = useListDiagnosticSetsQuery()
+    const [editing, setEditing] = useState<DiagnosticSetResponse | null>(null)
+
+    const groups = groupSetsBySubject(sets ?? [])
+
+    return (
+        <AdminLayout>
+            <div className="mt-8 flex flex-col gap-6">
+                <div className="flex items-center justify-between">
+                    <h1 className="text-2xl font-semibold">Diagnostic Sets</h1>
+                    <span className="text-sm text-gray-500">
+                        Sets are created by bulk import
+                    </span>
+                </div>
+
+                {isLoading && <p className="text-gray-500">Loading…</p>}
+
+                {!isLoading && (sets?.length ?? 0) === 0 && (
+                    <p className="text-gray-500">
+                        No diagnostic sets yet — bulk import a set from the
+                        Diagnostic Questions screen.
+                    </p>
+                )}
+
+                {!isLoading &&
+                    (sets?.length ?? 0) > 0 &&
+                    groups.map((group) => (
+                        <section key={group.subject} className="flex flex-col gap-2">
+                            <h2 className="text-lg font-medium">
+                                {group.subject}{' '}
+                                <span className="text-sm font-normal text-gray-400">
+                                    ({group.sets.length})
+                                </span>
+                            </h2>
+                            {group.sets.length === 0 ? (
+                                <p className="text-sm text-gray-400">
+                                    No sets for this subject yet.
+                                </p>
+                            ) : (
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead>Title</TableHead>
+                                            <TableHead>Questions</TableHead>
+                                            <TableHead>Time</TableHead>
+                                            <TableHead>Status</TableHead>
+                                            <TableHead />
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {group.sets.map((s) => (
+                                            <TableRow key={s.id}>
+                                                <TableCell className="font-medium">
+                                                    {s.title}
+                                                    {s.isFree && (
+                                                        <Badge
+                                                            variant="outline"
+                                                            className="ml-2"
+                                                        >
+                                                            free
+                                                        </Badge>
+                                                    )}
+                                                </TableCell>
+                                                <TableCell>
+                                                    {s.questionIds.length}
+                                                </TableCell>
+                                                <TableCell>
+                                                    {s.timeLimitMinutes} min
+                                                </TableCell>
+                                                <TableCell>
+                                                    <Badge
+                                                        variant={
+                                                            s.status === 'published'
+                                                                ? 'default'
+                                                                : 'secondary'
+                                                        }
+                                                    >
+                                                        {s.status}
+                                                    </Badge>
+                                                </TableCell>
+                                                <TableCell className="text-right">
+                                                    <div className="flex justify-end gap-2">
+                                                        <Button
+                                                            variant="outline"
+                                                            size="sm"
+                                                            onClick={() => setEditing(s)}
+                                                        >
+                                                            Edit
+                                                        </Button>
+                                                        <SetPublishButton set={s} />
+                                                    </div>
+                                                </TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            )}
+                        </section>
+                    ))}
+            </div>
+
+            {editing && (
+                <EditSetDialog
+                    set={editing}
+                    open={editing !== null}
+                    onOpenChange={(open) => !open && setEditing(null)}
+                    onSaved={() => {
+                        setEditing(null)
+                        toast.success('Set updated')
+                    }}
+                />
+            )}
+        </AdminLayout>
+    )
+}

--- a/src/test/setTopicCode.ts
+++ b/src/test/setTopicCode.ts
@@ -1,0 +1,18 @@
+import { fireEvent, screen } from '@testing-library/react'
+
+/**
+ * Sets the question form's topic-code combobox in tests.
+ *
+ * Named-role query, not getByRole('combobox') alone: Radix's Select
+ * triggers (core skill, difficulty, status) report role="combobox" too, so
+ * an unnamed query matches five things on this form.
+ */
+export function setTopicCode(value: string) {
+    fireEvent.click(screen.getByRole('combobox', { name: /topic code/i }))
+    fireEvent.change(screen.getByPlaceholderText(/search or type a new topic code/i), {
+        target: { value },
+    })
+    // Free-entry item — the tests use codes that aren't in the (stubbed,
+    // empty) option list, so this is the entry that commits the value.
+    fireEvent.click(screen.getByText(`Use “${value}”`))
+}


### PR DESCRIPTION
## What
Sets had **no UI at all** — publishing one was a hand-run API call, and there was nowhere to see what existed or which paper it belonged to. This adds **`/admin/sets`** (with a sidebar entry next to Diagnostic Questions).

- Every set **grouped by subject**, showing question count, time limit, `free` badge and status.
- **Publish / Unpublish** buttons — replacing the API call I ran by hand for your Maths II set.
- **Edit dialog**: title, **subject** (combobox of the three ESAT papers + free entry), time limit, free-tier.
- Grouping shows **known subjects even when empty** (an empty "ESAT Physics" heading says *nothing imported yet*, rather than the paper silently not existing), and puts **Uncategorised last, only when something is**.
- **Unpublish is confirmed; publish isn't** — publishing an unfinished set is undone by unpublishing, but unpublishing strands students mid-attempt.
- The set's **questions aren't editable here**: a set's questions come from its import and there's no endpoint to change them (that's the next piece of work).

## Topic-code combobox (folded in)
The topic input was free text, where a typo silently mis-tags a question. It now offers **the codes already in use** and still accepts a **new one typed in** — common case is a click, a genuinely new topic isn't blocked. Options are derived from existing questions (the codes in use *are* the list) and passed in as a prop, so the form stays presentational and needs no query context.

## A real bug this surfaced — and why live testing earns its keep
The generated client **does not throw on HTTP errors**; it resolves with `{ data: undefined, error }`. Returning `.data` blindly (the pattern the existing question mutations use, which this hook copied) made a **401 look like success**: `onSuccess` fired and a **"Set published" toast appeared while nothing had changed**. Unit tests mock the mutation and could never catch it — only driving the real thing did.

`useUpdateDiagnosticSetMutation` now throws on error so `onError` runs, with **a test pinning the false-success case**. (The pre-existing question mutations share this flaw — flagged as a separate follow-up, not silently widened here.)

## Tests — 161 green; tsc + lint clean on changed files
Pure grouping (`groupSetsBySubject`): stable known-subject order, empty headings kept, Uncategorised last/conditional, custom subjects after known ones, no duplication. `Combobox`: pick existing, free entry, no duplicate "Use…" on an exact match, clear-to-null. `SetPublishButton`: publish unconfirmed, unpublish confirmed, declined confirm does nothing. Sets page: grouping, real details, empty-subject heading, uncategorised, publish, edit dialog pre-filled. Plus the mutation-error test above. Existing form/page tests updated for the combobox via a shared `setTopicCode` helper (named-role query — Radix `Select` triggers also report `role="combobox"`).

## Live browser verification (real prod data, throwaway cleaned up)
- Your **live ESAT Maths II set** renders under its subject — 27 questions, 40 min, `published`, `free` ✅
- Empty **ESAT Maths I** / **ESAT Physics** headings shown; **Uncategorised** last ✅
- A **throwaway** set: categorised to "ESAT Physics" via the combobox → **moved groups**, Uncategorised group correctly disappeared, **persisted in the DB**; then **published** → persisted ✅
- Throwaway deleted and confirmed gone; **the live Maths II set untouched throughout** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)