### PR TITLE
Surface bulk-import failures instead of a false success

### DIFF
--- a/src/hooks/diagnostic/useBulkImportDiagnosticQuestionsMutation.test.tsx
+++ b/src/hooks/diagnostic/useBulkImportDiagnosticQuestionsMutation.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import useBulkImportDiagnosticQuestionsMutation from './useBulkImportDiagnosticQuestionsMutation'
+
+const mockImport = vi.fn()
+vi.mock('@/client', () => ({
+    bulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPost: (
+        ...args: unknown[]
+    ) => mockImport(...args),
+}))
+vi.mock('@/lib/authHeaders.ts', () => ({
+    getAuthHeaders: () => ({ Authorization: 'Bearer x' }),
+}))
+
+function wrapper({ children }: { children: ReactNode }) {
+    const client = new QueryClient({
+        defaultOptions: {
+            mutations: { retry: false },
+            queries: { retry: false },
+        },
+    })
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+const body = {
+    diagnosticSet: { title: 'X', timeLimitMinutes: 40, questionOrder: [] },
+    questions: [],
+} as Parameters<
+    ReturnType<typeof useBulkImportDiagnosticQuestionsMutation>['mutate']
+>[0]
+
+describe('useBulkImportDiagnosticQuestionsMutation', () => {
+    beforeEach(() => mockImport.mockReset())
+
+    it('returns the import summary on success', async () => {
+        mockImport.mockResolvedValue({
+            data: { message: 'Imported 27 questions.' },
+            error: undefined,
+            response: { status: 200 },
+        })
+        const { result } = renderHook(
+            () => useBulkImportDiagnosticQuestionsMutation(),
+            { wrapper }
+        )
+        act(() => result.current.mutate(body))
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+        expect(result.current.data).toEqual({ message: 'Imported 27 questions.' })
+    })
+
+    it('rejects (not a false success) when the client resolves an error', async () => {
+        // A pydantic 422: detail is a list, so the fallback message is used.
+        mockImport.mockResolvedValue({
+            data: undefined,
+            error: { detail: [{ loc: ['body', 'questions', 0], msg: 'field required' }] },
+            response: { status: 422 },
+        })
+        const { result } = renderHook(
+            () => useBulkImportDiagnosticQuestionsMutation(),
+            { wrapper }
+        )
+        act(() => result.current.mutate(body))
+        await waitFor(() => expect(result.current.isError).toBe(true))
+        expect(result.current.error?.message).toContain('required schema')
+    })
+
+    it('surfaces a backend string detail verbatim', async () => {
+        mockImport.mockResolvedValue({
+            data: undefined,
+            error: { detail: 'Duplicate sourceRef: q1.' },
+            response: { status: 400 },
+        })
+        const { result } = renderHook(
+            () => useBulkImportDiagnosticQuestionsMutation(),
+            { wrapper }
+        )
+        act(() => result.current.mutate(body))
+        await waitFor(() => expect(result.current.isError).toBe(true))
+        expect(result.current.error?.message).toContain('Duplicate sourceRef')
+    })
+})

--- a/src/hooks/diagnostic/useBulkImportDiagnosticQuestionsMutation.ts
+++ b/src/hooks/diagnostic/useBulkImportDiagnosticQuestionsMutation.ts
@@ -2,18 +2,37 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { bulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPost } from '@/client'
 import type { BulkImportRequest } from '@/client'
 import { getAuthHeaders } from '@/lib/authHeaders.ts'
+import { toDiagnosticApiError } from '@/lib/diagnosticApiError.ts'
 
+/**
+ * Bulk-import questions from a JSON file. Throws on error so the dialog's
+ * onError toast fires with the backend's message instead of a false success —
+ * the generated client resolves { data: undefined, error } on an HTTP error,
+ * so returning `.data` blindly reported a rejected import (e.g. a 422 when the
+ * JSON doesn't match the schema) as "completed successfully". A pydantic 422's
+ * detail is a list, not a string, so it surfaces the fallback; a 400 with a
+ * string detail (unknown correctOption, duplicate sourceRef) surfaces verbatim.
+ */
 export default function useBulkImportDiagnosticQuestionsMutation() {
     const queryClient = useQueryClient()
 
     return useMutation({
-        mutationFn: async (body: BulkImportRequest) =>
-            (
-                await bulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPost({
-                    body,
-                    headers: getAuthHeaders(),
-                })
-            ).data,
+        mutationFn: async (body: BulkImportRequest) => {
+            const result =
+                await bulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPost(
+                    {
+                        body,
+                        headers: getAuthHeaders(),
+                    }
+                )
+            if (result.error !== undefined) {
+                throw toDiagnosticApiError(
+                    result,
+                    'The file did not match the required schema.'
+                )
+            }
+            return result.data
+        },
         onSuccess: () =>
             queryClient.invalidateQueries({ queryKey: ['diagnostic-questions'] }),
     })


### PR DESCRIPTION
## Problem
Uploading a JSON file that the backend rejects (e.g. a **422** when the file doesn't match the schema) showed **"Bulk import completed successfully"** while nothing was imported — the exact confusion behind the earlier "it says it's successful but it doesn't appear" report.

## Root cause
The generated hey-api client does **not** throw on HTTP errors — it resolves `{ data: undefined, error }`. The hook returned `.data` blindly, so a rejected import fell through to `onSuccess`. The dialog already had a correct `onError` toast; it just never fired.

## Fix
Check `result.error` and `throw toDiagnosticApiError(...)`, matching every other diagnostic mutation. Now the dialog's `onError` toast shows the real message:
- **422** (pydantic, `detail` is a list) → `Bulk import failed: The file did not match the required schema.`
- **400** (string `detail`, e.g. unknown `correctOption`, duplicate `sourceRef`) → surfaced verbatim.

## Tests
Added `useBulkImportDiagnosticQuestionsMutation.test.tsx` (success returns summary; 422 rejects with fallback; 400 surfaces detail verbatim). Full run: **5 passed** (3 new + 2 existing dialog tests), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)