### PR TITLE
Report: self-interpreting layer — full skill names, strengths/focus, next steps

### DIFF
--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -863,12 +863,17 @@ export type DiagnosticQuestionResponse = {
 
 /**
  * DiagnosticReportResponse
- * The post-exam report (§6): Skills Radar (always all seven skills),
- * the flagged-and-never-revisited question ids, and per-question timing.
- * Only available once the attempt is terminal (submitted/timed_out).
+ * The post-exam report (§6): Skills Radar (the skills this set actually
+ * assesses, in S1–S7 order), the flagged-and-never-revisited question ids,
+ * and per-question timing. Only available once the attempt is terminal
+ * (submitted/timed_out).
  */
 export type DiagnosticReportResponse = {
     attempt: DiagnosticAttemptResponse;
+    /**
+     * Subject
+     */
+    subject?: string | null;
     /**
      * Answeredcount
      */
@@ -1275,9 +1280,11 @@ export type SkillLabelsResponse = {
 
 /**
  * SkillScore
- * One Skills Radar axis. score is null when this paper tests nothing
- * tagged with the skill (Σweight == 0) — 'not assessed', distinct from a
- * genuine low score.
+ * One Skills Radar axis, on a primary-skill basis. score = correct /
+ * attempted over the questions whose *primary* skill is this one; it is
+ * null when attempted == 0 — 'not measured in this set', which the report
+ * must show distinctly from a real 0%. attempted/correct are integer counts
+ * so the report can show the denominator ('0 of 4') and flag small samples.
  */
 export type SkillScore = {
     /**
@@ -1288,6 +1295,14 @@ export type SkillScore = {
      * Score
      */
     score?: number | null;
+    /**
+     * Attempted
+     */
+    attempted?: number;
+    /**
+     * Correct
+     */
+    correct?: number;
     /**
      * Label
      */

--- a/src/components/diagnostic/report/SkillsRadar.test.tsx
+++ b/src/components/diagnostic/report/SkillsRadar.test.tsx
@@ -4,38 +4,57 @@ import { SkillsRadar } from './SkillsRadar'
 import type { SkillScore } from '@/client'
 
 function skills(scores: Array<number | null>): SkillScore[] {
-    return scores.map((score, i) => ({ skill: `S${i + 1}`, score }))
+    return scores.map((score, i) => ({
+        skill: `S${i + 1}`,
+        score,
+        attempted: score === null ? 0 : 3,
+        correct: score === null ? 0 : Math.round(score * 3),
+    }))
 }
 
 describe('SkillsRadar', () => {
-    it('exposes an accessible table that reflects null vs. real scores', () => {
-        // S1=2/3, S2=0 (assessed), S3–S7 null.
+    it('legend keeps not-measured distinct from a real 0%', () => {
+        // S1 scored, S2 assessed-0, S3 not measured.
         render(<SkillsRadar skills={skills([2 / 3, 0, null, null, null, null, null])} />)
         const table = screen.getByRole('table')
-        const rows = within(table).getAllByRole('row')
-        // header + 7 skill rows
-        expect(rows).toHaveLength(8)
+        // 7 skill rows, no column-header row.
+        expect(within(table).getAllByRole('row')).toHaveLength(7)
 
-        const s1 = within(table).getByRole('rowheader', { name: 'S1' }).closest('tr')!
-        expect(within(s1).getByRole('cell')).toHaveTextContent('67%')
-
-        // The regression this whole thread guards against: a null skill must
-        // read "Not assessed", NOT "0%".
         const s3 = within(table).getByRole('rowheader', { name: 'S3' }).closest('tr')!
-        expect(within(s3).getByRole('cell')).toHaveTextContent('Not assessed')
+        expect(within(s3).getByRole('cell')).toHaveTextContent('not assessed in this set')
         expect(within(s3).getByRole('cell')).not.toHaveTextContent('0%')
 
-        // And an assessed 0 is a real "0%", distinct from "Not assessed".
         const s2 = within(table).getByRole('rowheader', { name: 'S2' }).closest('tr')!
         expect(within(s2).getByRole('cell')).toHaveTextContent('0%')
-        expect(within(s2).getByRole('cell')).not.toHaveTextContent('Not assessed')
+        expect(within(s2).getByRole('cell')).not.toHaveTextContent('not assessed')
+    })
+
+    it('shows the percentage with its denominator', () => {
+        render(
+            <SkillsRadar skills={[{ skill: 'S1', score: 0.25, attempted: 4, correct: 1 }]} />
+        )
+        const row = screen.getByRole('rowheader', { name: 'S1' }).closest('tr')!
+        expect(within(row).getByRole('cell')).toHaveTextContent('25%')
+        expect(within(row).getByRole('cell')).toHaveTextContent('(1/4)')
+    })
+
+    it('decodes codes into full subject names when a subject is given', () => {
+        render(
+            <SkillsRadar
+                subject="ESAT Physics"
+                skills={[{ skill: 'S3', score: 0.5, attempted: 2, correct: 1 }]}
+            />
+        )
+        // Physics S3 = Proportional & Ratio Reasoning (not the Maths meaning).
+        expect(
+            screen.getByRole('rowheader', { name: /Proportional & Ratio Reasoning/ })
+        ).toBeInTheDocument()
     })
 
     it('draws a data dot only on assessed axes — never on a null one', () => {
         const { container } = render(
             <SkillsRadar skills={skills([0.5, null, 0.5, null, 0.5, null, 0.5])} />
         )
-        // 4 assessed -> 4 dots.
         expect(container.querySelectorAll('circle')).toHaveLength(4)
     })
 
@@ -43,23 +62,17 @@ describe('SkillsRadar', () => {
         const { container } = render(
             <SkillsRadar skills={skills([0, null, null, null, null, null, null])} />
         )
-        // The single assessed-0 skill still gets its dot.
         expect(container.querySelectorAll('circle')).toHaveLength(1)
     })
 
     it('draws no connecting edge that spans a null axis', () => {
-        // Assessed at 0,2,5 — none adjacent -> zero connecting segments, so
-        // no line can cross a null spoke. (Grid rings are <polygon>, spokes
-        // and any outline are <line>; assert the emerald outline lines.)
         const { container } = render(
             <SkillsRadar skills={skills([0.5, null, 0.5, null, null, 0.5, null])} />
         )
-        const outline = container.querySelectorAll('line.stroke-emerald-500')
-        expect(outline).toHaveLength(0)
+        expect(container.querySelectorAll('line.stroke-emerald-500')).toHaveLength(0)
     })
 
     it('connects adjacent assessed axes with an emerald outline', () => {
-        // All assessed -> 7 connecting edges (closed heptagon).
         const { container } = render(
             <SkillsRadar skills={skills([0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5])} />
         )
@@ -67,25 +80,9 @@ describe('SkillsRadar', () => {
     })
 
     it('hides the decorative SVG from assistive tech', () => {
-        const { container } = render(<SkillsRadar skills={skills([0.5, null, null, null, null, null, null])} />)
+        const { container } = render(
+            <SkillsRadar skills={skills([0.5, null, null, null, null, null, null])} />
+        )
         expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
-    })
-
-    it('shows the per-subject label where present, falling back to the code', () => {
-        const withLabels: SkillScore[] = [
-            { skill: 'S1', score: 0.5, label: 'Mechanics' },
-            { skill: 'S2', score: 0.5, label: null }, // no label -> bare code
-            { skill: 'S3', score: null, label: 'Waves' }, // labelled even if unassessed
-            { skill: 'S4', score: null, label: null },
-            { skill: 'S5', score: null, label: null },
-            { skill: 'S6', score: null, label: null },
-            { skill: 'S7', score: null, label: null },
-        ]
-        render(<SkillsRadar skills={withLabels} />)
-        const table = screen.getByRole('table')
-        // Labelled rows use the name as the row header; unlabelled keep the code.
-        expect(within(table).getByRole('rowheader', { name: 'Mechanics' })).toBeInTheDocument()
-        expect(within(table).getByRole('rowheader', { name: 'Waves' })).toBeInTheDocument()
-        expect(within(table).getByRole('rowheader', { name: 'S2' })).toBeInTheDocument()
     })
 })

--- a/src/components/diagnostic/report/SkillsRadar.tsx
+++ b/src/components/diagnostic/report/SkillsRadar.tsx
@@ -1,42 +1,40 @@
 import type { SkillScore } from '@/client'
 import { radarLayout } from '@/lib/skillsRadarGeometry.ts'
 import { skillPercent } from '@/lib/diagnosticReport.ts'
+import { skillName } from '@/lib/diagnosticSkillFrameworks.ts'
 
 type Props = {
     skills: SkillScore[]
+    /** The set's subject, used to decode S1–S7 into full names in the legend. */
+    subject?: string | null
     size?: number
 }
 
 /**
- * The Skills Radar (§6). A heptagon of the seven core skills, each axis
- * carrying a dot at its score — except a *not-assessed* axis (null score),
+ * The Skills Radar (§6). A polygon over the skills this set assesses, each axis
+ * carrying a dot at its score — except a *not-measured* axis (null score),
  * which gets no dot and a muted, dashed spoke, and the connecting outline
- * breaks around it (see radarSegments) so no edge implies a value where
- * there's no data. Assessed-but-zero still plots a real dot at the centre,
- * keeping the null-vs-zero distinction in the geometry, not just the label.
+ * breaks around it so no edge implies a value where there's no data.
+ * Assessed-but-zero still plots a real dot at the centre, keeping the
+ * not-measured-vs-0% distinction in the geometry, not just the label.
  *
- * The SVG is decorative (aria-hidden); the data reaches assistive tech
- * through the visually-hidden <table>, a real semantic element so
- * "present" and "usable" can't drift apart.
+ * The SVG (decorative, aria-hidden) keeps compact codes; the legend beneath it
+ * is the real semantic table — full subject names, the percentage with its
+ * denominator, and an explicit "not assessed in this set" for null axes.
  */
-export function SkillsRadar({ skills, size = 300 }: Props) {
+export function SkillsRadar({ skills, subject, size = 300 }: Props) {
     const { center, axes, rings, segments } = radarLayout(skills, { size, padding: 36 })
 
     const dotByIndex = (i: number) => axes[i].dot
-
-    // Extra horizontal room in the viewBox so the left/right axis labels
-    // (which extend outward from their spoke tips) aren't clipped, without
-    // shrinking the radar itself.
     const marginX = 52
 
     return (
-        <figure className="m-0 flex flex-col items-center">
+        <figure className="m-0 flex flex-col items-center gap-4">
             <svg
                 aria-hidden="true"
                 viewBox={`${-marginX} 0 ${size + marginX * 2} ${size}`}
                 className="w-full max-w-[22rem]"
             >
-                {/* grid rings */}
                 {rings.map((points, i) => (
                     <polygon
                         key={`ring-${i}`}
@@ -46,7 +44,6 @@ export function SkillsRadar({ skills, size = 300 }: Props) {
                     />
                 ))}
 
-                {/* spokes — dashed + muted for not-assessed axes */}
                 {axes.map((axis) => (
                     <line
                         key={`spoke-${axis.skill}`}
@@ -64,7 +61,6 @@ export function SkillsRadar({ skills, size = 300 }: Props) {
                     />
                 ))}
 
-                {/* connecting outline — only between adjacent assessed axes */}
                 {segments.map(([i, j]) => {
                     const a = dotByIndex(i)
                     const b = dotByIndex(j)
@@ -83,7 +79,6 @@ export function SkillsRadar({ skills, size = 300 }: Props) {
                     )
                 })}
 
-                {/* data dots — assessed axes only */}
                 {axes.map((axis) =>
                     axis.dot ? (
                         <circle
@@ -96,12 +91,9 @@ export function SkillsRadar({ skills, size = 300 }: Props) {
                     ) : null
                 )}
 
-                {/* axis labels: the per-subject skill name (falling back to
-                    the bare code when this subject has none) + percent, or a
-                    muted "n/a" */}
+                {/* axis labels stay compact — full names live in the legend */}
                 {axes.map((axis, i) => {
                     const percent = skillPercent(skills[i].score)
-                    const name = skills[i].label ?? axis.skill
                     return (
                         <text
                             key={`label-${axis.skill}`}
@@ -116,7 +108,7 @@ export function SkillsRadar({ skills, size = 300 }: Props) {
                             }
                             fontSize={11}
                         >
-                            <tspan fontWeight={600}>{name}</tspan>
+                            <tspan fontWeight={600}>{axis.skill}</tspan>
                             <tspan dx={4} fontSize={10}>
                                 {percent === null ? 'n/a' : `${percent}%`}
                             </tspan>
@@ -125,22 +117,39 @@ export function SkillsRadar({ skills, size = 300 }: Props) {
                 })}
             </svg>
 
-            {/* Accessible equivalent — the SVG carries no data to AT. */}
-            <table className="sr-only">
-                <caption>Skills radar — score per core skill</caption>
-                <thead>
-                    <tr>
-                        <th scope="col">Skill</th>
-                        <th scope="col">Score</th>
-                    </tr>
-                </thead>
+            {/* Legend — the semantic, sighted-and-AT-shared representation:
+                full name per code, percentage with denominator, and an explicit
+                not-measured note kept distinct from a real 0%. */}
+            <table className="w-full text-sm">
+                <caption className="sr-only">
+                    Skills radar — score per core skill
+                </caption>
                 <tbody>
                     {skills.map((s) => {
                         const percent = skillPercent(s.score)
+                        const notMeasured = percent === null
                         return (
-                            <tr key={s.skill}>
-                                <th scope="row">{s.label ?? s.skill}</th>
-                                <td>{percent === null ? 'Not assessed' : `${percent}%`}</td>
+                            <tr key={s.skill} className="border-t border-gray-100 dark:border-gray-800">
+                                <th scope="row" className="py-1.5 pr-3 text-left font-normal">
+                                    {skillName(subject, s.skill)}
+                                    {skillName(subject, s.skill) !== s.skill && (
+                                        <span className="text-gray-400"> ({s.skill})</span>
+                                    )}
+                                </th>
+                                <td className="py-1.5 text-right whitespace-nowrap">
+                                    {notMeasured ? (
+                                        <span className="text-gray-400 dark:text-gray-500">
+                                            not assessed in this set
+                                        </span>
+                                    ) : (
+                                        <>
+                                            <span className="font-medium">{percent}%</span>{' '}
+                                            <span className="text-gray-400">
+                                                ({s.correct ?? 0}/{s.attempted ?? 0})
+                                            </span>
+                                        </>
+                                    )}
+                                </td>
                             </tr>
                         )
                     })}

--- a/src/lib/diagnosticReportInsights.test.ts
+++ b/src/lib/diagnosticReportInsights.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { buildReportInsights } from './diagnosticReportInsights'
+import type { SkillScore } from '@/client'
+
+const SUBJECT = 'ESAT Math 2'
+
+function s(skill: string, correct: number, attempted: number): SkillScore {
+    return {
+        skill,
+        attempted,
+        correct,
+        score: attempted === 0 ? null : correct / attempted,
+    }
+}
+
+describe('buildReportInsights', () => {
+    it('excludes not-measured skills entirely (never as a strength or focus)', () => {
+        const skills = [s('S1', 5, 6), s('S3', 0, 0)] // S3 not measured
+        const { strengths, focusAreas } = buildReportInsights(skills, SUBJECT, 5, 6)
+        const all = [...strengths, ...focusAreas].map((i) => i.code)
+        expect(all).not.toContain('S3')
+    })
+
+    it('names strengths in full and requires a reliable, high score', () => {
+        const skills = [
+            s('S1', 5, 6), // 83%, reliable -> strength
+            s('S7', 2, 2), // 100% but only 2 questions -> NOT a confident strength
+        ]
+        const { strengths } = buildReportInsights(skills, SUBJECT, 7, 8)
+        expect(strengths.map((i) => i.code)).toEqual(['S1'])
+        expect(strengths[0].name).toBe('Algebraic Manipulation & Fluency')
+    })
+
+    it('lists focus areas lowest-first with denominator and limited-data flag', () => {
+        const skills = [
+            s('S1', 5, 6), // 83% -> strength, not focus
+            s('S3', 1, 4), // 25%
+            s('S5', 0, 1), // 0%, single question -> limited data
+        ]
+        const { focusAreas } = buildReportInsights(skills, SUBJECT, 6, 11)
+        expect(focusAreas.map((i) => i.code)).toEqual(['S5', 'S3']) // lowest first
+        const s5 = focusAreas[0]
+        expect(s5.pct).toBe(0)
+        expect(s5.attempted).toBe(1)
+        expect(s5.limitedData).toBe(true) // < 3 questions
+        expect(focusAreas[1].limitedData).toBe(false) // S3 had 4
+    })
+
+    it('keeps a genuine 0% (attempted>0) as a focus area, unlike n/a', () => {
+        const skills = [s('S2', 0, 3), s('S4', 0, 0)] // S2 real 0%, S4 not measured
+        const { focusAreas } = buildReportInsights(skills, SUBJECT, 0, 3)
+        expect(focusAreas.map((i) => i.code)).toEqual(['S2'])
+        expect(focusAreas[0].pct).toBe(0)
+    })
+
+    it('adapts the headline to the score, never bare numbers', () => {
+        expect(buildReportInsights([], SUBJECT, 0, 0).headline).toMatch(/didn't answer/i)
+        expect(buildReportInsights([s('S1', 9, 10)], SUBJECT, 9, 10).headline).toMatch(
+            /strong result/i
+        )
+        expect(buildReportInsights([s('S1', 5, 10)], SUBJECT, 5, 10).headline).toMatch(
+            /solid base/i
+        )
+    })
+})

--- a/src/lib/diagnosticReportInsights.ts
+++ b/src/lib/diagnosticReportInsights.ts
@@ -1,0 +1,89 @@
+import type { SkillScore } from '@/client'
+import { skillName } from '@/lib/diagnosticSkillFrameworks.ts'
+
+/** A measured skill, decoded for the written summary. */
+export type SkillInsight = {
+    code: string
+    name: string
+    pct: number // 0–100, rounded
+    attempted: number
+    correct: number
+    limitedData: boolean // fewer than RELIABLE_MIN questions — read with care
+}
+
+export type ReportInsights = {
+    headline: string
+    strengths: SkillInsight[]
+    focusAreas: SkillInsight[]
+}
+
+// Below this many primary questions, a skill's percentage is too noisy to
+// call a confident strength; focus areas still surface it but flagged.
+const RELIABLE_MIN = 3
+// A strength must clear this and be reliable; a focus area sits below it.
+const STRENGTH_PCT = 60
+const MAX_PER_LIST = 3
+
+/** A skill is "measured" when at least one of its primary questions was
+ * answered (score not null) — the not-measured axes are excluded entirely. */
+function measured(skills: SkillScore[]): SkillScore[] {
+    return skills.filter((s) => s.score !== null && s.score !== undefined)
+}
+
+function toInsight(subject: string | null | undefined, s: SkillScore): SkillInsight {
+    const attempted = s.attempted ?? 0
+    return {
+        code: s.skill,
+        name: skillName(subject, s.skill),
+        pct: Math.round((s.score ?? 0) * 100),
+        attempted,
+        correct: s.correct ?? 0,
+        limitedData: attempted < RELIABLE_MIN,
+    }
+}
+
+function headlineFor(totalScore: number, answeredCount: number): string {
+    if (answeredCount === 0) {
+        return "You didn't answer any questions this time — give it another go when you're ready and we'll map out your strengths."
+    }
+    const ratio = totalScore / answeredCount
+    if (ratio >= 0.7) {
+        return `You answered ${totalScore} of ${answeredCount} correct — a strong result. Here's where you shone and a couple of areas to push even further.`
+    }
+    if (ratio >= 0.4) {
+        return `You answered ${totalScore} of ${answeredCount} correct — a solid base to build on, with a few clear areas to focus on next.`
+    }
+    return `You answered ${totalScore} of ${answeredCount} correct — a starting point, and the focus areas below are where the quickest gains are.`
+}
+
+/**
+ * Turn the skills radar into a plain-English strengths/focus summary. Uses
+ * only *measured* skills (never n/a). Strengths are the highest-scoring
+ * reliable skills (≥ 60%, ≥ 3 questions); focus areas are the lowest-scoring
+ * measured skills (< 60%), carrying denominators so small samples read
+ * honestly. Both capped at three and decoded to full subject names.
+ */
+export function buildReportInsights(
+    skills: SkillScore[],
+    subject: string | null | undefined,
+    totalScore: number,
+    answeredCount: number
+): ReportInsights {
+    const insights = measured(skills).map((s) => toInsight(subject, s))
+
+    const strengths = insights
+        .filter((i) => i.pct >= STRENGTH_PCT && !i.limitedData)
+        .sort((a, b) => b.pct - a.pct)
+        .slice(0, MAX_PER_LIST)
+
+    const focusAreas = insights
+        .filter((i) => i.pct < STRENGTH_PCT)
+        .sort((a, b) => a.pct - b.pct)
+        .slice(0, MAX_PER_LIST)
+
+    return {
+        headline: headlineFor(totalScore, answeredCount),
+        strengths,
+        focusAreas,
+    }
+}

--- a/src/lib/diagnosticSkillAdvice.ts
+++ b/src/lib/diagnosticSkillAdvice.ts
@@ -1,0 +1,47 @@
+import { normalizeSubject } from '@/lib/diagnosticSkillFrameworks.ts'
+
+/**
+ * One concrete, encouraging next step per skill, keyed by subject + code.
+ * Static (topic-level names aren't stored yet, so we can't ground these in the
+ * exact questions missed), revision-oriented, and phrased for a student. Kept
+ * to a sentence or two. Falls back to a generic-but-warm line for anything we
+ * don't have specific advice for.
+ */
+const ADVICE: Record<string, Record<string, string>> = {
+    'esat math 1': {
+        S1: 'Drill rearranging and simplifying expressions until the steps feel automatic — indices, brackets, and fractions are the foundation everything else stands on.',
+        S2: 'Before diving in, pause to pick the shortest route: look for a substitution or a symmetry that avoids heavy algebra. Try timing a few problems to build that instinct.',
+        S3: 'Revisit coordinate geometry and graph sketching — practise reading gradients, intercepts, and transformations straight from a diagram.',
+        S4: 'Work through a few “show that” and proof-style questions, writing each logical step in full. The goal is a watertight chain of reasoning, not just the answer.',
+        S5: 'Practise ratio, percentage, and proportion problems mentally where you can — quick numerical fluency saves time and cuts slips.',
+        S7: 'Spend time on functions and sequences: domain and range, composing functions, and spotting the rule behind a pattern.',
+    },
+    'esat math 2': {
+        S1: 'Drill rearranging and simplifying expressions until the steps feel automatic — indices, brackets, and fractions underpin the calculus too.',
+        S2: 'Before diving in, pause to pick the shortest route: look for a substitution or a symmetry that avoids heavy algebra.',
+        S3: 'Revisit coordinate geometry and graph sketching — practise reading gradients, intercepts, and transformations straight from a diagram.',
+        S4: 'Work through a few proof-style questions, writing each logical step in full — a watertight chain of reasoning, not just the answer.',
+        S5: 'Practise ratio, percentage, and proportion problems mentally to build quick, slip-free numerical fluency.',
+        S6: 'Focus on differentiation and integration: what a derivative means as a rate of change, and the standard rules. Practise a mix of “find the gradient” and “find the area” questions.',
+        S7: 'Spend time on functions and sequences: domain and range, composing functions, and spotting the rule behind a pattern.',
+    },
+    'esat physics': {
+        S1: 'Go back to the core concepts and definitions — practise explaining what each quantity *means* in words before reaching for a formula.',
+        S2: 'Build a habit of choosing the right equation first: list what you know and what you need, then match the formula. Practise clean symbol-to-number substitution.',
+        S3: 'Drill proportional reasoning — “if this doubles, what happens to that?” Scaling and ratio questions reward spotting the relationship quickly.',
+        S4: 'Practise multi-step problems by breaking them into stages and writing each result down before the next. Chaining steps cleanly is the skill here.',
+        S5: 'Try unfamiliar, applied questions that put physics in a new context — the aim is transferring a principle you know to a situation you haven’t seen.',
+        S6: 'Practise tracking units through a calculation and using them to check answers — dimensional reasoning catches mistakes before they cost marks.',
+        S7: 'Work on reading graphs and data: gradients, areas under curves, and intercepts, and what each represents physically.',
+    },
+}
+
+const GENERIC =
+    'Pick a handful of questions on this skill and work through them slowly, checking each step — steady practice here will pay off quickly.'
+
+export function skillAdvice(
+    subject: string | null | undefined,
+    code: string
+): string {
+    return ADVICE[normalizeSubject(subject)]?.[code] ?? GENERIC
+}

--- a/src/lib/diagnosticSkillFrameworks.test.ts
+++ b/src/lib/diagnosticSkillFrameworks.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeSubject, frameworkFor, skillName } from './diagnosticSkillFrameworks'
+
+describe('normalizeSubject', () => {
+    it('folds Maths/Math drift and casing to one key', () => {
+        expect(normalizeSubject('ESAT Maths 2')).toBe('esat math 2')
+        expect(normalizeSubject('ESAT Math 2')).toBe('esat math 2')
+        expect(normalizeSubject('  esat   maths 1 ')).toBe('esat math 1')
+    })
+})
+
+describe('skillName', () => {
+    it('decodes the SAME code differently per subject', () => {
+        // The trap the brief calls out: Physics S3 ≠ Maths S3.
+        expect(skillName('ESAT Physics', 'S3')).toBe('Proportional & Ratio Reasoning')
+        expect(skillName('ESAT Math 2', 'S3')).toBe('Graphical & Geometric Reasoning')
+    })
+
+    it('resolves Maths 1 / Maths 2 / Physics via the drifted real names', () => {
+        expect(skillName('ESAT Maths 1', 'S1')).toBe('Algebraic Manipulation & Fluency')
+        expect(skillName('ESAT Math 2', 'S6')).toBe('Calculus & Rate of Change')
+        expect(skillName('ESAT Physics', 'S6')).toBe('Units & Dimensional Reasoning')
+    })
+
+    it('falls back to the bare code for an unknown subject or code', () => {
+        expect(skillName('Chemistry', 'S1')).toBe('S1')
+        expect(skillName(null, 'S1')).toBe('S1')
+        expect(skillName('ESAT Physics', 'S9')).toBe('S9')
+    })
+})
+
+describe('frameworkFor', () => {
+    it('gives Maths 1 no S6 (no calculus), but Maths 2 does', () => {
+        expect(frameworkFor('ESAT Maths 1')).not.toHaveProperty('S6')
+        expect(frameworkFor('ESAT Math 2')).toHaveProperty('S6')
+    })
+
+    it('is null for an unrecognised subject', () => {
+        expect(frameworkFor('Biology')).toBeNull()
+    })
+})

--- a/src/lib/diagnosticSkillFrameworks.ts
+++ b/src/lib/diagnosticSkillFrameworks.ts
@@ -1,0 +1,65 @@
+/**
+ * Skill-code → full-name frameworks, per subject. The S1–S7 codes are shared
+ * but mean *different things* in each subject (Physics S3 is "Proportional &
+ * Ratio Reasoning"; Maths S3 is "Graphical & Geometric Reasoning"), and Maths 1
+ * has no S6 (no calculus). Selecting the wrong framework mislabels a student's
+ * whole profile, so this is keyed by the diagnostic's subject.
+ *
+ * The canonical `_detail` strings from the import JSON aren't persisted in the
+ * DB, so this constant is the single source of truth for names. Subject strings
+ * have drifted in real data ("ESAT Math 2" vs "ESAT Maths 2"), so we normalise
+ * before matching.
+ */
+
+const MATHS_SHARED: Record<string, string> = {
+    S1: 'Algebraic Manipulation & Fluency',
+    S2: 'Strategic & Efficient Problem Solving',
+    S3: 'Graphical & Geometric Reasoning',
+    S4: 'Logical Reasoning & Rigour',
+    S5: 'Proportional & Numerical Fluency',
+    S7: 'Functions, Sequences & Structure',
+}
+
+const FRAMEWORKS: Record<string, Record<string, string>> = {
+    // Maths 1 — no S6 (no calculus in the spec).
+    'esat math 1': { ...MATHS_SHARED },
+    // Maths 2 — Maths 1 plus calculus.
+    'esat math 2': { ...MATHS_SHARED, S6: 'Calculus & Rate of Change' },
+    // Physics — same codes, different meanings.
+    'esat physics': {
+        S1: 'Conceptual Understanding',
+        S2: 'Equation Selection & Substitution',
+        S3: 'Proportional & Ratio Reasoning',
+        S4: 'Multi-Step Problem Solving',
+        S5: 'Novel/Transfer Application',
+        S6: 'Units & Dimensional Reasoning',
+        S7: 'Graphical & Data Interpretation',
+    },
+}
+
+/** Fold subject-name drift to a stable key: lowercase, collapse spaces, and
+ * treat "maths" as "math" so "ESAT Maths 2" and "ESAT Math 2" both match. */
+export function normalizeSubject(subject: string | null | undefined): string {
+    return (subject ?? '')
+        .trim()
+        .toLowerCase()
+        .replace(/\bmaths\b/g, 'math')
+        .replace(/\s+/g, ' ')
+}
+
+/** The framework for a subject, or null when we don't recognise it (the report
+ * then falls back to bare codes rather than mislabelling). */
+export function frameworkFor(
+    subject: string | null | undefined
+): Record<string, string> | null {
+    return FRAMEWORKS[normalizeSubject(subject)] ?? null
+}
+
+/** Full name for a skill code in a subject; falls back to the bare code when
+ * the subject or code is unknown, so a code is always shown, never nothing. */
+export function skillName(
+    subject: string | null | undefined,
+    code: string
+): string {
+    return frameworkFor(subject)?.[code] ?? code
+}

--- a/src/pages/Diagnostic/DiagnosticReportPage.test.tsx
+++ b/src/pages/Diagnostic/DiagnosticReportPage.test.tsx
@@ -43,15 +43,12 @@ function report(over: Partial<DiagnosticReportResponse> = {}): DiagnosticReportR
             agreedToTerms: true,
             totalScore: 1,
         },
+        subject: 'ESAT Math 2',
         answeredCount: 2,
         skillsRadar: [
-            { skill: 'S1', score: 2 / 3 },
-            { skill: 'S2', score: 0 },
-            { skill: 'S3', score: null },
-            { skill: 'S4', score: null },
-            { skill: 'S5', score: null },
-            { skill: 'S6', score: null },
-            { skill: 'S7', score: null },
+            { skill: 'S1', score: 5 / 6, attempted: 6, correct: 5 }, // strength 83%
+            { skill: 'S3', score: 0.25, attempted: 4, correct: 1 }, // focus 25%
+            { skill: 'S5', score: null, attempted: 0, correct: 0 }, // not measured
         ],
         flaggedNeverRevisited: ['qb'],
         perQuestionTime: [
@@ -81,7 +78,6 @@ describe('DiagnosticReportPage', () => {
     it('shows a loading state while the report is fetching', () => {
         mockUseReport.mockReturnValue({ data: undefined, isLoading: true, error: null })
         renderPage()
-        // LoadingPage renders; the report content is absent.
         expect(screen.queryByText('Your diagnostic report')).not.toBeInTheDocument()
     })
 
@@ -107,56 +103,77 @@ describe('DiagnosticReportPage', () => {
         expect(screen.getByText(/report not available/i)).toBeInTheDocument()
     })
 
-    it('renders accuracy over attempted separately from completion (never a collapsed X/N)', () => {
+    it('renders accuracy over attempted separately from completion', () => {
         mockUseReport.mockReturnValue({ data: report(), isLoading: false, error: null })
         renderPage()
-        // 1 correct of 2 attempted — NOT 1/3 against the full set.
         expect(screen.getByText('1/2 correct')).toBeInTheDocument()
         expect(screen.getByText(/of questions attempted · 2\/3 attempted/i)).toBeInTheDocument()
         expect(screen.queryByText('1/3 correct')).not.toBeInTheDocument()
     })
 
-    it('renders the Skills Radar, with "not assessed" distinct from a low score', () => {
+    it('writes a plain-English strengths + focus-areas summary with full names', () => {
         mockUseReport.mockReturnValue({ data: report(), isLoading: false, error: null })
         renderPage()
-        // The radar's accessible table carries the per-skill data: all seven
-        // skills, S1 scored, S3 "Not assessed" (not 0%).
-        const table = screen.getByRole('table', { name: /skills radar/i })
-        expect(within(table).getAllByRole('rowheader')).toHaveLength(7)
-        const s1 = within(table).getByRole('rowheader', { name: 'S1' }).closest('tr')!
-        expect(within(s1).getByRole('cell')).toHaveTextContent('67%')
-        const s3 = within(table).getByRole('rowheader', { name: 'S3' }).closest('tr')!
-        expect(within(s3).getByRole('cell')).toHaveTextContent('Not assessed')
-        expect(within(s3).getByRole('cell')).not.toHaveTextContent('0%')
+        const summary = screen.getByText('Where you stand').closest('section')!
+        // Strength decoded to its full Maths 2 name, with percentage.
+        expect(within(summary).getByText(/Algebraic Manipulation & Fluency/)).toBeInTheDocument()
+        // Focus area decoded, lowest-first, with denominator.
+        const focus = within(summary).getByText(/Graphical & Geometric Reasoning/)
+        expect(focus.closest('li')).toHaveTextContent('25%')
+        expect(focus.closest('li')).toHaveTextContent('(1 of 4)')
     })
 
-    it('names flagged-never-revisited questions by position', () => {
+    it('gives a concrete next step for each focus area', () => {
         mockUseReport.mockReturnValue({ data: report(), isLoading: false, error: null })
         renderPage()
-        const flagged = screen.getByText('Flagged & never revisited').closest('section')!
-        // qb is order index 1 -> "Question 2".
+        const steps = screen.getByText('Your next steps').closest('section')!
+        expect(within(steps).getByText(/Graphical & Geometric Reasoning/)).toBeInTheDocument()
+        // The static advice for Maths S3 mentions coordinate geometry.
+        expect(within(steps).getByText(/coordinate geometry/i)).toBeInTheDocument()
+    })
+
+    it('radar legend keeps "not assessed" distinct from a low score, in full names', () => {
+        mockUseReport.mockReturnValue({ data: report(), isLoading: false, error: null })
+        renderPage()
+        const table = screen.getByRole('table', { name: /skills radar/i })
+        // Full subject names as row headers; S5 not measured reads explicitly.
+        const s1 = within(table)
+            .getByRole('rowheader', { name: /Algebraic Manipulation & Fluency/ })
+            .closest('tr')!
+        expect(within(s1).getByRole('cell')).toHaveTextContent('83%')
+        const s5 = within(table)
+            .getByRole('rowheader', { name: /Proportional & Numerical Fluency/ })
+            .closest('tr')!
+        expect(within(s5).getByRole('cell')).toHaveTextContent('not assessed in this set')
+        expect(within(s5).getByRole('cell')).not.toHaveTextContent('0%')
+    })
+
+    it('labels the flagged-questions section and names them by position', () => {
+        mockUseReport.mockReturnValue({ data: report(), isLoading: false, error: null })
+        renderPage()
+        const flagged = screen
+            .getByText('Questions you flagged to revisit')
+            .closest('section')!
         expect(within(flagged).getByText('Question 2')).toBeInTheDocument()
     })
 
     it('renders the pacing curve, zero-filling the paper to the set size', () => {
         mockUseReport.mockReturnValue({ data: report(), isLoading: false, error: null })
         renderPage()
-        // Fixture: qa (15s, 2 visits), qb (65s); set has 3 questions, so Q3
-        // was never reached — the curve spans the whole paper via the
-        // set-preview question count.
         const table = screen.getByRole('table', { name: /time per question/i })
         const q1 = within(table).getByRole('rowheader', { name: 'Question 1' }).closest('tr')!
         expect(within(q1).getAllByRole('cell')[0]).toHaveTextContent('0:15')
-        expect(within(q1).getAllByRole('cell')[1]).toHaveTextContent('2')
-        const q2 = within(table).getByRole('rowheader', { name: 'Question 2' }).closest('tr')!
-        expect(within(q2).getAllByRole('cell')[0]).toHaveTextContent('1:05')
         const q3 = within(table).getByRole('rowheader', { name: 'Question 3' }).closest('tr')!
         expect(within(q3).getAllByRole('cell')[0]).toHaveTextContent('Not reached')
     })
 
     it('handles a zero-answer attempt without a nonsense 0/0', () => {
         mockUseReport.mockReturnValue({
-            data: report({ answeredCount: 0, attempt: { ...report().attempt, totalScore: 0 } }),
+            data: report({
+                answeredCount: 0,
+                attempt: { ...report().attempt, totalScore: 0 },
+                skillsRadar: [{ skill: 'S1', score: null, attempted: 0, correct: 0 }],
+            }),
             isLoading: false,
             error: null,
         })

--- a/src/pages/Diagnostic/DiagnosticReportPage.tsx
+++ b/src/pages/Diagnostic/DiagnosticReportPage.tsx
@@ -10,17 +10,19 @@ import useGetSetPreviewQuery from '@/hooks/diagnostic/useGetSetPreviewQuery.ts'
 import { questionLabelByIdFrom } from '@/lib/diagnosticReport.ts'
 import { SkillsRadar } from '@/components/diagnostic/report/SkillsRadar.tsx'
 import { PacingCurve } from '@/components/diagnostic/report/PacingCurve.tsx'
+import {
+    buildReportInsights,
+    type SkillInsight,
+} from '@/lib/diagnosticReportInsights.ts'
+import { skillAdvice } from '@/lib/diagnosticSkillAdvice.ts'
 
 /**
- * Post-exam report screen (§6). Its own route/query, reached from the
- * terminal exam view's "View your report" CTA (or directly, later). Turns
- * the report endpoint's three deliverables into a screen: the accuracy-
- * over-attempted headline, the Skills Radar (all seven skills; "not
- * assessed" is distinct from a low score), the flagged-and-never-revisited
- * call-out, and the per-question pacing list.
- *
- * PR 1 renders these plainly (labelled rows/bars); the SVG Skills Radar and
- * pacing curve are PR 2, layered over this same already-flowing data.
+ * Post-exam report screen (§6). Reads the report endpoint and turns it into a
+ * self-interpreting screen for a student: the accuracy headline, a written
+ * strengths/focus-areas summary (decoding S1–S7 into full subject names),
+ * the Skills Radar with a full-name legend, concrete next steps per focus
+ * area, the flagged-questions call-out, and the pacing curve. "Not measured"
+ * (n/a) is kept distinct from a real 0% throughout.
  */
 export function DiagnosticReportPage() {
     const { attemptId } = useParams()
@@ -32,9 +34,6 @@ export function DiagnosticReportPage() {
         error,
     } = useGetAttemptReportQuery({ attemptId: attemptId ?? '' })
 
-    // Completion denominator: the set's full question count. Sourced from
-    // the existing preview query rather than duplicated into the report —
-    // enabled only once we know the set from the report.
     const { data: preview } = useGetSetPreviewQuery({
         setId: report?.attempt.diagnosticSetId ?? '',
         enabled: report !== undefined,
@@ -42,7 +41,6 @@ export function DiagnosticReportPage() {
 
     if (isLoading) return <LoadingPage />
 
-    // Still in progress: the endpoint 409s. Offer to resume, not an error.
     if (error instanceof AttemptReportError && error.status === 409) {
         return (
             <div className="mx-auto mt-16 flex max-w-md flex-col items-center gap-4 text-center">
@@ -74,15 +72,20 @@ export function DiagnosticReportPage() {
     }
 
     const totalScore = report.attempt.totalScore ?? 0
-    const { answeredCount } = report
+    const { answeredCount, subject } = report
     const labelById = questionLabelByIdFrom(report.perQuestionTime)
+    const insights = buildReportInsights(
+        report.skillsRadar,
+        subject,
+        totalScore,
+        answeredCount
+    )
 
     return (
         <div className="mx-auto mt-12 flex max-w-2xl flex-col gap-6 px-4">
             <h1 className="text-3xl font-semibold">Your diagnostic report</h1>
 
-            {/* Accuracy over *attempted*, kept separate from completion — an
-                unanswered question is never counted as wrong. */}
+            {/* Accuracy over *attempted*, kept separate from completion. */}
             <Card>
                 <CardContent className="flex flex-col gap-1 pt-6">
                     <span className="text-3xl font-semibold">
@@ -99,19 +102,85 @@ export function DiagnosticReportPage() {
                 </CardContent>
             </Card>
 
-            {/* Skills Radar — all seven skills; null = not assessed. */}
+            {/* Written strengths & focus areas — the plain-English layer. */}
             <section className="flex flex-col gap-3">
-                <h2 className="text-xl font-medium">Skills</h2>
+                <h2 className="text-xl font-medium">Where you stand</h2>
                 <Card>
-                    <CardContent className="pt-6">
-                        <SkillsRadar skills={report.skillsRadar} />
+                    <CardContent className="flex flex-col gap-4 pt-6">
+                        <p className="text-gray-700">{insights.headline}</p>
+
+                        <div>
+                            <h3 className="mb-1 text-sm font-semibold text-emerald-700 dark:text-emerald-400">
+                                Where you&apos;re strong
+                            </h3>
+                            {insights.strengths.length === 0 ? (
+                                <p className="text-sm text-gray-600">
+                                    No standout strengths this time — but that just
+                                    means there&apos;s lots of room to grow. Start
+                                    with the focus areas below.
+                                </p>
+                            ) : (
+                                <ul className="flex flex-col gap-1">
+                                    {insights.strengths.map((s) => (
+                                        <SkillLine key={s.code} insight={s} tone="strength" />
+                                    ))}
+                                </ul>
+                            )}
+                        </div>
+
+                        {insights.focusAreas.length > 0 && (
+                            <div>
+                                <h3 className="mb-1 text-sm font-semibold text-amber-700 dark:text-amber-400">
+                                    Where to focus next
+                                </h3>
+                                <ul className="flex flex-col gap-1">
+                                    {insights.focusAreas.map((s) => (
+                                        <SkillLine key={s.code} insight={s} tone="focus" />
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
                     </CardContent>
                 </Card>
             </section>
 
-            {/* Flagged and never revisited — a concrete pacing failure mode. */}
+            {/* Skills Radar — the set's real axes; full names in the legend. */}
             <section className="flex flex-col gap-3">
-                <h2 className="text-xl font-medium">Flagged &amp; never revisited</h2>
+                <h2 className="text-xl font-medium">Your skills at a glance</h2>
+                <Card>
+                    <CardContent className="pt-6">
+                        <SkillsRadar skills={report.skillsRadar} subject={subject} />
+                    </CardContent>
+                </Card>
+            </section>
+
+            {/* Concrete next steps for each focus area. */}
+            {insights.focusAreas.length > 0 && (
+                <section className="flex flex-col gap-3">
+                    <h2 className="text-xl font-medium">Your next steps</h2>
+                    <Card>
+                        <CardContent className="flex flex-col gap-4 pt-6">
+                            {insights.focusAreas.map((s) => (
+                                <div key={s.code}>
+                                    <p className="text-sm font-medium">
+                                        {s.name}
+                                        {s.name !== s.code && (
+                                            <span className="text-gray-400"> ({s.code})</span>
+                                        )}
+                                    </p>
+                                    <p className="text-sm text-gray-600">
+                                        {skillAdvice(subject, s.code)}
+                                    </p>
+                                </div>
+                            ))}
+                        </CardContent>
+                    </Card>
+                </section>
+            )}
+
+            {/* Flagged and never revisited — now clearly labelled. */}
+            <section className="flex flex-col gap-3">
+                <h2 className="text-xl font-medium">Questions you flagged to revisit</h2>
                 <Card>
                     <CardContent className="pt-6">
                         {report.flaggedNeverRevisited.length === 0 ? (
@@ -119,23 +188,34 @@ export function DiagnosticReportPage() {
                                 You went back to every question you flagged — nice.
                             </p>
                         ) : (
-                            <div className="flex flex-wrap gap-2">
-                                {report.flaggedNeverRevisited.map((id) => (
-                                    <Badge key={id} variant="secondary">
-                                        {labelById.get(id) ?? 'Question'}
-                                    </Badge>
-                                ))}
+                            <div className="flex flex-col gap-2">
+                                <p className="text-sm text-gray-600">
+                                    You flagged these during the exam but didn&apos;t
+                                    come back to them — worth a second look.
+                                </p>
+                                <div className="flex flex-wrap gap-2">
+                                    {report.flaggedNeverRevisited.map((id) => (
+                                        <Badge key={id} variant="secondary">
+                                            {labelById.get(id) ?? 'Question'}
+                                        </Badge>
+                                    ))}
+                                </div>
                             </div>
                         )}
                     </CardContent>
                 </Card>
             </section>
 
-            {/* Pacing — time per question across the paper sequence. */}
+            {/* Pacing — time per question, with a caption explaining it. */}
             <section className="flex flex-col gap-3">
                 <h2 className="text-xl font-medium">Time per question</h2>
                 <Card>
-                    <CardContent className="pt-6">
+                    <CardContent className="flex flex-col gap-3 pt-6">
+                        <p className="text-sm text-gray-600">
+                            How long you spent on each question, in order. Tall bars
+                            are where you slowed down — useful for spotting which
+                            topics cost you time.
+                        </p>
                         <PacingCurve
                             perQuestionTime={report.perQuestionTime}
                             questionCount={preview?.questionCount}
@@ -150,5 +230,32 @@ export function DiagnosticReportPage() {
                 </Button>
             </div>
         </div>
+    )
+}
+
+/** One strength/focus line: full name, code, percentage, and — for focus areas
+ * — the denominator plus a "limited data" note when the sample is small. */
+function SkillLine({
+    insight,
+    tone,
+}: {
+    insight: SkillInsight
+    tone: 'strength' | 'focus'
+}) {
+    return (
+        <li className="text-sm text-gray-700">
+            <span className="font-medium">{insight.name}</span>
+            {insight.name !== insight.code && (
+                <span className="text-gray-400"> ({insight.code})</span>
+            )}{' '}
+            — {insight.pct}%
+            {tone === 'focus' && (
+                <span className="text-gray-500">
+                    {' '}
+                    ({insight.correct} of {insight.attempted}
+                    {insight.limitedData ? ', limited data' : ''})
+                </span>
+            )}
+        </li>
     )
 }


### PR DESCRIPTION
## What
Makes the student report **interpret itself** (tutor brief) — additive to the existing visuals (backend enablers in ClintonWeeYuan/math-be#18, merged + deployed).

- **Full skill names, subject-aware** — S1–S7 decoded via a subject-keyed framework constant. The codes mean different things per subject (Physics S3 ≠ Maths S3) and Maths 1 has no S6; subject-name drift ("Math 2" vs "Maths 2") is normalised. Falls back to bare codes for an unknown subject.
- **"Where you stand" summary** — a warm, score-aware headline; **strengths** (≥60%, ≥3 questions, decoded) and **focus areas** (lowest measured, decoded, lowest-first) with denominators and a "limited data" note under 3 questions. Uses only *measured* skills — never n/a.
- **"Your next steps"** — one encouraging, subject-aware revision step per focus area.
- **n/a vs 0% fixed** — the radar legend shows the percentage with its denominator ("0% · 0/1") and an explicit "not assessed in this set" for null axes, kept distinct from a genuine 0%.
- **Radar** shows the set's real axes with a full-name legend; **flagged chips** now labelled ("Questions you flagged to revisit"); **pacing caption** added.

Decisions confirmed with the tutor: fixed framework constant as the single source of truth (the `_detail` strings aren't persisted); static per-skill advice (topic names aren't stored yet).

## Tests (29 pass)
`diagnosticSkillFrameworks` (per-subject decoding, drift, no-S6), `diagnosticReportInsights` (strengths/focus rules, small-sample, n/a exclusion, headline), `SkillsRadar` (legend, denominators, not-measured), `DiagnosticReportPage` (summary, next steps, radar legend, flagged label).

## Live-verified against prod
Real score-11 ESAT Math 2 report rendered end-to-end: subject-correct full names throughout, headline "solid base to build on", strength "Functions, Sequences & Structure (S7) — 67%", focus areas "Proportional & Numerical Fluency (S5) — 0% (0 of 1, limited data)" / "Graphical & Geometric Reasoning (S3) — 25% (1 of 4)", subject-specific axes (no S4), per-skill next steps, labelled flagged section, pacing caption. Screenshot in thread.

## Note
This makes the editable **Skill Labels** screen (fe#27) redundant for the report — the report now uses the fixed framework names. Flagging for later cleanup; not removed here.

## Out of scope (noted for later)
Topic-family rollup, cohort/historical comparison, linking focus areas to practice sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)