### PR TITLE
Per-question student preview + multiselect bulk delete/preview (re-target to main)

### DIFF
--- a/src/components/diagnostic/QuestionPreviewDialog.test.tsx
+++ b/src/components/diagnostic/QuestionPreviewDialog.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { QuestionPreviewDialog } from './QuestionPreviewDialog'
+import type { DiagnosticQuestionResponse } from '@/client'
+
+vi.mock('@/components/diagnostic/LatexText.tsx', () => ({
+    LatexText: ({ text }: { text: string }) => <span>{text}</span>,
+}))
+
+function q(over: Partial<DiagnosticQuestionResponse>): DiagnosticQuestionResponse {
+    return {
+        id: 'id',
+        topicCode: 'P6.3',
+        coreSkillPrimary: 'S1',
+        stem: 'a stem',
+        options: [
+            { label: 'A', text: 'first option', isCorrect: true, misconception: 'the trap' },
+            { label: 'B', text: 'second option', isCorrect: false },
+        ],
+        correctOption: 'A',
+        status: 'draft',
+        createdAt: '2026-07-13T00:00:00Z',
+        ...over,
+    }
+}
+
+describe('QuestionPreviewDialog', () => {
+    it('shows the stem and options but NOT the answer key or misconception', () => {
+        render(
+            <QuestionPreviewDialog questions={[q({})]} open onOpenChange={vi.fn()} />
+        )
+        expect(screen.getByText('a stem')).toBeInTheDocument()
+        expect(screen.getByText('first option')).toBeInTheDocument()
+        expect(screen.getByText('second option')).toBeInTheDocument()
+        // The student view must not leak which option is correct, nor the
+        // misconception note.
+        expect(screen.queryByText(/correct/i)).not.toBeInTheDocument()
+        expect(screen.queryByText('the trap')).not.toBeInTheDocument()
+    })
+
+    it('steps through multiple questions with Previous/Next', () => {
+        const questions = [
+            q({ id: 'a', stem: 'question one' }),
+            q({ id: 'b', stem: 'question two' }),
+        ]
+        render(<QuestionPreviewDialog questions={questions} open onOpenChange={vi.fn()} />)
+
+        expect(screen.getByText('1 of 2')).toBeInTheDocument()
+        expect(screen.getByText('question one')).toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: /next/i }))
+        expect(screen.getByText('2 of 2')).toBeInTheDocument()
+        expect(screen.getByText('question two')).toBeInTheDocument()
+        // Next is disabled at the end.
+        expect(screen.getByRole('button', { name: /next/i })).toBeDisabled()
+    })
+
+    it('shows no navigation for a single question', () => {
+        render(<QuestionPreviewDialog questions={[q({})]} open onOpenChange={vi.fn()} />)
+        expect(screen.queryByRole('button', { name: /next/i })).not.toBeInTheDocument()
+        expect(screen.queryByText(/of 1/)).not.toBeInTheDocument()
+    })
+})

