### PR TITLE
Split the 580-line DiagnosticQuestionForm into focused parts

### DIFF
--- a/src/components/diagnostic/DiagnosticQuestionForm.tsx
+++ b/src/components/diagnostic/DiagnosticQuestionForm.tsx
@@ -1,100 +1,26 @@
-import { useForm, useFieldArray, Controller } from 'react-hook-form'
-import { useEffect, useState, type ChangeEvent } from 'react'
-import {
-    Select,
-    SelectContent,
-    SelectGroup,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from '@/components/ui/select.tsx'
-import { Input } from '@/components/ui/input.tsx'
+import { useForm, FormProvider } from 'react-hook-form'
+import { useEffect } from 'react'
 import { Textarea } from '@/components/ui/textarea.tsx'
 import { Button } from '@/components/ui/button.tsx'
-import { Card, CardContent } from '@/components/ui/card.tsx'
-import { Plus, Trash2 } from 'lucide-react'
 import { LatexText } from '@/components/diagnostic/LatexText.tsx'
-import { Combobox } from '@/components/ui/combobox.tsx'
 import type { DiagnosticQuestionResponse } from '@/client'
+import {
+    defaultValues,
+    labelForIndex,
+    type DiagnosticQuestionFormValues,
+} from './questionForm/types.ts'
+import { QuestionMetaFields } from './questionForm/QuestionMetaFields.tsx'
+import { QuestionOptionsEditor } from './questionForm/QuestionOptionsEditor.tsx'
+import { QuestionDiagramField } from './questionForm/QuestionDiagramField.tsx'
 
-const CORE_SKILLS = ['S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7'] as const
-const DIFFICULTY_TAGS = ['creative', 'TMUA-stretch'] as const
-
-type OptionField = {
-    label: string
-    text: string
-    isCorrect: boolean
-    misconception: string
-}
-
-export type DiagnosticQuestionFormValues = {
-    topicCode: string
-    coreSkillPrimary: string
-    coreSkillSecondary: string | null
-    difficultyTag: string | null
-    stem: string
-    options: OptionField[]
-    status: 'draft' | 'published'
-    // Paste-SVG mode. diagramSvgTouched tracks whether the admin interacted
-    // with this field at all this session (typed into it, or clicked
-    // "Remove diagram") — on update, omitting the key entirely (untouched)
-    // must leave the existing diagram alone, which is a different outcome
-    // from sending an explicit empty/null value (which clears it). See
-    // getDiagramSvgForUpdate below — this mirrors the backend's own
-    // omit-vs-explicit-null distinction (UpdateDiagnosticQuestionBody's
-    // diagram_svg, gated by "diagram_svg" in update_data after
-    // exclude_unset) exactly, on the frontend side of the same contract.
-    diagramSvg: string
-    diagramSvgTouched: boolean
-    // Upload-image mode, entirely separate from the JSON body — handled by
-    // the pages via a second request to POST .../{id}/diagram after
-    // create/update succeeds, since a file can't ride along in the same
-    // JSON payload as diagramSvg.
-    diagramFile: File | null
-}
-
-/**
- * The one place "does this form have exactly one correct option" is
- * checked. Both the create and edit pages call this before submitting —
- * previously each had its own inline copy of the same
- * `.find((o) => o.isCorrect)` check, which is exactly the kind of
- * duplication that quietly drifts apart the next time either page
- * changes (the same class of risk as the backend's diagram-upload logic
- * before it was pulled into _upload_diagram_content).
- */
-export function getCorrectOptionLabel(
-    values: DiagnosticQuestionFormValues
-): string | null {
-    return values.options.find((o) => o.isCorrect)?.label ?? null
-}
-
-/**
- * For create: there's no existing diagram to preserve, so the only
- * question is whether one was provided at all — matches the backend's
- * own `if body.diagram_svg:` truthiness check on create.
- */
-export function getDiagramSvgForCreate(
-    values: DiagnosticQuestionFormValues
-): string | undefined {
-    return values.diagramSvg.trim() === '' ? undefined : values.diagramSvg
-}
-
-/**
- * For update: omitted (untouched) must leave the existing diagram alone,
- * distinct from an explicit empty value (clears it) — the three-way
- * distinction the backend's UpdateDiagnosticQuestionBody.diagram_svg
- * itself enforces via exclude_unset. Returning undefined here means the
- * caller must NOT include the key in the request body at all (spreading
- * `{ ...(x !== undefined ? { diagramSvg: x } : {}) }`), not send it as
- * literally `undefined`, which would serialize away in JSON.stringify
- * anyway but the distinction matters for callers to get right.
- */
-export function getDiagramSvgForUpdate(
-    values: DiagnosticQuestionFormValues
-): string | null | undefined {
-    if (!values.diagramSvgTouched) return undefined
-    return values.diagramSvg.trim() === '' ? null : values.diagramSvg
-}
+// Re-exported so callers (the create/edit pages, tests) keep importing the
+// form's public API from one place even though the internals are now split.
+export type { DiagnosticQuestionFormValues } from './questionForm/types.ts'
+export {
+    getCorrectOptionLabel,
+    getDiagramSvgForCreate,
+    getDiagramSvgForUpdate,
+} from './questionForm/types.ts'
 
 type Props = {
     initialData?: DiagnosticQuestionResponse
@@ -111,49 +37,13 @@ type Props = {
     topicCodeOptions?: string[]
 }
 
-function labelForIndex(index: number): string {
-    return String.fromCharCode('A'.charCodeAt(0) + index)
-}
-
-function defaultValues(
-    initialData?: DiagnosticQuestionResponse
-): DiagnosticQuestionFormValues {
-    if (!initialData) {
-        return {
-            topicCode: '',
-            coreSkillPrimary: '',
-            coreSkillSecondary: null,
-            difficultyTag: null,
-            stem: '',
-            options: [
-                { label: 'A', text: '', isCorrect: true, misconception: '' },
-                { label: 'B', text: '', isCorrect: false, misconception: '' },
-            ],
-            status: 'draft',
-            diagramSvg: '',
-            diagramSvgTouched: false,
-            diagramFile: null,
-        }
-    }
-    return {
-        topicCode: initialData.topicCode,
-        coreSkillPrimary: initialData.coreSkillPrimary,
-        coreSkillSecondary: initialData.coreSkillSecondary ?? null,
-        difficultyTag: initialData.difficultyTag ?? null,
-        stem: initialData.stem,
-        options: initialData.options.map((o) => ({
-            label: o.label,
-            text: o.text,
-            isCorrect: o.isCorrect ?? false,
-            misconception: o.misconception ?? '',
-        })),
-        status: initialData.status,
-        diagramSvg: '',
-        diagramSvgTouched: false,
-        diagramFile: null,
-    }
-}
-
+/**
+ * The diagnostic-question authoring form. Composes the metadata grid, the
+ * stem, the answer-options editor, and the diagram field — each a focused
+ * sub-component that reads the shared react-hook-form context (FormProvider).
+ * This component owns the form instance, the reset-on-record-change, and the
+ * submit (which re-derives positional option labels).
+ */
 export function DiagnosticQuestionForm({
     initialData,
     onSubmit,
@@ -164,69 +54,16 @@ export function DiagnosticQuestionForm({
     const form = useForm<DiagnosticQuestionFormValues>({
         defaultValues: defaultValues(initialData),
     })
-    const [diagramMode, setDiagramMode] = useState<'svg' | 'upload'>('svg')
 
     useEffect(() => {
         form.reset(defaultValues(initialData))
-        // Only re-run when the record identity changes (switching from
-        // create to edit, or between two different questions) — not on
-        // every initialData re-render, which would wipe in-progress edits.
+        // Only re-run when the record identity changes (switching from create
+        // to edit, or between two different questions) — not on every
+        // initialData re-render, which would wipe in-progress edits.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [initialData?.id])
 
-    const { fields, append, remove } = useFieldArray({
-        control: form.control,
-        name: 'options',
-    })
-
     const stem = form.watch('stem')
-    const options = form.watch('options')
-    const hasCorrectOption = options.some((o) => o.isCorrect)
-    const diagramSvg = form.watch('diagramSvg')
-    const diagramSvgTouched = form.watch('diagramSvgTouched')
-    const diagramFile = form.watch('diagramFile')
-    // Untouched + no new file + an existing diagram on the record: show the
-    // current diagram (from the last save) rather than a blank editor, so
-    // the admin can see what's there before deciding to change it.
-    const showExistingDiagram =
-        !diagramSvgTouched && !diagramFile && !!initialData?.diagramUrl
-
-    function handleRemoveDiagram() {
-        form.setValue('diagramSvg', '')
-        form.setValue('diagramSvgTouched', true)
-        form.setValue('diagramFile', null)
-        setDiagramMode('svg')
-    }
-
-    function handleDiagramFileChange(e: ChangeEvent<HTMLInputElement>) {
-        form.setValue('diagramFile', e.target.files?.[0] ?? null)
-    }
-
-    function handleAddOption() {
-        append({
-            label: labelForIndex(fields.length),
-            text: '',
-            isCorrect: false,
-            misconception: '',
-        })
-    }
-
-    function handleRemoveOption(index: number) {
-        // If this was the correct option, nothing needs to happen to the
-        // others — every other option's isCorrect is already false (only
-        // one can ever be true, enforced by handleSetCorrect below), so
-        // removing it naturally leaves the set with zero correct options.
-        // Deliberately not auto-picking a fallback: an admin should notice
-        // and choose, not have the form silently decide for them. The
-        // hasCorrectOption banner below is what surfaces that state.
-        remove(index)
-    }
-
-    function handleSetCorrect(index: number) {
-        options.forEach((_, i) => {
-            form.setValue(`options.${i}.isCorrect`, i === index)
-        })
-    }
 
     function submit(values: DiagnosticQuestionFormValues) {
         // Labels are derived from position, not free-typed, so a removed/
@@ -239,342 +76,42 @@ export function DiagnosticQuestionForm({
     }
 
     return (
-        <form
-            onSubmit={form.handleSubmit(submit)}
-            className="flex flex-col gap-6 max-w-5xl"
-        >
-            <div className="grid grid-cols-2 gap-4">
-                <div className="flex flex-col gap-1.5">
-                    <label className="text-sm font-medium" htmlFor="topic-code">
-                        Topic code
-                    </label>
-                    <Controller
-                        control={form.control}
-                        name="topicCode"
-                        rules={{ required: true }}
-                        render={({ field }) => (
-                            <Combobox
-                                id="topic-code"
-                                value={field.value || null}
-                                onChange={(v) => field.onChange(v ?? '')}
-                                options={topicCodeOptions}
-                                placeholder="e.g. MM1.6"
-                                searchPlaceholder="Search or type a new topic code…"
-                            />
-                        )}
-                    />
-                </div>
-
-                <div className="flex flex-col gap-1.5">
-                    <label className="text-sm font-medium">Status</label>
-                    <Controller
-                        control={form.control}
-                        name="status"
-                        render={({ field }) => (
-                            <Select onValueChange={field.onChange} value={field.value}>
-                                <SelectTrigger className="w-full">
-                                    <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectGroup>
-                                        <SelectItem value="draft">Draft</SelectItem>
-                                        <SelectItem value="published">
-                                            Published
-                                        </SelectItem>
-                                    </SelectGroup>
-                                </SelectContent>
-                            </Select>
-                        )}
-                    />
-                </div>
+        <FormProvider {...form}>
+            <form
+                onSubmit={form.handleSubmit(submit)}
+                className="flex flex-col gap-6 max-w-5xl"
+            >
+                <QuestionMetaFields topicCodeOptions={topicCodeOptions} />
 
                 <div className="flex flex-col gap-1.5">
                     <label className="text-sm font-medium">
-                        Core skill (primary)
+                        Stem (LaTeX, $...$-delimited)
                     </label>
-                    <Controller
-                        control={form.control}
-                        name="coreSkillPrimary"
-                        rules={{ required: true }}
-                        render={({ field }) => (
-                            <Select onValueChange={field.onChange} value={field.value}>
-                                <SelectTrigger className="w-full">
-                                    <SelectValue placeholder="Select a skill" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectGroup>
-                                        {CORE_SKILLS.map((s) => (
-                                            <SelectItem key={s} value={s}>
-                                                {s}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectGroup>
-                                </SelectContent>
-                            </Select>
-                        )}
-                    />
-                </div>
-
-                <div className="flex flex-col gap-1.5">
-                    <label className="text-sm font-medium">
-                        Core skill (secondary)
-                    </label>
-                    <Controller
-                        control={form.control}
-                        name="coreSkillSecondary"
-                        render={({ field }) => (
-                            <Select
-                                onValueChange={(v) =>
-                                    field.onChange(v === 'none' ? null : v)
-                                }
-                                value={field.value ?? 'none'}
-                            >
-                                <SelectTrigger className="w-full">
-                                    <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectGroup>
-                                        <SelectItem value="none">None</SelectItem>
-                                        {CORE_SKILLS.map((s) => (
-                                            <SelectItem key={s} value={s}>
-                                                {s}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectGroup>
-                                </SelectContent>
-                            </Select>
-                        )}
-                    />
-                </div>
-
-                <div className="flex flex-col gap-1.5">
-                    <label className="text-sm font-medium">Difficulty tag</label>
-                    <Controller
-                        control={form.control}
-                        name="difficultyTag"
-                        render={({ field }) => (
-                            <Select
-                                onValueChange={(v) =>
-                                    field.onChange(v === 'none' ? null : v)
-                                }
-                                value={field.value ?? 'none'}
-                            >
-                                <SelectTrigger className="w-full">
-                                    <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectGroup>
-                                        <SelectItem value="none">None</SelectItem>
-                                        {DIFFICULTY_TAGS.map((tag) => (
-                                            <SelectItem key={tag} value={tag}>
-                                                {tag}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectGroup>
-                                </SelectContent>
-                            </Select>
-                        )}
-                    />
-                </div>
-            </div>
-
-            <div className="flex flex-col gap-1.5">
-                <label className="text-sm font-medium">
-                    Stem (LaTeX, $...$-delimited)
-                </label>
-                <div className="grid grid-cols-2 gap-4">
-                    <Textarea
-                        rows={4}
-                        placeholder="Given that $x^2 + kx + 9 = 0$ has equal roots..."
-                        {...form.register('stem', { required: true })}
-                    />
-                    <div className="rounded-md border p-3 bg-gray-50 text-sm">
-                        <div className="text-xs uppercase text-gray-400 mb-2">
-                            Preview
+                    <div className="grid grid-cols-2 gap-4">
+                        <Textarea
+                            rows={4}
+                            placeholder="Given that $x^2 + kx + 9 = 0$ has equal roots..."
+                            {...form.register('stem', { required: true })}
+                        />
+                        <div className="rounded-md border p-3 bg-gray-50 text-sm">
+                            <div className="text-xs uppercase text-gray-400 mb-2">
+                                Preview
+                            </div>
+                            <LatexText text={stem || ''} />
                         </div>
-                        <LatexText text={stem || ''} />
                     </div>
                 </div>
-            </div>
 
-            <div className="flex flex-col gap-3">
-                <div className="flex items-center justify-between">
-                    <label className="text-sm font-medium">Options</label>
-                    <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={handleAddOption}
-                    >
-                        <Plus className="w-4 h-4" /> Add option
+                <QuestionOptionsEditor />
+
+                <QuestionDiagramField initialData={initialData} />
+
+                <div>
+                    <Button type="submit" disabled={isSubmitting}>
+                        {isSubmitting ? 'Saving...' : submitLabel}
                     </Button>
                 </div>
-
-                {!hasCorrectOption && (
-                    <div
-                        role="alert"
-                        className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800"
-                    >
-                        No option is marked as the correct answer. Select one
-                        below before saving.
-                    </div>
-                )}
-
-                {fields.map((field, index) => (
-                    <Card key={field.id}>
-                        <CardContent className="pt-4 flex flex-col gap-3">
-                            <div className="flex items-center gap-3">
-                                <span className="font-semibold w-6">
-                                    {labelForIndex(index)}
-                                </span>
-                                <label className="flex items-center gap-1.5 text-sm">
-                                    <input
-                                        type="radio"
-                                        name="correct-option"
-                                        checked={options[index]?.isCorrect ?? false}
-                                        onChange={() => handleSetCorrect(index)}
-                                    />
-                                    Correct answer
-                                </label>
-                                <div className="flex-1" />
-                                <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="sm"
-                                    disabled={fields.length <= 2}
-                                    onClick={() => handleRemoveOption(index)}
-                                >
-                                    <Trash2 className="w-4 h-4" />
-                                </Button>
-                            </div>
-
-                            <div className="grid grid-cols-2 gap-4">
-                                <Textarea
-                                    rows={2}
-                                    placeholder="Option text, LaTeX allowed"
-                                    {...form.register(`options.${index}.text`, {
-                                        required: true,
-                                    })}
-                                />
-                                <div className="rounded-md border p-3 bg-gray-50 text-sm">
-                                    <LatexText text={options[index]?.text || ''} />
-                                </div>
-                            </div>
-
-                            {!options[index]?.isCorrect && (
-                                <Input
-                                    placeholder="Misconception (why a student might pick this wrong answer)"
-                                    {...form.register(
-                                        `options.${index}.misconception`
-                                    )}
-                                />
-                            )}
-                        </CardContent>
-                    </Card>
-                ))}
-            </div>
-
-            <div className="flex flex-col gap-3">
-                <div className="flex items-center justify-between">
-                    <label className="text-sm font-medium">
-                        Diagram (optional)
-                    </label>
-                    {(showExistingDiagram || diagramSvgTouched || diagramFile) && (
-                        <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            onClick={handleRemoveDiagram}
-                        >
-                            <Trash2 className="w-4 h-4" /> Remove diagram
-                        </Button>
-                    )}
-                </div>
-
-                {showExistingDiagram && initialData?.diagramUrl && (
-                    <div className="rounded-md border p-3 bg-gray-50">
-                        <img
-                            src={initialData.diagramUrl}
-                            alt="Current diagram"
-                            className="max-h-64"
-                        />
-                    </div>
-                )}
-
-                {!showExistingDiagram && (
-                    <>
-                        <div className="flex gap-2">
-                            <Button
-                                type="button"
-                                variant={diagramMode === 'svg' ? 'default' : 'outline'}
-                                size="sm"
-                                onClick={() => setDiagramMode('svg')}
-                            >
-                                Paste SVG
-                            </Button>
-                            <Button
-                                type="button"
-                                variant={
-                                    diagramMode === 'upload' ? 'default' : 'outline'
-                                }
-                                size="sm"
-                                onClick={() => setDiagramMode('upload')}
-                            >
-                                Upload image
-                            </Button>
-                        </div>
-
-                        {diagramMode === 'svg' && (
-                            <div className="grid grid-cols-2 gap-4">
-                                <Textarea
-                                    rows={6}
-                                    placeholder="<svg ...>...</svg>"
-                                    {...form.register('diagramSvg', {
-                                        onChange: () =>
-                                            form.setValue(
-                                                'diagramSvgTouched',
-                                                true
-                                            ),
-                                    })}
-                                />
-                                <div className="rounded-md border p-3 bg-gray-50 text-sm overflow-auto">
-                                    {diagramSvg ? (
-                                        <div
-                                            dangerouslySetInnerHTML={{
-                                                __html: diagramSvg,
-                                            }}
-                                        />
-                                    ) : (
-                                        <span className="text-gray-400">
-                                            Preview
-                                        </span>
-                                    )}
-                                </div>
-                            </div>
-                        )}
-
-                        {diagramMode === 'upload' && (
-                            <Input
-                                type="file"
-                                accept="image/*"
-                                onChange={handleDiagramFileChange}
-                            />
-                        )}
-
-                        {diagramFile && (
-                            <span className="text-sm text-gray-500">
-                                Selected: {diagramFile.name}
-                            </span>
-                        )}
-                    </>
-                )}
-            </div>
-
-            <div>
-                <Button type="submit" disabled={isSubmitting}>
-                    {isSubmitting ? 'Saving...' : submitLabel}
-                </Button>
-            </div>
-        </form>
+            </form>
+        </FormProvider>
     )
 }

--- a/src/components/diagnostic/questionForm/QuestionDiagramField.tsx
+++ b/src/components/diagnostic/questionForm/QuestionDiagramField.tsx
@@ -1,0 +1,126 @@
+import { useState, type ChangeEvent } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { Input } from '@/components/ui/input.tsx'
+import { Textarea } from '@/components/ui/textarea.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { Trash2 } from 'lucide-react'
+import type { DiagnosticQuestionResponse } from '@/client'
+import type { DiagnosticQuestionFormValues } from './types.ts'
+
+type Props = {
+    /** The record being edited (for its existing diagram), if any. */
+    initialData?: DiagnosticQuestionResponse
+}
+
+/** The optional diagram field: shows the existing diagram on edit, or a
+ * paste-SVG / upload-image editor. The svg-touched flag preserves the
+ * omit-vs-clear distinction the backend enforces on update. */
+export function QuestionDiagramField({ initialData }: Props) {
+    const { register, watch, setValue } =
+        useFormContext<DiagnosticQuestionFormValues>()
+    const [diagramMode, setDiagramMode] = useState<'svg' | 'upload'>('svg')
+
+    const diagramSvg = watch('diagramSvg')
+    const diagramSvgTouched = watch('diagramSvgTouched')
+    const diagramFile = watch('diagramFile')
+    // Untouched + no new file + an existing diagram on the record: show the
+    // current diagram (from the last save) rather than a blank editor.
+    const showExistingDiagram =
+        !diagramSvgTouched && !diagramFile && !!initialData?.diagramUrl
+
+    function handleRemoveDiagram() {
+        setValue('diagramSvg', '')
+        setValue('diagramSvgTouched', true)
+        setValue('diagramFile', null)
+        setDiagramMode('svg')
+    }
+
+    function handleDiagramFileChange(e: ChangeEvent<HTMLInputElement>) {
+        setValue('diagramFile', e.target.files?.[0] ?? null)
+    }
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+                <label className="text-sm font-medium">Diagram (optional)</label>
+                {(showExistingDiagram || diagramSvgTouched || diagramFile) && (
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={handleRemoveDiagram}
+                    >
+                        <Trash2 className="w-4 h-4" /> Remove diagram
+                    </Button>
+                )}
+            </div>
+
+            {showExistingDiagram && initialData?.diagramUrl && (
+                <div className="rounded-md border p-3 bg-gray-50">
+                    <img
+                        src={initialData.diagramUrl}
+                        alt="Current diagram"
+                        className="max-h-64"
+                    />
+                </div>
+            )}
+
+            {!showExistingDiagram && (
+                <>
+                    <div className="flex gap-2">
+                        <Button
+                            type="button"
+                            variant={diagramMode === 'svg' ? 'default' : 'outline'}
+                            size="sm"
+                            onClick={() => setDiagramMode('svg')}
+                        >
+                            Paste SVG
+                        </Button>
+                        <Button
+                            type="button"
+                            variant={diagramMode === 'upload' ? 'default' : 'outline'}
+                            size="sm"
+                            onClick={() => setDiagramMode('upload')}
+                        >
+                            Upload image
+                        </Button>
+                    </div>
+
+                    {diagramMode === 'svg' && (
+                        <div className="grid grid-cols-2 gap-4">
+                            <Textarea
+                                rows={6}
+                                placeholder="<svg ...>...</svg>"
+                                {...register('diagramSvg', {
+                                    onChange: () =>
+                                        setValue('diagramSvgTouched', true),
+                                })}
+                            />
+                            <div className="rounded-md border p-3 bg-gray-50 text-sm overflow-auto">
+                                {diagramSvg ? (
+                                    <div dangerouslySetInnerHTML={{ __html: diagramSvg }} />
+                                ) : (
+                                    <span className="text-gray-400">Preview</span>
+                                )}
+                            </div>
+                        </div>
+                    )}
+
+                    {diagramMode === 'upload' && (
+                        <Input
+                            type="file"
+                            accept="image/*"
+                            onChange={handleDiagramFileChange}
+                        />
+                    )}
+
+                    {diagramFile && (
+                        <span className="text-sm text-gray-500">
+                            Selected: {diagramFile.name}
+                        </span>
+                    )}
+                </>
+            )}
+        </div>
+    )
+}

--- a/src/components/diagnostic/questionForm/QuestionMetaFields.tsx
+++ b/src/components/diagnostic/questionForm/QuestionMetaFields.tsx
@@ -1,0 +1,156 @@
+import { Controller, useFormContext } from 'react-hook-form'
+import {
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select.tsx'
+import { Combobox } from '@/components/ui/combobox.tsx'
+import {
+    CORE_SKILLS,
+    DIFFICULTY_TAGS,
+    type DiagnosticQuestionFormValues,
+} from './types.ts'
+
+type Props = {
+    /** Topic codes already in use, offered in the combobox (a new one can
+     * always be typed). */
+    topicCodeOptions?: string[]
+}
+
+/** The question's metadata grid: topic code, status, primary/secondary core
+ * skill, and difficulty. All Controller-bound to the shared form context. */
+export function QuestionMetaFields({ topicCodeOptions = [] }: Props) {
+    const { control } = useFormContext<DiagnosticQuestionFormValues>()
+
+    return (
+        <div className="grid grid-cols-2 gap-4">
+            <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium" htmlFor="topic-code">
+                    Topic code
+                </label>
+                <Controller
+                    control={control}
+                    name="topicCode"
+                    rules={{ required: true }}
+                    render={({ field }) => (
+                        <Combobox
+                            id="topic-code"
+                            value={field.value || null}
+                            onChange={(v) => field.onChange(v ?? '')}
+                            options={topicCodeOptions}
+                            placeholder="e.g. MM1.6"
+                            searchPlaceholder="Search or type a new topic code…"
+                        />
+                    )}
+                />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium">Status</label>
+                <Controller
+                    control={control}
+                    name="status"
+                    render={({ field }) => (
+                        <Select onValueChange={field.onChange} value={field.value}>
+                            <SelectTrigger className="w-full">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectGroup>
+                                    <SelectItem value="draft">Draft</SelectItem>
+                                    <SelectItem value="published">
+                                        Published
+                                    </SelectItem>
+                                </SelectGroup>
+                            </SelectContent>
+                        </Select>
+                    )}
+                />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium">Core skill (primary)</label>
+                <Controller
+                    control={control}
+                    name="coreSkillPrimary"
+                    rules={{ required: true }}
+                    render={({ field }) => (
+                        <Select onValueChange={field.onChange} value={field.value}>
+                            <SelectTrigger className="w-full">
+                                <SelectValue placeholder="Select a skill" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectGroup>
+                                    {CORE_SKILLS.map((s) => (
+                                        <SelectItem key={s} value={s}>
+                                            {s}
+                                        </SelectItem>
+                                    ))}
+                                </SelectGroup>
+                            </SelectContent>
+                        </Select>
+                    )}
+                />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium">Core skill (secondary)</label>
+                <Controller
+                    control={control}
+                    name="coreSkillSecondary"
+                    render={({ field }) => (
+                        <Select
+                            onValueChange={(v) => field.onChange(v === 'none' ? null : v)}
+                            value={field.value ?? 'none'}
+                        >
+                            <SelectTrigger className="w-full">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectGroup>
+                                    <SelectItem value="none">None</SelectItem>
+                                    {CORE_SKILLS.map((s) => (
+                                        <SelectItem key={s} value={s}>
+                                            {s}
+                                        </SelectItem>
+                                    ))}
+                                </SelectGroup>
+                            </SelectContent>
+                        </Select>
+                    )}
+                />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium">Difficulty tag</label>
+                <Controller
+                    control={control}
+                    name="difficultyTag"
+                    render={({ field }) => (
+                        <Select
+                            onValueChange={(v) => field.onChange(v === 'none' ? null : v)}
+                            value={field.value ?? 'none'}
+                        >
+                            <SelectTrigger className="w-full">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectGroup>
+                                    <SelectItem value="none">None</SelectItem>
+                                    {DIFFICULTY_TAGS.map((tag) => (
+                                        <SelectItem key={tag} value={tag}>
+                                            {tag}
+                                        </SelectItem>
+                                    ))}
+                                </SelectGroup>
+                            </SelectContent>
+                        </Select>
+                    )}
+                />
+            </div>
+        </div>
+    )
+}

--- a/src/components/diagnostic/questionForm/QuestionOptionsEditor.tsx
+++ b/src/components/diagnostic/questionForm/QuestionOptionsEditor.tsx
@@ -1,0 +1,115 @@
+import { useFieldArray, useFormContext } from 'react-hook-form'
+import { Input } from '@/components/ui/input.tsx'
+import { Textarea } from '@/components/ui/textarea.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { Card, CardContent } from '@/components/ui/card.tsx'
+import { Plus, Trash2 } from 'lucide-react'
+import { LatexText } from '@/components/diagnostic/LatexText.tsx'
+import { labelForIndex, type DiagnosticQuestionFormValues } from './types.ts'
+
+/** The answer-options editor: add/remove options, mark exactly one correct
+ * (mutual exclusivity), and per-option text (LaTeX preview) + misconception.
+ * Labels are positional (A, B, C…) so they can't drift on remove/reorder. */
+export function QuestionOptionsEditor() {
+    const { control, register, watch, setValue } =
+        useFormContext<DiagnosticQuestionFormValues>()
+    const { fields, append, remove } = useFieldArray({ control, name: 'options' })
+
+    const options = watch('options')
+    const hasCorrectOption = options.some((o) => o.isCorrect)
+
+    function handleAddOption() {
+        append({
+            label: labelForIndex(fields.length),
+            text: '',
+            isCorrect: false,
+            misconception: '',
+        })
+    }
+
+    function handleRemoveOption(index: number) {
+        // If this was the correct option, nothing needs to happen to the
+        // others — every other option's isCorrect is already false (only one
+        // can ever be true, enforced by handleSetCorrect), so removing it
+        // naturally leaves the set with zero correct options. Deliberately
+        // not auto-picking a fallback: an admin should notice and choose, not
+        // have the form silently decide. The banner below surfaces that state.
+        remove(index)
+    }
+
+    function handleSetCorrect(index: number) {
+        options.forEach((_, i) => {
+            setValue(`options.${i}.isCorrect`, i === index)
+        })
+    }
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+                <label className="text-sm font-medium">Options</label>
+                <Button type="button" variant="outline" size="sm" onClick={handleAddOption}>
+                    <Plus className="w-4 h-4" /> Add option
+                </Button>
+            </div>
+
+            {!hasCorrectOption && (
+                <div
+                    role="alert"
+                    className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+                >
+                    No option is marked as the correct answer. Select one below
+                    before saving.
+                </div>
+            )}
+
+            {fields.map((field, index) => (
+                <Card key={field.id}>
+                    <CardContent className="pt-4 flex flex-col gap-3">
+                        <div className="flex items-center gap-3">
+                            <span className="font-semibold w-6">
+                                {labelForIndex(index)}
+                            </span>
+                            <label className="flex items-center gap-1.5 text-sm">
+                                <input
+                                    type="radio"
+                                    name="correct-option"
+                                    checked={options[index]?.isCorrect ?? false}
+                                    onChange={() => handleSetCorrect(index)}
+                                />
+                                Correct answer
+                            </label>
+                            <div className="flex-1" />
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                disabled={fields.length <= 2}
+                                onClick={() => handleRemoveOption(index)}
+                            >
+                                <Trash2 className="w-4 h-4" />
+                            </Button>
+                        </div>
+
+                        <div className="grid grid-cols-2 gap-4">
+                            <Textarea
+                                rows={2}
+                                placeholder="Option text, LaTeX allowed"
+                                {...register(`options.${index}.text`, { required: true })}
+                            />
+                            <div className="rounded-md border p-3 bg-gray-50 text-sm">
+                                <LatexText text={options[index]?.text || ''} />
+                            </div>
+                        </div>
+
+                        {!options[index]?.isCorrect && (
+                            <Input
+                                placeholder="Misconception (why a student might pick this wrong answer)"
+                                {...register(`options.${index}.misconception`)}
+                            />
+                        )}
+                    </CardContent>
+                </Card>
+            ))}
+        </div>
+    )
+}

--- a/src/components/diagnostic/questionForm/types.ts
+++ b/src/components/diagnostic/questionForm/types.ts
@@ -1,0 +1,125 @@
+import type { DiagnosticQuestionResponse } from '@/client'
+
+export const CORE_SKILLS = ['S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7'] as const
+export const DIFFICULTY_TAGS = ['creative', 'TMUA-stretch'] as const
+
+export type OptionField = {
+    label: string
+    text: string
+    isCorrect: boolean
+    misconception: string
+}
+
+export type DiagnosticQuestionFormValues = {
+    topicCode: string
+    coreSkillPrimary: string
+    coreSkillSecondary: string | null
+    difficultyTag: string | null
+    stem: string
+    options: OptionField[]
+    status: 'draft' | 'published'
+    // Paste-SVG mode. diagramSvgTouched tracks whether the admin interacted
+    // with this field at all this session (typed into it, or clicked
+    // "Remove diagram") — on update, omitting the key entirely (untouched)
+    // must leave the existing diagram alone, which is a different outcome
+    // from sending an explicit empty/null value (which clears it). See
+    // getDiagramSvgForUpdate below — this mirrors the backend's own
+    // omit-vs-explicit-null distinction (UpdateDiagnosticQuestionBody's
+    // diagram_svg, gated by "diagram_svg" in update_data after
+    // exclude_unset) exactly, on the frontend side of the same contract.
+    diagramSvg: string
+    diagramSvgTouched: boolean
+    // Upload-image mode, entirely separate from the JSON body — handled by
+    // the pages via a second request to POST .../{id}/diagram after
+    // create/update succeeds, since a file can't ride along in the same
+    // JSON payload as diagramSvg.
+    diagramFile: File | null
+}
+
+/** Option labels are derived from position (A, B, C…), never free-typed, so a
+ * removed/reordered option can't leave a stale or duplicate label behind. */
+export function labelForIndex(index: number): string {
+    return String.fromCharCode('A'.charCodeAt(0) + index)
+}
+
+export function defaultValues(
+    initialData?: DiagnosticQuestionResponse
+): DiagnosticQuestionFormValues {
+    if (!initialData) {
+        return {
+            topicCode: '',
+            coreSkillPrimary: '',
+            coreSkillSecondary: null,
+            difficultyTag: null,
+            stem: '',
+            options: [
+                { label: 'A', text: '', isCorrect: true, misconception: '' },
+                { label: 'B', text: '', isCorrect: false, misconception: '' },
+            ],
+            status: 'draft',
+            diagramSvg: '',
+            diagramSvgTouched: false,
+            diagramFile: null,
+        }
+    }
+    return {
+        topicCode: initialData.topicCode,
+        coreSkillPrimary: initialData.coreSkillPrimary,
+        coreSkillSecondary: initialData.coreSkillSecondary ?? null,
+        difficultyTag: initialData.difficultyTag ?? null,
+        stem: initialData.stem,
+        options: initialData.options.map((o) => ({
+            label: o.label,
+            text: o.text,
+            isCorrect: o.isCorrect ?? false,
+            misconception: o.misconception ?? '',
+        })),
+        status: initialData.status,
+        diagramSvg: '',
+        diagramSvgTouched: false,
+        diagramFile: null,
+    }
+}
+
+/**
+ * The one place "does this form have exactly one correct option" is
+ * checked. Both the create and edit pages call this before submitting —
+ * previously each had its own inline copy of the same
+ * `.find((o) => o.isCorrect)` check, which is exactly the kind of
+ * duplication that quietly drifts apart the next time either page
+ * changes (the same class of risk as the backend's diagram-upload logic
+ * before it was pulled into _upload_diagram_content).
+ */
+export function getCorrectOptionLabel(
+    values: DiagnosticQuestionFormValues
+): string | null {
+    return values.options.find((o) => o.isCorrect)?.label ?? null
+}
+
+/**
+ * For create: there's no existing diagram to preserve, so the only
+ * question is whether one was provided at all — matches the backend's
+ * own `if body.diagram_svg:` truthiness check on create.
+ */
+export function getDiagramSvgForCreate(
+    values: DiagnosticQuestionFormValues
+): string | undefined {
+    return values.diagramSvg.trim() === '' ? undefined : values.diagramSvg
+}
+
+/**
+ * For update: omitted (untouched) must leave the existing diagram alone,
+ * distinct from an explicit empty value (clears it) — the three-way
+ * distinction the backend's UpdateDiagnosticQuestionBody.diagram_svg
+ * itself enforces via exclude_unset. Returning undefined here means the
+ * caller must NOT include the key in the request body at all (spreading
+ * `{ ...(x !== undefined ? { diagramSvg: x } : {}) }`), not send it as
+ * literally `undefined`, which would serialize away in JSON.stringify
+ * anyway but the distinction matters for callers to get right.
+ */
+export function getDiagramSvgForUpdate(
+    values: DiagnosticQuestionFormValues
+): string | null | undefined {
+    if (!values.diagramSvgTouched) return undefined
+    return values.diagramSvg.trim() === '' ? null : values.diagramSvg
+}


### PR DESCRIPTION
## What
Frontend modularity: the question-authoring form was one **580-line** component mixing the metadata grid, stem, options editor, and diagram field. Split via a shared `FormProvider` context into focused parts:

- `questionForm/types.ts` — form-values type + pure helpers (`defaultValues`, `labelForIndex`, `getCorrectOptionLabel`, `getDiagramSvg{Create,Update}`) + skill/difficulty constants
- `questionForm/QuestionMetaFields.tsx` — topic / status / skill / difficulty grid
- `questionForm/QuestionOptionsEditor.tsx` — options `useFieldArray` + add/remove/mark-correct (positional labels)
- `questionForm/QuestionDiagramField.tsx` — existing diagram / paste-SVG / upload

`DiagnosticQuestionForm.tsx` is now a **117-line composer** that owns the form instance, reset-on-record-change, and submit, and **re-exports the pure helpers** so the create/edit pages and the test import unchanged.

## Impact
- Form file **580 → 117 lines**; four focused modules (~115–156 lines each).
- Behaviour and rendered DOM identical. No API change.

## Verified
- **26 tests pass** (form options behaviour + create/edit page tests) — the options tests exercise the sub-components through the real `FormProvider`.
- **Live**: the create form renders identically; adding an option correctly produced A, B, C through the shared context. Screenshot in thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)