### PR TITLE
Add a Subjects management screen (rename / delete across sets)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { DiagnosticSetsListPage } from '@/pages/Admin/Diagnostic/DiagnosticSetsL
 import { DiagnosticSetCreatePage } from '@/pages/Admin/Diagnostic/DiagnosticSetCreatePage.tsx'
 import { DiagnosticSetQuestionsPage } from '@/pages/Admin/Diagnostic/DiagnosticSetQuestionsPage.tsx'
 import { DiagnosticSetReviewPage } from '@/pages/Admin/Diagnostic/DiagnosticSetReviewPage.tsx'
+import { DiagnosticSubjectsPage } from '@/pages/Admin/Diagnostic/DiagnosticSubjectsPage.tsx'
 import { DiagnosticQuestionCreatePage } from '@/pages/Admin/Diagnostic/DiagnosticQuestionCreatePage.tsx'
 import { DiagnosticQuestionEditPage } from '@/pages/Admin/Diagnostic/DiagnosticQuestionEditPage.tsx'
 import { SetInstructionsPage } from '@/pages/Diagnostic/SetInstructionsPage.tsx'
@@ -125,6 +126,7 @@ function App() {
                         element={<DiagnosticQuestionEditPage />}
                     />
                     <Route path="admin/sets" element={<DiagnosticSetsListPage />} />
+                    <Route path="admin/subjects" element={<DiagnosticSubjectsPage />} />
                     <Route path="admin/sets/new" element={<DiagnosticSetCreatePage />} />
                     <Route
                         path="admin/sets/:setId/questions"

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
 
 import {
     FlaskConical,
+    FolderTree,
     Inbox,
     Layers,
     LucideCodesandbox,
@@ -52,6 +53,11 @@ const ITEMS = [
         title: 'Diagnostic Sets',
         url: '/admin/sets',
         icon: Layers,
+    },
+    {
+        title: 'Subjects',
+        url: '/admin/subjects',
+        icon: FolderTree,
     },
 ]
 

--- a/src/hooks/diagnostic/useReassignSubjectMutation.ts
+++ b/src/hooks/diagnostic/useReassignSubjectMutation.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { updateDiagnosticSetDiagnosticSetsSetIdPatch } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
+import { toDiagnosticApiError } from '@/lib/diagnosticApiError.ts'
+
+/**
+ * Rename or delete a subject across every set that uses it.
+ *
+ * A subject isn't a stored entity — it's a free-text label on each set — so
+ * "rename subject X to Y" (or "delete subject X") is really "set subject = Y
+ * (or null) on all the sets currently tagged X". This applies that as one
+ * batch over the existing per-set update endpoint (no dedicated subjects
+ * table), reporting how many succeeded.
+ *
+ * subject: null uncategorises the sets — i.e. deletes the subject label.
+ */
+export default function useReassignSubjectMutation() {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: async ({
+            setIds,
+            subject,
+        }: {
+            setIds: string[]
+            subject: string | null
+        }) => {
+            const results = await Promise.allSettled(
+                setIds.map(async (setId) => {
+                    const result = await updateDiagnosticSetDiagnosticSetsSetIdPatch({
+                        path: { set_id: setId },
+                        body: { subject },
+                        headers: getAuthHeaders(),
+                    })
+                    if (result.error !== undefined) {
+                        throw toDiagnosticApiError(result, 'Failed to update set')
+                    }
+                    return result.data
+                })
+            )
+            const ok = results.filter((r) => r.status === 'fulfilled').length
+            return { ok, failed: results.length - ok }
+        },
+        onSuccess: () =>
+            queryClient.invalidateQueries({ queryKey: ['diagnostic-sets'] }),
+    })
+}

