### PR TITLE
Link each question to its editor from the set review page

### DIFF
--- a/src/pages/Admin/Diagnostic/DiagnosticSetReviewPage.test.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticSetReviewPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { DiagnosticSetReviewPage } from './DiagnosticSetReviewPage'
 import type { DiagnosticQuestionResponse, DiagnosticSetResponse } from '@/client'
 
@@ -78,15 +79,26 @@ describe('DiagnosticSetReviewPage', () => {
 
     it('renders the questions in the set order, not the source order', () => {
         mockGetSet.mockReturnValue({ data: set(), isLoading: false })
-        render(<DiagnosticSetReviewPage />)
+        render(<MemoryRouter><DiagnosticSetReviewPage /></MemoryRouter>)
         const cards = screen.getAllByText(/stem$/).map((n) => n.textContent)
         // set.questionIds is [qb, qa] -> second stem before first stem.
         expect(cards).toEqual(['second stem', 'first stem'])
     })
 
+    it('links each question to its own edit page', () => {
+        mockGetSet.mockReturnValue({ data: set(), isLoading: false })
+        render(<MemoryRouter><DiagnosticSetReviewPage /></MemoryRouter>)
+        // set.questionIds is [qb, qa] -> Q1 is qb, Q2 is qa. Each Edit link
+        // points at that exact question, so an admin can jump straight to
+        // (e.g.) Physics Q12 to replace its diagram.
+        const editLinks = screen.getAllByRole('link', { name: /edit/i })
+        expect(editLinks[0]).toHaveAttribute('href', '/admin/questions/qb')
+        expect(editLinks[1]).toHaveAttribute('href', '/admin/questions/qa')
+    })
+
     it('marks the correct option (which the student view hides)', () => {
         mockGetSet.mockReturnValue({ data: set({ questionIds: ['qa'] }), isLoading: false })
-        render(<DiagnosticSetReviewPage />)
+        render(<MemoryRouter><DiagnosticSetReviewPage /></MemoryRouter>)
         const correct = screen.getByText('right').closest('li')!
         expect(within(correct).getByText('correct')).toBeInTheDocument()
         // the wrong option is not marked
@@ -95,7 +107,7 @@ describe('DiagnosticSetReviewPage', () => {
 
     it('offers "Publish all questions" only when some are draft, and bulk-publishes on click', () => {
         mockGetSet.mockReturnValue({ data: set(), isLoading: false }) // qb is draft
-        render(<DiagnosticSetReviewPage />)
+        render(<MemoryRouter><DiagnosticSetReviewPage /></MemoryRouter>)
         const btn = screen.getByRole('button', { name: /publish all questions/i })
         fireEvent.click(btn)
         expect(mockBulkPublish.mock.calls[0][0]).toEqual({
@@ -109,7 +121,7 @@ describe('DiagnosticSetReviewPage', () => {
             data: set({ questionIds: ['qa'] }), // qa is published
             isLoading: false,
         })
-        render(<DiagnosticSetReviewPage />)
+        render(<MemoryRouter><DiagnosticSetReviewPage /></MemoryRouter>)
         expect(
             screen.queryByRole('button', { name: /publish all questions/i })
         ).not.toBeInTheDocument()

--- a/src/pages/Admin/Diagnostic/DiagnosticSetReviewPage.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticSetReviewPage.tsx
@@ -1,5 +1,5 @@
-import { useNavigate, useParams } from 'react-router-dom'
-import { Check } from 'lucide-react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Check, Pencil } from 'lucide-react'
 import { toast } from 'sonner'
 import { AdminLayout } from '@/components/layout/AdminLayout.tsx'
 import { Badge } from '@/components/ui/badge.tsx'
@@ -125,6 +125,20 @@ export function DiagnosticSetReviewPage() {
                                 {q.status === 'draft' && (
                                     <Badge variant="secondary">draft</Badge>
                                 )}
+                                {/* Jump straight to this exact question to edit it
+                                    (e.g. replace an inaccurate diagram). A Link, so
+                                    cmd/middle-click opens it in a new tab and keeps
+                                    this numbered review as the index. */}
+                                <Button
+                                    asChild
+                                    variant="ghost"
+                                    size="sm"
+                                    className="ml-auto"
+                                >
+                                    <Link to={`/admin/questions/${q.id}`}>
+                                        <Pencil className="h-4 w-4" /> Edit
+                                    </Link>
+                                </Button>
                             </div>
 
                             <div className="text-gray-900">


### PR DESCRIPTION
## What
The review page (`/admin/sets/:id/preview`) numbers a set's questions Q1…Qn in exam order, but there was no way to jump into editing a specific one — to fix an inaccurate diagram on "Physics Q12" you had to search the flat, unnumbered `/admin/questions` list with no set context.

Each review card now has an **Edit** link → that question's editor, where the **PNG/JPEG diagram upload** already lives. It's a real `<Link>`, so cmd/middle-click opens it in a new tab and keeps the numbered review open as your index while you edit several (e.g. Q12, Q17, Q22).

## Tests
Review-page test asserts each card links to `/admin/questions/<that exact id>`, in set order. Full suite green (189); tsc + lint clean.

*(A one-line navigation change; verified by the unit test rather than a live browser pass.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)