### PR TITLE
Filter the diagnostic questions list by set, status, topic (+ Sets column)

### DIFF
--- a/src/lib/questionListFilters.test.ts
+++ b/src/lib/questionListFilters.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import {
+    NO_SET,
+    filterQuestionsForList,
+    setsByQuestionId,
+} from './questionListFilters'
+import type { DiagnosticQuestionResponse, DiagnosticSetResponse } from '@/client'
+
+function q(over: Partial<DiagnosticQuestionResponse>): DiagnosticQuestionResponse {
+    return {
+        id: 'id',
+        topicCode: 'MM1.1',
+        coreSkillPrimary: 'S1',
+        stem: 'stem',
+        options: [],
+        correctOption: 'A',
+        status: 'published',
+        createdAt: '2026-07-13T00:00:00Z',
+        ...over,
+    }
+}
+function s(id: string, title: string, questionIds: string[]): DiagnosticSetResponse {
+    return {
+        id,
+        title,
+        description: null,
+        timeLimitMinutes: 40,
+        questionIds,
+        isFree: false,
+        status: 'draft',
+        subject: null,
+        createdAt: '2026-07-13T00:00:00Z',
+    }
+}
+
+const questions = [
+    q({ id: 'a', topicCode: 'MM1.1', status: 'published', stem: 'derivative' }),
+    q({ id: 'b', topicCode: 'MM2.3', status: 'draft', stem: 'integral' }),
+    q({ id: 'c', topicCode: 'MM1.1', status: 'draft', stem: 'limit' }),
+]
+const sets = [s('set1', 'Physics A', ['a', 'b']), s('set2', 'Maths A', ['a'])]
+const membership = setsByQuestionId(sets)
+
+describe('setsByQuestionId', () => {
+    it('maps each question to every set that contains it', () => {
+        expect(membership.get('a')!.map((x) => x.id)).toEqual(['set1', 'set2'])
+        expect(membership.get('b')!.map((x) => x.id)).toEqual(['set1'])
+        expect(membership.get('c')).toBeUndefined() // in no set
+    })
+})
+
+describe('filterQuestionsForList', () => {
+    it('filters to a specific set (by membership, not a field on the question)', () => {
+        expect(
+            filterQuestionsForList(questions, membership, { setId: 'set1' }).map((x) => x.id)
+        ).toEqual(['a', 'b'])
+        expect(
+            filterQuestionsForList(questions, membership, { setId: 'set2' }).map((x) => x.id)
+        ).toEqual(['a'])
+    })
+
+    it('finds orphans — questions in no set', () => {
+        expect(
+            filterQuestionsForList(questions, membership, { setId: NO_SET }).map((x) => x.id)
+        ).toEqual(['c'])
+    })
+
+    it('returns everything when the set filter is null', () => {
+        expect(filterQuestionsForList(questions, membership, { setId: null })).toHaveLength(3)
+    })
+
+    it('combines the set filter with status/topic/search', () => {
+        // set1 has a,b; of those, only the draft one is b.
+        expect(
+            filterQuestionsForList(questions, membership, {
+                setId: 'set1',
+                status: 'draft',
+            }).map((x) => x.id)
+        ).toEqual(['b'])
+        // topic within a set
+        expect(
+            filterQuestionsForList(questions, membership, {
+                setId: 'set1',
+                topicCode: 'MM1.1',
+            }).map((x) => x.id)
+        ).toEqual(['a'])
+        // search within a set
+        expect(
+            filterQuestionsForList(questions, membership, {
+                setId: 'set1',
+                search: 'integr',
+            }).map((x) => x.id)
+        ).toEqual(['b'])
+    })
+})