--- a/src/lib/diagnosticSubjectsAdmin.test.ts
+++ b/src/lib/diagnosticSubjectsAdmin.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { subjectsInUse } from './diagnosticSubjectsAdmin'
+import type { DiagnosticSetResponse } from '@/client'
+
+function s(id: string, title: string, subject: string | null): DiagnosticSetResponse {
+    return {
+        id, title, description: null, timeLimitMinutes: 40, questionIds: [],
+        isFree: false, status: 'draft', subject, createdAt: '2026-07-13T00:00:00Z',
+    }
+}
+
+describe('subjectsInUse', () => {
+    it('groups sets by their subject, sorted, with ids and titles', () => {
+        const groups = subjectsInUse([
+            s('1', 'Physics A', 'ESAT Physics'),
+            s('2', 'Maths A', 'ESAT Maths I'),
+            s('3', 'Physics B', 'ESAT Physics'),
+        ])
+        expect(groups.map((g) => g.subject)).toEqual(['ESAT Maths I', 'ESAT Physics'])
+        const physics = groups.find((g) => g.subject === 'ESAT Physics')!
+        expect(physics.setIds).toEqual(['1', '3'])
+        expect(physics.setTitles).toEqual(['Physics A', 'Physics B'])
+    })
+
+    it('excludes uncategorised (null-subject) sets', () => {
+        const groups = subjectsInUse([s('1', 'A', null), s('2', 'B', 'ESAT Physics')])
+        expect(groups.map((g) => g.subject)).toEqual(['ESAT Physics'])
+    })
+
+    it('surfaces drift as distinct subjects (so it can be fixed)', () => {
+        // "Maths 1" and "Maths I" are different labels -> two rows to reconcile.
+        const groups = subjectsInUse([s('1', 'A', 'ESAT Maths 1'), s('2', 'B', 'ESAT Maths I')])
+        expect(groups.map((g) => g.subject)).toEqual(['ESAT Maths 1', 'ESAT Maths I'])
+    })
+})

--- a/src/lib/diagnosticSubjectsAdmin.ts
+++ b/src/lib/diagnosticSubjectsAdmin.ts
@@ -1,0 +1,30 @@
+import type { DiagnosticSetResponse } from '@/client'
+
+export type SubjectGroup = {
+    subject: string
+    setIds: string[]
+    setTitles: string[]
+}
+
+/**
+ * The subjects actually in use, derived from the sets tagged with them —
+ * since a subject is only a free-text label on sets, not a stored entity.
+ * Uncategorised sets (null subject) are excluded; a subject appears only if
+ * at least one set carries it. Sorted by name for a stable roster.
+ */
+export function subjectsInUse(sets: DiagnosticSetResponse[]): SubjectGroup[] {
+    const bySubject = new Map<string, DiagnosticSetResponse[]>()
+    for (const set of sets) {
+        if (!set.subject) continue
+        const list = bySubject.get(set.subject)
+        if (list) list.push(set)
+        else bySubject.set(set.subject, [set])
+    }
+    return [...bySubject.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([subject, subjectSets]) => ({
+            subject,
+            setIds: subjectSets.map((s) => s.id),
+            setTitles: subjectSets.map((s) => s.title),
+        }))
+}

