### PR TITLE
Fix diagram images stretching on the admin Set Review page

### DIFF
--- a/src/pages/Admin/Diagnostic/DiagnosticSetReviewPage.tsx
+++ b/src/pages/Admin/Diagnostic/DiagnosticSetReviewPage.tsx
@@ -146,10 +146,15 @@ export function DiagnosticSetReviewPage() {
                             </div>
 
                             {q.diagramUrl && (
+                                // self-start: the img is a direct child of this
+                                // flex-col card, so without it align-items:stretch
+                                // forces the img to full width and object-fit:fill
+                                // then distorts the diagram. object-contain is a
+                                // backstop against any future definite-size box.
                                 <img
                                     src={q.diagramUrl}
                                     alt={`Diagram for question ${index + 1}`}
-                                    className="max-h-64 max-w-full rounded border"
+                                    className="max-h-64 max-w-full self-start rounded border object-contain"
                                 />
                             )}
 


### PR DESCRIPTION
## Problem
On the admin **Set Review** page (`/admin/sets/:id/preview`), every question diagram was rendered horizontally stretched — a near-square 864×826 image displayed at ~3.9:1, so a round coin appeared as a flat oval.

## Root cause
The diagram `<img>` is a **direct child** of the flex-column `CardContent`. The default `align-items: stretch` forces the img to the card's full width; `max-h-64` then caps its height, and the browser default `object-fit: fill` distorts the picture to fill the resulting wide box.

The exam view, student preview, and edit form were unaffected — their diagram imgs sit inside a block wrapper `<div>`, which the stretch doesn't reach.

## Fix
Add `self-start` (so the img keeps its intrinsic width instead of stretching) plus `object-contain` as a backstop.

## Verification
Live measurement with the real image on the running app:

| Structure | Rendered | Ratio |
|---|---|---|
| Source | — | 1.046 |
| Before (`max-h-64 max-w-full`) | 1000×256 | **3.906** |
| After (`+ self-start object-contain`) | 266×254 | 1.047 ✅ |

Source images in storage were confirmed undistorted; the squashing was purely at render time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)