--- a/src/lib/questionListFilters.ts
+++ b/src/lib/questionListFilters.ts
@@ -1,0 +1,56 @@
+import type { DiagnosticQuestionResponse, DiagnosticSetResponse } from '@/client'
+import { filterQuestions } from '@/lib/questionPicker.ts'
+
+/**
+ * Reverse-lookup + filtering for the diagnostic questions list. A question
+ * has no set field — the *set* lists its questions (§3) — so "which sets is
+ * this question in" is derived here, and a question can be in several sets
+ * or none.
+ */
+
+/** questionId -> the sets that contain it (in the order sets were given). */
+export function setsByQuestionId(
+    sets: DiagnosticSetResponse[]
+): Map<string, DiagnosticSetResponse[]> {
+    const map = new Map<string, DiagnosticSetResponse[]>()
+    for (const set of sets) {
+        for (const qid of set.questionIds) {
+            const list = map.get(qid)
+            if (list) list.push(set)
+            else map.set(qid, [set])
+        }
+    }
+    return map
+}
+
+/** Sentinel for the "in no set" (orphan) filter — distinct from "all sets"
+ * (null/undefined). */
+export const NO_SET = '__none__'
+
+export function filterQuestionsForList(
+    questions: DiagnosticQuestionResponse[],
+    membership: Map<string, DiagnosticSetResponse[]>,
+    {
+        setId,
+        status,
+        topicCode,
+        search,
+    }: {
+        setId?: string | null
+        status?: 'draft' | 'published' | null
+        topicCode?: string | null
+        search?: string
+    }
+): DiagnosticQuestionResponse[] {
+    let result = questions
+    if (setId === NO_SET) {
+        result = result.filter((q) => (membership.get(q.id)?.length ?? 0) === 0)
+    } else if (setId) {
+        result = result.filter((q) =>
+            (membership.get(q.id) ?? []).some((s) => s.id === setId)
+        )
+    }
+    // Reuse the picker's status/topic/search predicate, so the two places
+    // that filter questions stay consistent.
+    return filterQuestions(result, { status, topicCode, search })
+}