--- a/src/components/diagnostic/QuestionPreviewDialog.tsx
+++ b/src/components/diagnostic/QuestionPreviewDialog.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { Badge } from '@/components/ui/badge.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog.tsx'
+import { StudentQuestionPreview } from '@/components/diagnostic/StudentQuestionPreview.tsx'
+import type { DiagnosticQuestionResponse } from '@/client'
+
+type Props = {
+    /** One or more questions to preview. Prev/Next step through them (used
+     * both for a single-question preview and the bulk preview). */
+    questions: DiagnosticQuestionResponse[]
+    open: boolean
+    onOpenChange: (open: boolean) => void
+}
+
+export function QuestionPreviewDialog({ questions, open, onOpenChange }: Props) {
+    const [index, setIndex] = useState(0)
+
+    // Restart at the first question whenever a new preview is opened.
+    useEffect(() => {
+        if (open) setIndex(0)
+    }, [open])
+
+    if (questions.length === 0) return null
+    const clamped = Math.min(index, questions.length - 1)
+    const question = questions[clamped]
+    const many = questions.length > 1
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2">
+                        Student preview
+                        {many && (
+                            <span className="text-sm font-normal text-gray-500">
+                                {clamped + 1} of {questions.length}
+                            </span>
+                        )}
+                        {question.status === 'draft' && (
+                            <Badge variant="secondary">draft</Badge>
+                        )}
+                    </DialogTitle>
+                    <DialogDescription>
+                        {question.topicCode} · {question.coreSkillPrimary}
+                        {question.coreSkillSecondary
+                            ? ` / ${question.coreSkillSecondary}`
+                            : ''}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <StudentQuestionPreview question={question} />
+
+                {many && (
+                    <div className="flex items-center justify-between pt-2">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={clamped === 0}
+                            onClick={() => setIndex(clamped - 1)}
+                        >
+                            <ChevronLeft className="h-4 w-4" /> Previous
+                        </Button>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={clamped === questions.length - 1}
+                            onClick={() => setIndex(clamped + 1)}
+                        >
+                            Next <ChevronRight className="h-4 w-4" />
+                        </Button>
+                    </div>
+                )}
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/components/diagnostic/StudentQuestionPreview.tsx
+++ b/src/components/diagnostic/StudentQuestionPreview.tsx
@@ -1,0 +1,52 @@
+import { LatexText } from '@/components/diagnostic/LatexText.tsx'
+import type { DiagnosticQuestionResponse } from '@/client'
+
+type Props = {
+    question: DiagnosticQuestionResponse
+}
+
+/**
+ * One question exactly as a student sees it during the exam — stem, diagram,
+ * and options as selectable choices, with NO correct answer marked and NO
+ * misconception shown. Deliberately the sanitized view (unlike the admin
+ * review, which reveals the answer key): this is for checking what the
+ * student will actually be presented with.
+ *
+ * Mirrors the exam's QuestionPane layout (§9's one shared LatexText
+ * renderer), minus the interactivity — nothing is selectable here.
+ */
+export function StudentQuestionPreview({ question }: Props) {
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="text-lg leading-relaxed">
+                <LatexText text={question.stem} />
+            </div>
+
+            {question.diagramUrl && (
+                <div className="rounded-md border bg-gray-50 p-3">
+                    <img
+                        src={question.diagramUrl}
+                        alt="Question diagram"
+                        className="max-h-72"
+                    />
+                </div>
+            )}
+
+            <div className="flex flex-col gap-2">
+                {question.options.map((option) => (
+                    <div
+                        key={option.label}
+                        className="flex items-center gap-3 rounded-md border px-3 py-2"
+                    >
+                        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-sm font-medium">
+                            {option.label}
+                        </span>
+                        <span>
+                            <LatexText text={option.text} />
+                        </span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/src/pages/Admin/Diagnostic/DiagnosticQuestionsListPage.test.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticQuestionsListPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, within } from '@testing-library/react'
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react'
 import { DiagnosticQuestionsListPage } from './DiagnosticQuestionsListPage'
 import type { DiagnosticQuestionResponse, DiagnosticSetResponse } from '@/client'
 
@@ -12,8 +12,9 @@ vi.mock('@/hooks/diagnostic/useListDiagnosticQuestionsQuery.ts', () => ({
 vi.mock('@/hooks/diagnostic/useListDiagnosticSetsQuery.ts', () => ({
     default: () => mockSets(),
 }))
+const mockDeleteAsync = vi.fn().mockResolvedValue(undefined)
 vi.mock('@/hooks/diagnostic/useDeleteDiagnosticQuestionMutation.ts', () => ({
-    default: () => ({ mutate: vi.fn() }),
+    default: () => ({ mutate: vi.fn(), mutateAsync: mockDeleteAsync }),
 }))
 vi.mock('@/components/diagnostic/BulkImportDialog.tsx', () => ({
     BulkImportDialog: () => null,
@@ -58,7 +59,16 @@ describe('DiagnosticQuestionsListPage', () => {
     beforeEach(() => {
         mockQuestions.mockReturnValue({ data: questions, isLoading: false })
         mockSets.mockReturnValue({ data: sets })
+        mockDeleteAsync.mockClear()
     })
+
+    function selectRow(topic: string) {
+        const row = screen.getByRole('cell', { name: topic }).closest('tr')!
+        fireEvent.click(within(row).getByRole('checkbox'))
+    }
+    function bulkBar() {
+        return screen.getByText(/\d+ selected/).closest('div')!
+    }
 
     // Rows are identified by topic code (the page shows topic/skill/sets/
     // status, not the stem). Set membership is the reverse lookup.
@@ -71,6 +81,51 @@ describe('DiagnosticQuestionsListPage', () => {
         expect(within(rowB).getByText('Maths A')).toBeInTheDocument()
         const rowC = screen.getByRole('cell', { name: 'MM3.5' }).closest('tr')!
         expect(within(rowC).getByText('—')).toBeInTheDocument()
+    })
+
+    it('bulk-previews the selected questions with navigation', () => {
+        render(<DiagnosticQuestionsListPage />)
+        selectRow('MM1.1') // a
+        selectRow('MM2.3') // b
+        fireEvent.click(within(bulkBar()).getByRole('button', { name: 'Preview' }))
+        const dialog = screen.getByRole('dialog')
+        expect(within(dialog).getByText('Student preview')).toBeInTheDocument()
+        expect(within(dialog).getByText('1 of 2')).toBeInTheDocument()
+    })
+
+    it('bulk-deletes only the selected questions that are in no set', async () => {
+        vi.stubGlobal('confirm', vi.fn(() => true))
+        render(<DiagnosticQuestionsListPage />)
+        selectRow('MM1.1') // a — in Physics A (blocked)
+        selectRow('MM3.5') // c — in no set (deletable)
+        expect(screen.getByText('2 selected')).toBeInTheDocument()
+
+        fireEvent.click(within(bulkBar()).getByRole('button', { name: 'Delete' }))
+        // Only the orphan c is deleted; a is skipped (it's in a set).
+        await waitFor(() => expect(mockDeleteAsync).toHaveBeenCalledTimes(1))
+        expect(mockDeleteAsync).toHaveBeenCalledWith('c')
+        vi.unstubAllGlobals()
+    })
+
+    it('bulk delete refuses when every selected question is in a set', () => {
+        vi.stubGlobal('confirm', vi.fn(() => true))
+        render(<DiagnosticQuestionsListPage />)
+        selectRow('MM1.1') // a — Physics
+        selectRow('MM2.3') // b — both sets
+        fireEvent.click(within(bulkBar()).getByRole('button', { name: 'Delete' }))
+        expect(mockDeleteAsync).not.toHaveBeenCalled()
+        vi.unstubAllGlobals()
+    })
+
+    it('opens a student preview of a question from its Preview button', () => {
+        render(<DiagnosticQuestionsListPage />)
+        const rowA = screen.getByRole('cell', { name: 'MM1.1' }).closest('tr')!
+        fireEvent.click(within(rowA).getByRole('button', { name: 'Preview' }))
+        const dialog = screen.getByRole('dialog')
+        expect(within(dialog).getByText('Student preview')).toBeInTheDocument()
+        // Its stem is shown (LatexText is not mocked here, so the raw text
+        // appears in the DOM).
+        expect(within(dialog).getByText('in physics only')).toBeInTheDocument()
     })
 
     it('shows a filtered count and narrows the rows as you search', () => {

--- a/src/pages/Admin/Diagnostic/DiagnosticQuestionsListPage.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticQuestionsListPage.tsx
@@ -4,6 +4,7 @@ import { AdminLayout } from '@/components/layout/AdminLayout.tsx'
 import { Button } from '@/components/ui/button.tsx'
 import { Badge } from '@/components/ui/badge.tsx'
 import { Input } from '@/components/ui/input.tsx'
+import { Checkbox } from '@/components/ui/checkbox.tsx'
 import { Combobox } from '@/components/ui/combobox.tsx'
 import {
     Select,
@@ -25,6 +26,8 @@ import useListDiagnosticQuestionsQuery from '@/hooks/diagnostic/useListDiagnosti
 import useListDiagnosticSetsQuery from '@/hooks/diagnostic/useListDiagnosticSetsQuery.ts'
 import useDeleteDiagnosticQuestionMutation from '@/hooks/diagnostic/useDeleteDiagnosticQuestionMutation.ts'
 import { BulkImportDialog } from '@/components/diagnostic/BulkImportDialog.tsx'
+import { QuestionPreviewDialog } from '@/components/diagnostic/QuestionPreviewDialog.tsx'
+import type { DiagnosticQuestionResponse } from '@/client'
 import {
     NO_SET,
     filterQuestionsForList,
@@ -37,14 +40,19 @@ const ALL = '__all__'
 export function DiagnosticQuestionsListPage() {
     const navigate = useNavigate()
     const [bulkImportOpen, setBulkImportOpen] = useState(false)
+    // null = closed; a non-empty array previews those questions (one row's
+    // Preview passes [q]; the bulk preview will pass the selection).
+    const [previewing, setPreviewing] = useState<DiagnosticQuestionResponse[] | null>(null)
     const { data: questions, isLoading } = useListDiagnosticQuestionsQuery()
     const { data: sets } = useListDiagnosticSetsQuery()
-    const { mutate: deleteQuestion } = useDeleteDiagnosticQuestionMutation()
+    const { mutate: deleteQuestion, mutateAsync: deleteQuestionAsync } =
+        useDeleteDiagnosticQuestionMutation()
 
     const [setFilter, setSetFilter] = useState<string>(ALL)
     const [statusFilter, setStatusFilter] = useState<'draft' | 'published' | typeof ALL>(ALL)
     const [topicFilter, setTopicFilter] = useState<string | null>(null)
     const [search, setSearch] = useState('')
+    const [selected, setSelected] = useState<Set<string>>(new Set())
 
     const membership = useMemo(() => setsByQuestionId(sets ?? []), [sets])
     const topicCodes = useMemo(
@@ -71,6 +79,61 @@ export function DiagnosticQuestionsListPage() {
             onError: (err) => toast.error(err.message),
             onSuccess: () => toast.success('Question deleted'),
         })
+    }
+
+    const selectedQuestions = (questions ?? []).filter((q) => selected.has(q.id))
+    const allFilteredSelected =
+        filtered.length > 0 && filtered.every((q) => selected.has(q.id))
+
+    function toggleOne(id: string, on: boolean) {
+        setSelected((prev) => {
+            const next = new Set(prev)
+            if (on) next.add(id)
+            else next.delete(id)
+            return next
+        })
+    }
+    function toggleAllFiltered(on: boolean) {
+        setSelected((prev) => {
+            const next = new Set(prev)
+            for (const q of filtered) {
+                if (on) next.add(q.id)
+                else next.delete(q.id)
+            }
+            return next
+        })
+    }
+
+    async function handleBulkDelete() {
+        const ids = [...selected]
+        // Only questions in no set can be deleted (the delete-protection 409s
+        // the rest). Split up front so we don't fire doomed requests, and tell
+        // the admin exactly what's being skipped.
+        const deletable = ids.filter((id) => (membership.get(id)?.length ?? 0) === 0)
+        const blocked = ids.length - deletable.length
+        if (deletable.length === 0) {
+            toast.error(
+                `All ${blocked} selected question${blocked === 1 ? '' : 's'} ` +
+                    `belong to a set — remove them from their sets first.`
+            )
+            return
+        }
+        const suffix =
+            blocked > 0
+                ? ` (${blocked} in a set will be skipped)`
+                : ' This cannot be undone.'
+        if (!confirm(`Delete ${deletable.length} question(s)?${suffix}`)) return
+
+        const results = await Promise.allSettled(
+            deletable.map((id) => deleteQuestionAsync(id))
+        )
+        const ok = results.filter((r) => r.status === 'fulfilled').length
+        const failed = results.length - ok
+        toast.success(
+            `Deleted ${ok} question${ok === 1 ? '' : 's'}` +
+                (failed > 0 ? `, ${failed} failed` : '')
+        )
+        setSelected(new Set())
     }
 
     return (
@@ -137,9 +200,44 @@ export function DiagnosticQuestionsListPage() {
                     </span>
                 </div>
 
+                {selected.size > 0 && (
+                    <div className="flex items-center gap-3 rounded-md border bg-gray-50 px-3 py-2 text-sm">
+                        <span className="font-medium">{selected.size} selected</span>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setPreviewing(selectedQuestions)}
+                        >
+                            Preview
+                        </Button>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="text-red-600 hover:text-red-700"
+                            onClick={handleBulkDelete}
+                        >
+                            Delete
+                        </Button>
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setSelected(new Set())}
+                        >
+                            Clear
+                        </Button>
+                    </div>
+                )}
+
                 <Table>
                     <TableHeader>
                         <TableRow>
+                            <TableHead className="w-8">
+                                <Checkbox
+                                    aria-label="Select all"
+                                    checked={allFilteredSelected}
+                                    onCheckedChange={(v) => toggleAllFiltered(v === true)}
+                                />
+                            </TableHead>
                             <TableHead>Topic</TableHead>
                             <TableHead>Skill</TableHead>
                             <TableHead>Sets</TableHead>
@@ -151,12 +249,12 @@ export function DiagnosticQuestionsListPage() {
                     <TableBody>
                         {isLoading && (
                             <TableRow>
-                                <TableCell colSpan={6}>Loading...</TableCell>
+                                <TableCell colSpan={7}>Loading...</TableCell>
                             </TableRow>
                         )}
                         {!isLoading && (questions?.length ?? 0) === 0 && (
                             <TableRow>
-                                <TableCell colSpan={6} className="text-gray-500">
+                                <TableCell colSpan={7} className="text-gray-500">
                                     No diagnostic questions yet.
                                 </TableCell>
                             </TableRow>
@@ -165,7 +263,7 @@ export function DiagnosticQuestionsListPage() {
                             (questions?.length ?? 0) > 0 &&
                             filtered.length === 0 && (
                                 <TableRow>
-                                    <TableCell colSpan={6} className="text-gray-500">
+                                    <TableCell colSpan={7} className="text-gray-500">
                                         No questions match these filters.
                                     </TableCell>
                                 </TableRow>
@@ -174,6 +272,15 @@ export function DiagnosticQuestionsListPage() {
                             const inSets = membership.get(q.id) ?? []
                             return (
                                 <TableRow key={q.id}>
+                                    <TableCell>
+                                        <Checkbox
+                                            aria-label={`Select ${q.topicCode}`}
+                                            checked={selected.has(q.id)}
+                                            onCheckedChange={(v) =>
+                                                toggleOne(q.id, v === true)
+                                            }
+                                        />
+                                    </TableCell>
                                     <TableCell>{q.topicCode}</TableCell>
                                     <TableCell>
                                         {q.coreSkillPrimary}
@@ -210,6 +317,13 @@ export function DiagnosticQuestionsListPage() {
                                         <Button
                                             variant="outline"
                                             size="sm"
+                                            onClick={() => setPreviewing([q])}
+                                        >
+                                            Preview
+                                        </Button>
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
                                             onClick={() =>
                                                 navigate(`/admin/questions/${q.id}`)
                                             }
@@ -232,6 +346,12 @@ export function DiagnosticQuestionsListPage() {
             </div>
 
             <BulkImportDialog open={bulkImportOpen} onOpenChange={setBulkImportOpen} />
+
+            <QuestionPreviewDialog
+                questions={previewing ?? []}
+                open={previewing !== null}
+                onOpenChange={(open) => !open && setPreviewing(null)}
+            />
         </AdminLayout>
     )
 }


### PR DESCRIPTION
Re-targets #24 to `main`. #24 was auto-created against the filters branch (#23) as a stack; when #23 merged first, the auto-retarget didn't land, so #24 merged into the (already-merged) filters branch and its changes never reached `main`. This PR carries exactly the one A+B commit (`747ca6d`) — the filters are already in main via #23, so the diff is only the preview + multiselect work.

Same content as #24 (already reviewed): per-question student preview (sanitized, no answer key), and multiselect bulk delete/preview on the questions list. 207 tests green; browser-verified against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)