--- a/src/pages/Admin/Diagnostic/DiagnosticSubjectsPage.test.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticSubjectsPage.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { DiagnosticSubjectsPage } from './DiagnosticSubjectsPage'
+import type { DiagnosticSetResponse } from '@/client'
+
+const mockSets = vi.fn()
+const mockReassign = vi.fn()
+
+vi.mock('@/hooks/diagnostic/useListDiagnosticSetsQuery.ts', () => ({
+    default: () => mockSets(),
+}))
+vi.mock('@/hooks/diagnostic/useReassignSubjectMutation.ts', () => ({
+    default: () => ({ mutate: mockReassign, isPending: false }),
+}))
+vi.mock('@/components/layout/AdminLayout.tsx', () => ({
+    AdminLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+function s(id: string, title: string, subject: string | null): DiagnosticSetResponse {
+    return {
+        id, title, description: null, timeLimitMinutes: 40, questionIds: [],
+        isFree: false, status: 'draft', subject, createdAt: '2026-07-13T00:00:00Z',
+    }
+}
+
+const sets = [
+    s('m1', 'Maths 1 Set A', 'ESAT Maths 1'),
+    s('p1', 'Physics Set A', 'ESAT Physics'),
+    s('p2', 'Physics Set B', 'ESAT Physics'),
+]
+
+describe('DiagnosticSubjectsPage', () => {
+    beforeEach(() => {
+        mockSets.mockReturnValue({ data: sets, isLoading: false })
+        mockReassign.mockReset()
+    })
+
+    it('lists the subjects in use with their sets', () => {
+        render(<DiagnosticSubjectsPage />)
+        const maths = screen.getByText('ESAT Maths 1').closest('tr')!
+        expect(within(maths).getByText('Maths 1 Set A')).toBeInTheDocument()
+        const physics = screen.getByText('ESAT Physics').closest('tr')!
+        expect(within(physics).getByText('Physics Set A')).toBeInTheDocument()
+        expect(within(physics).getByText('Physics Set B')).toBeInTheDocument()
+    })
+
+    it('renames a subject across all its sets', () => {
+        render(<DiagnosticSubjectsPage />)
+        const row = screen.getByText('ESAT Maths 1').closest('tr')!
+        fireEvent.click(within(row).getByRole('button', { name: 'Rename' }))
+        const input = within(row).getByRole('textbox')
+        fireEvent.change(input, { target: { value: 'ESAT Maths I' } })
+        fireEvent.click(within(row).getByRole('button', { name: 'Save' }))
+        expect(mockReassign.mock.calls[0][0]).toEqual({
+            setIds: ['m1'],
+            subject: 'ESAT Maths I',
+        })
+    })
+
+    it('deletes a subject by uncategorising its sets (subject: null)', () => {
+        vi.stubGlobal('confirm', vi.fn(() => true))
+        render(<DiagnosticSubjectsPage />)
+        const row = screen.getByText('ESAT Physics').closest('tr')!
+        fireEvent.click(within(row).getByRole('button', { name: 'Delete' }))
+        expect(mockReassign.mock.calls[0][0]).toEqual({
+            setIds: ['p1', 'p2'],
+            subject: null,
+        })
+        vi.unstubAllGlobals()
+    })
+
+    it('does not delete when the confirm is declined', () => {
+        vi.stubGlobal('confirm', vi.fn(() => false))
+        render(<DiagnosticSubjectsPage />)
+        const row = screen.getByText('ESAT Physics').closest('tr')!
+        fireEvent.click(within(row).getByRole('button', { name: 'Delete' }))
+        expect(mockReassign).not.toHaveBeenCalled()
+        vi.unstubAllGlobals()
+    })
+})

--- a/src/pages/Admin/Diagnostic/DiagnosticSubjectsPage.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticSubjectsPage.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { AdminLayout } from '@/components/layout/AdminLayout.tsx'
+import { Badge } from '@/components/ui/badge.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { Input } from '@/components/ui/input.tsx'
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table.tsx'
+import useListDiagnosticSetsQuery from '@/hooks/diagnostic/useListDiagnosticSetsQuery.ts'
+import useReassignSubjectMutation from '@/hooks/diagnostic/useReassignSubjectMutation.ts'
+import { subjectsInUse, type SubjectGroup } from '@/lib/diagnosticSubjectsAdmin.ts'
+
+/**
+ * Manage the subjects a diagnostic set can belong to. Subjects are free-text
+ * labels on sets (not a stored entity), so this lists the ones in use and
+ * lets an admin rename one across all its sets — the fix for drift like
+ * "ESAT Maths 1" vs "ESAT Maths I" — or delete one (its sets fall back to
+ * uncategorised). Both apply as a batch over the affected sets.
+ */
+export function DiagnosticSubjectsPage() {
+    const { data: sets, isLoading } = useListDiagnosticSetsQuery()
+    const { mutate: reassign, isPending } = useReassignSubjectMutation()
+
+    const [editing, setEditing] = useState<string | null>(null)
+    const [draft, setDraft] = useState('')
+
+    const groups = subjectsInUse(sets ?? [])
+
+    function startRename(group: SubjectGroup) {
+        setEditing(group.subject)
+        setDraft(group.subject)
+    }
+
+    function saveRename(group: SubjectGroup) {
+        const to = draft.trim()
+        if (to === '' || to === group.subject) {
+            setEditing(null)
+            return
+        }
+        reassign(
+            { setIds: group.setIds, subject: to },
+            {
+                onSuccess: ({ ok, failed }) => {
+                    setEditing(null)
+                    toast.success(
+                        `Renamed to “${to}” across ${ok} set${ok === 1 ? '' : 's'}` +
+                            (failed > 0 ? `, ${failed} failed` : '')
+                    )
+                },
+                onError: (err) => toast.error(err.message),
+            }
+        )
+    }
+
+    function handleDelete(group: SubjectGroup) {
+        const n = group.setIds.length
+        if (
+            !confirm(
+                `Delete the subject “${group.subject}”? Its ${n} set${
+                    n === 1 ? '' : 's'
+                } will become uncategorised (the sets themselves aren’t deleted).`
+            )
+        ) {
+            return
+        }
+        reassign(
+            { setIds: group.setIds, subject: null },
+            {
+                onSuccess: ({ ok, failed }) =>
+                    toast.success(
+                        `Uncategorised ${ok} set${ok === 1 ? '' : 's'}` +
+                            (failed > 0 ? `, ${failed} failed` : '')
+                    ),
+                onError: (err) => toast.error(err.message),
+            }
+        )
+    }
+
+    return (
+        <AdminLayout>
+            <div className="mt-8 flex flex-col gap-4">
+                <div>
+                    <h1 className="text-2xl font-semibold">Subjects</h1>
+                    <p className="text-sm text-gray-500">
+                        Renaming a subject updates every set tagged with it.
+                    </p>
+                </div>
+
+                {isLoading && <p className="text-gray-500">Loading…</p>}
+
+                {!isLoading && groups.length === 0 && (
+                    <p className="text-gray-500">
+                        No subjects in use yet — assign one to a set from the
+                        Diagnostic Sets screen.
+                    </p>
+                )}
+
+                {!isLoading && groups.length > 0 && (
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Subject</TableHead>
+                                <TableHead>Sets</TableHead>
+                                <TableHead />
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {groups.map((group) => (
+                                <TableRow key={group.subject}>
+                                    <TableCell className="font-medium">
+                                        {editing === group.subject ? (
+                                            <Input
+                                                autoFocus
+                                                value={draft}
+                                                onChange={(e) => setDraft(e.target.value)}
+                                                onKeyDown={(e) => {
+                                                    if (e.key === 'Enter') saveRename(group)
+                                                    if (e.key === 'Escape') setEditing(null)
+                                                }}
+                                                className="w-64"
+                                            />
+                                        ) : (
+                                            group.subject
+                                        )}
+                                    </TableCell>
+                                    <TableCell>
+                                        <div className="flex flex-wrap gap-1">
+                                            {group.setTitles.map((title, i) => (
+                                                <Badge key={group.setIds[i]} variant="outline">
+                                                    {title}
+                                                </Badge>
+                                            ))}
+                                        </div>
+                                    </TableCell>
+                                    <TableCell className="text-right space-x-2">
+                                        {editing === group.subject ? (
+                                            <>
+                                                <Button
+                                                    size="sm"
+                                                    disabled={isPending}
+                                                    onClick={() => saveRename(group)}
+                                                >
+                                                    Save
+                                                </Button>
+                                                <Button
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    onClick={() => setEditing(null)}
+                                                >
+                                                    Cancel
+                                                </Button>
+                                            </>
+                                        ) : (
+                                            <>
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    onClick={() => startRename(group)}
+                                                >
+                                                    Rename
+                                                </Button>
+                                                <Button
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    className="text-red-600 hover:text-red-700"
+                                                    onClick={() => handleDelete(group)}
+                                                >
+                                                    Delete
+                                                </Button>
+                                            </>
+                                        )}
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                )}
+            </div>
+        </AdminLayout>
+    )
+}


### PR DESCRIPTION
## What
Subjects are free-text labels on sets, not stored entities, so they **drift** — your live data already has `"ESAT Maths 1"`, `"ESAT Math 2"`, `"ESAT Physics"`, inconsistent with each other and the app's suggestions. A new **`/admin/subjects`** screen (sidebar entry) makes the roster manageable.

- **Lists the subjects in use**, derived from the sets tagged with them, each showing its sets. Drift appears as separate rows, so it's visible and fixable.
- **Rename** → applies the new name to every set tagged with it (the fix for the drift; also **merges** if you rename onto an existing subject).
- **Delete** → its sets fall back to **uncategorised** (`subject: null`); the sets themselves are untouched. Confirmed.

Both apply as a batch over the existing per-set update endpoint (`useReassignSubjectMutation`, where `subject: null` is the delete) — **no subjects table or backend change** — reusing the throw-on-error pattern to report success/failure counts.

## Tests — 214 green, tsc + lint clean
Pure `subjectsInUse` (grouping, excludes uncategorised, surfaces drift as distinct rows) and the page (rename cascades to the right set ids, delete sends `subject: null`, declined-confirm no-ops).

## Browser verification (real prod data — throwaway subject, cleaned up, real subjects untouched)
The page **surfaced your real drift** (`ESAT Math 2` vs `ESAT Maths 1`). Renaming a throwaway subject updated its set (persisted in the DB); deleting it uncategorised the set while leaving the set intact; your real subjects were untouched throughout.

*Note: I deliberately didn't rename your real subjects — which canonical form you want ("ESAT Maths I"? "ESAT Maths 1"?) is your call. This screen lets you do it in one click each.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)