--- a/src/pages/Admin/Diagnostic/DiagnosticQuestionsListPage.test.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticQuestionsListPage.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { DiagnosticQuestionsListPage } from './DiagnosticQuestionsListPage'
+import type { DiagnosticQuestionResponse, DiagnosticSetResponse } from '@/client'
+
+const mockQuestions = vi.fn()
+const mockSets = vi.fn()
+
+vi.mock('@/hooks/diagnostic/useListDiagnosticQuestionsQuery.ts', () => ({
+    default: () => mockQuestions(),
+}))
+vi.mock('@/hooks/diagnostic/useListDiagnosticSetsQuery.ts', () => ({
+    default: () => mockSets(),
+}))
+vi.mock('@/hooks/diagnostic/useDeleteDiagnosticQuestionMutation.ts', () => ({
+    default: () => ({ mutate: vi.fn() }),
+}))
+vi.mock('@/components/diagnostic/BulkImportDialog.tsx', () => ({
+    BulkImportDialog: () => null,
+}))
+vi.mock('@/components/layout/AdminLayout.tsx', () => ({
+    AdminLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+    return { ...actual, useNavigate: () => vi.fn() }
+})
+
+function q(over: Partial<DiagnosticQuestionResponse>): DiagnosticQuestionResponse {
+    return {
+        id: 'id',
+        topicCode: 'MM1.1',
+        coreSkillPrimary: 'S1',
+        stem: 'stem',
+        options: [{ label: 'A', text: 'x', isCorrect: true }],
+        correctOption: 'A',
+        status: 'published',
+        createdAt: '2026-07-13T00:00:00Z',
+        ...over,
+    }
+}
+function s(id: string, title: string, questionIds: string[]): DiagnosticSetResponse {
+    return {
+        id, title, description: null, timeLimitMinutes: 40, questionIds,
+        isFree: false, status: 'published', subject: null, createdAt: '2026-07-13T00:00:00Z',
+    }
+}
+
+const questions = [
+    q({ id: 'a', topicCode: 'MM1.1', stem: 'in physics only' }),
+    q({ id: 'b', topicCode: 'MM2.3', stem: 'in both sets', status: 'draft' }),
+    q({ id: 'c', topicCode: 'MM3.5', stem: 'orphan question' }),
+]
+const sets = [s('phys', 'Physics A', ['a', 'b']), s('math', 'Maths A', ['b'])]
+
+describe('DiagnosticQuestionsListPage', () => {
+    beforeEach(() => {
+        mockQuestions.mockReturnValue({ data: questions, isLoading: false })
+        mockSets.mockReturnValue({ data: sets })
+    })
+
+    // Rows are identified by topic code (the page shows topic/skill/sets/
+    // status, not the stem). Set membership is the reverse lookup.
+    it('shows each question’s set membership, and "—" for an orphan', () => {
+        render(<DiagnosticQuestionsListPage />)
+        const rowA = screen.getByRole('cell', { name: 'MM1.1' }).closest('tr')!
+        expect(within(rowA).getByText('Physics A')).toBeInTheDocument()
+        const rowB = screen.getByRole('cell', { name: 'MM2.3' }).closest('tr')!
+        expect(within(rowB).getByText('Physics A')).toBeInTheDocument()
+        expect(within(rowB).getByText('Maths A')).toBeInTheDocument()
+        const rowC = screen.getByRole('cell', { name: 'MM3.5' }).closest('tr')!
+        expect(within(rowC).getByText('—')).toBeInTheDocument()
+    })
+
+    it('shows a filtered count and narrows the rows as you search', () => {
+        render(<DiagnosticQuestionsListPage />)
+        expect(screen.getByText('3 of 3')).toBeInTheDocument()
+        // Search matches question c's stem "orphan question" -> just MM3.5.
+        fireEvent.change(screen.getByPlaceholderText(/search stem/i), {
+            target: { value: 'orphan' },
+        })
+        expect(screen.getByText('1 of 3')).toBeInTheDocument()
+        expect(screen.getByRole('cell', { name: 'MM3.5' })).toBeInTheDocument()
+        expect(screen.queryByRole('cell', { name: 'MM1.1' })).not.toBeInTheDocument()
+    })
+})

--- a/src/pages/Admin/Diagnostic/DiagnosticQuestionsListPage.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticQuestionsListPage.tsx
@@ -1,8 +1,17 @@
 import { useNavigate } from 'react-router-dom'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { AdminLayout } from '@/components/layout/AdminLayout.tsx'
 import { Button } from '@/components/ui/button.tsx'
 import { Badge } from '@/components/ui/badge.tsx'
+import { Input } from '@/components/ui/input.tsx'
+import { Combobox } from '@/components/ui/combobox.tsx'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select.tsx'
 import {
     Table,
     TableBody,
@@ -13,20 +22,51 @@ import {
 } from '@/components/ui/table.tsx'
 import { Plus, Upload } from 'lucide-react'
 import useListDiagnosticQuestionsQuery from '@/hooks/diagnostic/useListDiagnosticQuestionsQuery.ts'
+import useListDiagnosticSetsQuery from '@/hooks/diagnostic/useListDiagnosticSetsQuery.ts'
 import useDeleteDiagnosticQuestionMutation from '@/hooks/diagnostic/useDeleteDiagnosticQuestionMutation.ts'
 import { BulkImportDialog } from '@/components/diagnostic/BulkImportDialog.tsx'
+import {
+    NO_SET,
+    filterQuestionsForList,
+    setsByQuestionId,
+} from '@/lib/questionListFilters.ts'
 import { toast } from 'sonner'
+
+const ALL = '__all__'
 
 export function DiagnosticQuestionsListPage() {
     const navigate = useNavigate()
     const [bulkImportOpen, setBulkImportOpen] = useState(false)
     const { data: questions, isLoading } = useListDiagnosticQuestionsQuery()
+    const { data: sets } = useListDiagnosticSetsQuery()
     const { mutate: deleteQuestion } = useDeleteDiagnosticQuestionMutation()
+
+    const [setFilter, setSetFilter] = useState<string>(ALL)
+    const [statusFilter, setStatusFilter] = useState<'draft' | 'published' | typeof ALL>(ALL)
+    const [topicFilter, setTopicFilter] = useState<string | null>(null)
+    const [search, setSearch] = useState('')
+
+    const membership = useMemo(() => setsByQuestionId(sets ?? []), [sets])
+    const topicCodes = useMemo(
+        () => [...new Set((questions ?? []).map((q) => q.topicCode).filter(Boolean))].sort(),
+        [questions]
+    )
+
+    const filtered = useMemo(
+        () =>
+            filterQuestionsForList(questions ?? [], membership, {
+                setId: setFilter === ALL ? null : setFilter,
+                status: statusFilter === ALL ? null : statusFilter,
+                topicCode: topicFilter,
+                search,
+            }),
+        [questions, membership, setFilter, statusFilter, topicFilter, search]
+    )
 
     function handleDelete(id: string) {
         if (!confirm('Delete this question? This cannot be undone.')) return
         deleteQuestion(id, {
-            // Surface the backend's message — PR C's 409 names the sets that
+            // Surface the backend's message — the 409 names the sets that
             // still hold this question, so the admin knows to unlink it first.
             onError: (err) => toast.error(err.message),
             onSuccess: () => toast.success('Question deleted'),
@@ -37,14 +77,9 @@ export function DiagnosticQuestionsListPage() {
         <AdminLayout>
             <div className="mt-8 flex flex-col gap-4">
                 <div className="flex items-center justify-between">
-                    <h1 className="text-2xl font-semibold">
-                        Diagnostic Questions
-                    </h1>
+                    <h1 className="text-2xl font-semibold">Diagnostic Questions</h1>
                     <div className="flex gap-2">
-                        <Button
-                            variant="outline"
-                            onClick={() => setBulkImportOpen(true)}
-                        >
+                        <Button variant="outline" onClick={() => setBulkImportOpen(true)}>
                             <Upload className="w-4 h-4" /> Bulk import
                         </Button>
                         <Button onClick={() => navigate('/admin/questions/new')}>
@@ -53,11 +88,61 @@ export function DiagnosticQuestionsListPage() {
                     </div>
                 </div>
 
+                {/* Filters — keep a growing library navigable across many sets. */}
+                <div className="flex flex-wrap items-center gap-2">
+                    <Select value={setFilter} onValueChange={setSetFilter}>
+                        <SelectTrigger className="w-56">
+                            <SelectValue placeholder="All sets" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value={ALL}>All sets</SelectItem>
+                            <SelectItem value={NO_SET}>In no set</SelectItem>
+                            {(sets ?? []).map((s) => (
+                                <SelectItem key={s.id} value={s.id}>
+                                    {s.title}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                    <Select
+                        value={statusFilter}
+                        onValueChange={(v) => setStatusFilter(v as typeof statusFilter)}
+                    >
+                        <SelectTrigger className="w-36">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value={ALL}>All statuses</SelectItem>
+                            <SelectItem value="published">Published</SelectItem>
+                            <SelectItem value="draft">Draft</SelectItem>
+                        </SelectContent>
+                    </Select>
+                    <div className="w-44">
+                        <Combobox
+                            value={topicFilter}
+                            onChange={setTopicFilter}
+                            options={topicCodes}
+                            placeholder="All topics"
+                            clearLabel="All topics"
+                        />
+                    </div>
+                    <Input
+                        className="w-52 flex-1"
+                        placeholder="Search stem…"
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                    />
+                    <span className="text-sm text-gray-400">
+                        {filtered.length} of {questions?.length ?? 0}
+                    </span>
+                </div>
+
                 <Table>
                     <TableHeader>
                         <TableRow>
                             <TableHead>Topic</TableHead>
                             <TableHead>Skill</TableHead>
+                            <TableHead>Sets</TableHead>
                             <TableHead>Status</TableHead>
                             <TableHead>Options</TableHead>
                             <TableHead />
@@ -66,65 +151,87 @@ export function DiagnosticQuestionsListPage() {
                     <TableBody>
                         {isLoading && (
                             <TableRow>
-                                <TableCell colSpan={5}>Loading...</TableCell>
+                                <TableCell colSpan={6}>Loading...</TableCell>
                             </TableRow>
                         )}
-                        {!isLoading && questions?.length === 0 && (
+                        {!isLoading && (questions?.length ?? 0) === 0 && (
                             <TableRow>
-                                <TableCell colSpan={5} className="text-gray-500">
+                                <TableCell colSpan={6} className="text-gray-500">
                                     No diagnostic questions yet.
                                 </TableCell>
                             </TableRow>
                         )}
-                        {questions?.map((q) => (
-                            <TableRow key={q.id}>
-                                <TableCell>{q.topicCode}</TableCell>
-                                <TableCell>
-                                    {q.coreSkillPrimary}
-                                    {q.coreSkillSecondary
-                                        ? ` / ${q.coreSkillSecondary}`
-                                        : ''}
-                                </TableCell>
-                                <TableCell>
-                                    <Badge
-                                        variant={
-                                            q.status === 'published'
-                                                ? 'default'
-                                                : 'secondary'
-                                        }
-                                    >
-                                        {q.status}
-                                    </Badge>
-                                </TableCell>
-                                <TableCell>{q.options.length}</TableCell>
-                                <TableCell className="text-right space-x-2">
-                                    <Button
-                                        variant="outline"
-                                        size="sm"
-                                        onClick={() =>
-                                            navigate(`/admin/questions/${q.id}`)
-                                        }
-                                    >
-                                        Edit
-                                    </Button>
-                                    <Button
-                                        variant="destructive"
-                                        size="sm"
-                                        onClick={() => handleDelete(q.id)}
-                                    >
-                                        Delete
-                                    </Button>
-                                </TableCell>
-                            </TableRow>
-                        ))}
+                        {!isLoading &&
+                            (questions?.length ?? 0) > 0 &&
+                            filtered.length === 0 && (
+                                <TableRow>
+                                    <TableCell colSpan={6} className="text-gray-500">
+                                        No questions match these filters.
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                        {filtered.map((q) => {
+                            const inSets = membership.get(q.id) ?? []
+                            return (
+                                <TableRow key={q.id}>
+                                    <TableCell>{q.topicCode}</TableCell>
+                                    <TableCell>
+                                        {q.coreSkillPrimary}
+                                        {q.coreSkillSecondary
+                                            ? ` / ${q.coreSkillSecondary}`
+                                            : ''}
+                                    </TableCell>
+                                    <TableCell>
+                                        {inSets.length === 0 ? (
+                                            <span className="text-gray-300">—</span>
+                                        ) : (
+                                            <div className="flex flex-wrap gap-1">
+                                                {inSets.map((s) => (
+                                                    <Badge key={s.id} variant="outline">
+                                                        {s.title}
+                                                    </Badge>
+                                                ))}
+                                            </div>
+                                        )}
+                                    </TableCell>
+                                    <TableCell>
+                                        <Badge
+                                            variant={
+                                                q.status === 'published'
+                                                    ? 'default'
+                                                    : 'secondary'
+                                            }
+                                        >
+                                            {q.status}
+                                        </Badge>
+                                    </TableCell>
+                                    <TableCell>{q.options.length}</TableCell>
+                                    <TableCell className="text-right space-x-2">
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() =>
+                                                navigate(`/admin/questions/${q.id}`)
+                                            }
+                                        >
+                                            Edit
+                                        </Button>
+                                        <Button
+                                            variant="destructive"
+                                            size="sm"
+                                            onClick={() => handleDelete(q.id)}
+                                        >
+                                            Delete
+                                        </Button>
+                                    </TableCell>
+                                </TableRow>
+                            )
+                        })}
                     </TableBody>
                 </Table>
             </div>
 
-            <BulkImportDialog
-                open={bulkImportOpen}
-                onOpenChange={setBulkImportOpen}
-            />
+            <BulkImportDialog open={bulkImportOpen} onOpenChange={setBulkImportOpen} />
         </AdminLayout>
     )
 }


### PR DESCRIPTION
## What
The questions list (`/admin/questions`) was one flat table of every question from every set, with **no filters** — unmanageable as the library grows across Maths I / II / Physics. Adds a filter row and a **Sets** column.

- **Sets column** — which set(s) each question belongs to, or **"—"** for one in no set. A question has no set field (the *set* lists its questions, §3), so this is a **reverse lookup** built on the frontend from the sets list; a question can be in several sets or none.
- **Filters** — by **set** (with an **"In no set"** option to find orphans: just-authored questions to add somewhere, or unused ones to delete), by **status** and **topic**, and a **stem search**. Reuses the question picker's own filter predicate so the two places that filter questions stay consistent. A live **"N of M"** count.

## Tests — 200 green, tsc + lint clean
Pure logic (`setsByQuestionId` / `filterQuestionsForList`): the reverse lookup, the orphan filter, and combining the set filter with status/topic/search. Page test: the Sets column, the orphan "—", and the live count/search.

## Browser verification (real prod data — 125 questions across 3 sets, read-only)
Sets column showed correct membership; the **set filter narrowed to "27 of 125"** for ESAT Physics (Sets column showing only Physics); the search count updated live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)