### PR TITLE
New IA: goal-based landing fork + exam pickers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ import { VerificationPage } from '@/pages/Auth/VerificationPage.tsx'
 import { MoreInfoFormPage } from '@/pages/Auth/MoreInfoFormPage.tsx'
 import { useEffect } from 'react'
 import { LandingPage } from '@/pages/LandingPage.tsx'
+import { RevisionPickerPage } from '@/pages/RevisionPickerPage.tsx'
+import { AdmissionsPickerPage } from '@/pages/AdmissionsPickerPage.tsx'
 import SubjectsPage from '@/pages/SubjectsPage.tsx'
 import { QuizGeneratorPage } from '@/pages/v3/QuizGeneratorPage.tsx'
 import { QuizPage } from './components/questionBank/v3/Quiz'
@@ -60,6 +62,11 @@ function App() {
         <>
             <Routes>
                 <Route path="" element={<LandingPage />} />
+                <Route path="revision" element={<RevisionPickerPage />} />
+                <Route
+                    path="admissions"
+                    element={<AdmissionsPickerPage />}
+                />
                 <Route path="about" element={<AboutPage />} />
                 <Route path="esat-tmua" element={<EsatTmuaPage />} />
                 <Route path="diagnostics" element={<DiagnosticsCatalogPage />} />

--- a/src/components/layout/landing/LandingHeader.tsx
+++ b/src/components/layout/landing/LandingHeader.tsx
@@ -1,31 +1,30 @@
 import { Button } from '@/components/ui/button.tsx'
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/components/auth/AuthContext.tsx'
-import { useGetSubjectsLink } from '@/components/routing/useGetSubjectsLink.ts'
-import { useMemo } from 'react'
+
+/**
+ * Public-site header. The menu mirrors the goal fork on the landing page —
+ * one entry per track (Revision, Admissions) plus About — so a visitor can
+ * jump straight to their track's exam picker from anywhere.
+ */
+const MENU_ITEMS: { text: string; link: string }[] = [
+    {
+        text: 'Revision',
+        link: '/revision',
+    },
+    {
+        text: 'Admissions',
+        link: '/admissions',
+    },
+    {
+        text: 'About',
+        link: '/about',
+    },
+]
 
 export function LandingHeader() {
     const navigate = useNavigate()
     const { user } = useAuth()
-    const subjectLink = useGetSubjectsLink()
-
-    const MENU_ITEMS: { text: string; link: string }[] = useMemo(
-        () => [
-            {
-                text: 'Subjects',
-                link: subjectLink,
-            },
-            {
-                text: 'ESAT & TMUA',
-                link: '/esat-tmua',
-            },
-            {
-                text: 'About',
-                link: '/about',
-            },
-        ],
-        [subjectLink]
-    )
 
     return (
         <div className="flex px-2 md:px-12 py-4 md:py-8 items-center justify-between">

--- a/src/pages/AdmissionsPickerPage.tsx
+++ b/src/pages/AdmissionsPickerPage.tsx
@@ -1,0 +1,103 @@
+import { LandingLayout } from '@/components/layout/landing/LandingLayout.tsx'
+import { Link, useNavigate } from 'react-router-dom'
+import { Button } from '@/components/ui/button.tsx'
+import { useEffect } from 'react'
+
+/**
+ * Step 1 of the admissions track: pick your test. ESAT is live; TMUA and
+ * further tests are signposted as roadmap so the catalogue reads as
+ * ambition, not absence. New tests are added here, never as new doors on
+ * the landing fork.
+ */
+export function AdmissionsPickerPage() {
+    const navigate = useNavigate()
+
+    useEffect(() => {
+        document.title = 'Choose Your Test | JomExam Admissions'
+    }, [])
+
+    return (
+        <LandingLayout>
+            <div className="px-4 md:px-[50px] xl:px-[150px] py-12 md:py-20 max-w-5xl">
+                <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-4">
+                    Admissions · step 1 of 2
+                </p>
+
+                <p className="text-3xl md:text-5xl font-bold mb-4 leading-tight">
+                    Which test are you preparing for?
+                </p>
+
+                <p className="text-sm md:text-lg text-slate-500 mb-10 max-w-2xl">
+                    Each test gets its own diagnostics, skills report and
+                    catalogue.
+                </p>
+
+                <div className="grid md:grid-cols-3 gap-6">
+                    {/* ESAT — live */}
+                    <div className="border border-slate-200 rounded-xl p-6 bg-white flex flex-col hover:shadow-xl hover:scale-[1.02] transition-all">
+                        <div className="flex items-center gap-3 mb-2">
+                            <p className="text-lg font-bold">ESAT</p>
+                            <span className="text-xs font-medium bg-emerald-50 text-emerald-700 px-2.5 py-0.5 rounded-full border border-emerald-200">
+                                Live
+                            </span>
+                        </div>
+                        <p className="text-slate-500 text-sm leading-relaxed mb-6 flex-1">
+                            Engineering and Science Admissions Test — Cambridge,
+                            Imperial and others. Diagnostics live now.
+                        </p>
+                        <Button
+                            className="cursor-pointer w-full"
+                            onClick={() => navigate('/esat-tmua')}
+                        >
+                            Enter ESAT →
+                        </Button>
+                    </div>
+
+                    {/* TMUA — coming soon */}
+                    <div className="border border-slate-200 rounded-xl p-6 bg-white flex flex-col opacity-70">
+                        <div className="flex items-center gap-3 mb-2">
+                            <p className="text-lg font-bold">TMUA</p>
+                            <span className="text-xs font-medium bg-amber-100 text-amber-700 px-2.5 py-0.5 rounded-full border border-amber-200">
+                                Coming soon
+                            </span>
+                        </div>
+                        <p className="text-slate-500 text-sm leading-relaxed mb-6 flex-1">
+                            Test of Mathematics for University Admission —
+                            Cambridge, LSE, Warwick, Durham, Bath.
+                        </p>
+                        <p className="text-xs text-slate-400 font-medium">
+                            In development
+                        </p>
+                    </div>
+
+                    {/* Roadmap */}
+                    <div className="border border-slate-200 rounded-xl p-6 bg-white flex flex-col opacity-70">
+                        <div className="flex items-center gap-3 mb-2">
+                            <p className="text-lg font-bold">More tests</p>
+                            <span className="text-xs font-medium bg-amber-100 text-amber-700 px-2.5 py-0.5 rounded-full border border-amber-200">
+                                Roadmap
+                            </span>
+                        </div>
+                        <p className="text-slate-500 text-sm leading-relaxed mb-6 flex-1">
+                            MAT, STEP and PAT are on the roadmap as the
+                            diagnostic engine grows.
+                        </p>
+                        <p className="text-xs text-slate-400 font-medium">
+                            Planned
+                        </p>
+                    </div>
+                </div>
+
+                <p className="text-sm text-slate-500 mt-10">
+                    Just revising your curriculum?{' '}
+                    <Link
+                        to="/revision"
+                        className="font-semibold text-green-700 underline underline-offset-4"
+                    >
+                        Switch to exam revision →
+                    </Link>
+                </p>
+            </div>
+        </LandingLayout>
+    )
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,225 +1,150 @@
 import { LandingLayout } from '@/components/layout/landing/LandingLayout.tsx'
-import { Button } from '@/components/ui/button.tsx'
-import { Link, useNavigate } from 'react-router-dom'
-import SubjectsPage from '@/pages/SubjectsPage.tsx'
+import { Link } from 'react-router-dom'
+import { useEffect } from 'react'
 
+const PERIWINKLE = '#799ED1'
+
+/**
+ * The front door is a goal fork, not an exam list: a visitor tells us where
+ * they're headed (curriculum revision vs university admissions) and every
+ * screen after is scoped to that goal. New exams join the pickers behind
+ * these two doors — the fork itself never grows.
+ */
 export function LandingPage() {
-    const navigate = useNavigate()
+    useEffect(() => {
+        document.title =
+            'JomExam — STEM Exam Prep, from SPM to University Admissions'
+    }, [])
 
     return (
         <LandingLayout>
-
-            {/* ── HERO ── */}
-            <div className="px-4 md:px-[50px] xl:px-[150px] mt-4 md:mt-10 w-full">
-                <div className="flex flex-col justify-center w-full">
-
-                    {/* Eyebrow pill */}
-                    <div className="mb-5">
-                        <span className="inline-block bg-slate-100 text-slate-600 text-xs md:text-sm font-medium px-4 py-1.5 rounded-full border border-slate-200">
-                            Free exam prep — no sign-up required
-                        </span>
-                    </div>
-
-                    {/* Heading */}
-                    <p className="text-3xl md:text-6xl font-bold mb-4 leading-tight">
-                        Practise smarter.<br />
-                        <span style={{ color: '#799ED1' }}>
-                            Know where to focus.
-                        </span>
-                    </p>
-
-                    {/* Subtext */}
-                    <p className="text-sm md:text-lg text-slate-500 mb-6 md:mb-10 max-w-2xl">
-                        Free diagnostic questions for SPM, ESAT and TMUA —
-                        organised by topic and skill, so you drill exactly what
-                        you need. Expert one-to-one tutoring also available.
-                    </p>
-
-                    {/* CTAs + illustration */}
-                    <div className="flex flex-col md:flex-row md:items-start gap-4">
-                        <div className="flex flex-col sm:flex-row gap-3 md:pt-2">
-                            <Button
-                                className="xl:py-6 cursor-pointer"
-                                onClick={() => navigate('subjects')}
-                            >
-                                Start practising free
-                            </Button>
-                            <Button
-                                variant="outline"
-                                className="xl:py-6 cursor-pointer"
-                                onClick={() => navigate('/about')}
-                            >
-                                Work with Hazel ↗
-                            </Button>
-                        </div>
-                        <img
-                            className="md:w-[700px] xl:w-[900px]"
-                            src="/hero.png"
-                            alt="Student studying for exams"
-                        />
-                    </div>
+            <div className="px-4 md:px-[50px] xl:px-[150px] py-10 md:py-16 w-full">
+                {/* Eyebrow */}
+                <div className="mb-5">
+                    <span className="inline-block bg-slate-100 text-slate-600 text-xs md:text-sm font-medium px-4 py-1.5 rounded-full border border-slate-200">
+                        STEM exam prep — pick your goal
+                    </span>
                 </div>
-            </div>
 
-            {/* ── CHOOSE YOUR TRACK ── */}
-            <div className="px-4 md:px-[50px] xl:px-[150px] mt-12 md:mt-16 w-full">
-                <h2 className="text-2xl md:text-3xl font-bold mb-6">Choose your track</h2>
-                <div className="grid md:grid-cols-2 gap-6">
+                {/* Heading */}
+                <p className="text-3xl md:text-6xl font-bold mb-4 leading-tight">
+                    Every step of STEM,
+                    <br />
+                    <span style={{ color: PERIWINKLE }}>up to admissions.</span>
+                </p>
 
-                    {/* SPM card */}
-                    <Link to="/subjects">
-                        <div className="h-full border border-slate-200 rounded-xl p-6 bg-white hover:shadow-xl hover:scale-[1.02] transition-all cursor-pointer group">
-                            <div className="text-3xl mb-4">📚</div>
-                            <div className="flex items-center gap-3 mb-2">
-                                <p className="text-xl font-bold">SPM</p>
-                                <span className="text-xs font-medium bg-green-100 text-green-700 px-2.5 py-0.5 rounded-full border border-green-200">
-                                    Free forever
-                                </span>
-                            </div>
-                            <p className="text-slate-500 text-sm leading-relaxed mb-4">
-                                Free practice questions across Mathematics, Add
-                                Maths, Science and more — organised by topic and
-                                difficulty.
-                            </p>
-                            <div className="flex items-center text-slate-400 group-hover:text-slate-700 transition-colors text-sm font-medium">
-                                Browse subjects →
+                <p className="text-sm md:text-lg text-slate-500 mb-8 md:mb-12 max-w-2xl">
+                    From SPM revision to A-Level and IB practice, to the
+                    admissions tests for the world&apos;s top STEM courses.
+                    Pick your goal — everything you see after is scoped to it.
+                </p>
+
+                {/* The two doors */}
+                <div className="grid md:grid-cols-2 gap-6 max-w-5xl">
+                    <Link to="/revision">
+                        <div className="h-full border border-slate-200 rounded-xl bg-white overflow-hidden hover:shadow-xl hover:scale-[1.02] transition-all cursor-pointer group">
+                            <div className="h-1 bg-green-600" />
+                            <div className="p-6 md:p-8 flex flex-col h-full">
+                                <p className="text-xl md:text-2xl font-bold mb-1">
+                                    Revise my exams
+                                </p>
+                                <p className="text-xs font-medium text-slate-400 uppercase tracking-widest mb-4">
+                                    Curriculum · SPM / A-Level / IB
+                                </p>
+                                <p className="text-slate-500 text-sm leading-relaxed mb-4">
+                                    Master your syllabus topic by topic, with a
+                                    question bank scoped to your exact exam.
+                                </p>
+                                <ul className="text-sm text-slate-600 flex flex-col gap-2 mb-6">
+                                    <li className="flex gap-2">
+                                        <span className="text-green-600">→</span>
+                                        SPM Maths &amp; Add Maths — live now
+                                    </li>
+                                    <li className="flex gap-2">
+                                        <span className="text-green-600">→</span>
+                                        A-Level &amp; IB Maths — coming soon
+                                    </li>
+                                    <li className="flex gap-2">
+                                        <span className="text-green-600">→</span>
+                                        Practise by topic, at your own pace
+                                    </li>
+                                </ul>
+                                <div className="mt-auto flex items-center text-green-700 group-hover:translate-x-1 transition-transform text-sm font-semibold">
+                                    Choose your exam →
+                                </div>
                             </div>
                         </div>
                     </Link>
 
-                    {/* ESAT & TMUA card */}
-                    <Link to="/esat-tmua">
-                        <div className="h-full border border-slate-200 rounded-xl p-6 bg-white hover:shadow-xl hover:scale-[1.02] transition-all cursor-pointer group">
-                            <div className="text-3xl mb-4">🎯</div>
-                            <div className="flex items-center gap-3 mb-2">
-                                <p className="text-xl font-bold">ESAT & TMUA</p>
-                                <span className="text-xs font-medium bg-amber-100 text-amber-700 px-2.5 py-0.5 rounded-full border border-amber-200">
-                                    New
-                                </span>
-                            </div>
-                            <p className="text-slate-500 text-sm leading-relaxed mb-4">
-                                Diagnostic questions mapped to specific skills —
-                                for students targeting Cambridge, Imperial, LSE
-                                and beyond.
-                            </p>
-                            <div className="flex items-center text-slate-400 group-hover:text-slate-700 transition-colors text-sm font-medium">
-                                Explore questions →
-                            </div>
-                        </div>
-                    </Link>
-                </div>
-            </div>
-
-            {/* ── ESAT & TMUA SECTION ── */}
-            <div className="px-4 md:px-[50px] xl:px-[150px] mt-12 md:mt-16 w-full">
-                <div className="bg-slate-50 border border-slate-100 rounded-2xl p-8 md:p-12">
-                    <h2 className="text-2xl md:text-3xl font-bold mb-3">
-                        ESAT & TMUA preparation
-                    </h2>
-                    <p className="text-slate-500 text-sm md:text-base mb-8 max-w-2xl leading-relaxed">
-                        Free diagnostic questions built around the actual skills
-                        these tests examine — not just past papers. Understand
-                        exactly where you stand before you start preparing.
-                    </p>
-
-                    <div className="grid md:grid-cols-2 gap-6 mb-8">
-                        {/* ESAT */}
-                        <div className="bg-white border border-slate-200 rounded-xl p-6">
-                            <p className="text-lg font-bold mb-2">ESAT</p>
-                            <p className="text-slate-600 text-sm leading-relaxed mb-3">
-                                Engineering and Science Admissions Test. Covers
-                                Mathematics, Physics, Chemistry and Biology
-                                modules.
-                            </p>
-                            <p className="text-xs text-slate-400 font-medium">
-                                Cambridge · Imperial · and others
-                            </p>
-                        </div>
-
-                        {/* TMUA */}
-                        <div className="bg-white border border-slate-200 rounded-xl p-6">
-                            <p className="text-lg font-bold mb-2">TMUA</p>
-                            <p className="text-slate-600 text-sm leading-relaxed mb-3">
-                                Test of Mathematics for University Admission.
-                                Tests mathematical reasoning in novel
-                                applications.
-                            </p>
-                            <p className="text-xs text-slate-400 font-medium">
-                                Cambridge · LSE · Warwick · Durham
-                            </p>
-                        </div>
-                    </div>
-
-                    <div className="flex flex-col sm:flex-row gap-3">
-                        <Button
-                            className="cursor-pointer"
-                            onClick={() => navigate('/esat-tmua')}
-                        >
-                            Try free questions
-                        </Button>
-                        <Button
-                            variant="ghost"
-                            className="cursor-pointer"
-                            onClick={() => navigate('/about')}
-                        >
-                            Get one-to-one tutoring →
-                        </Button>
-                    </div>
-                </div>
-            </div>
-
-            {/* ── HAZEL TUTORING STRIP ── */}
-            <div className="px-4 md:px-[50px] xl:px-[150px] mt-12 md:mt-16 w-full">
-                <div
-                    className="rounded-2xl p-8 md:p-12 flex flex-col md:flex-row md:items-center justify-between gap-8"
-                    style={{ backgroundColor: '#1a1f2e' }}
-                >
-                    <div className="flex-1">
-                        <h2 className="text-2xl md:text-3xl font-bold text-white mb-3">
-                            One-to-one tutoring with Hazel
-                        </h2>
-                        <p className="text-slate-400 text-sm md:text-base leading-relaxed mb-6 max-w-xl">
-                            Oxford-trained. 5,000+ hours of online teaching.
-                            Diagnostic-first — every student starts with a
-                            skills assessment so sessions target exactly the
-                            right gaps.
-                        </p>
-                        <div className="flex flex-wrap gap-2">
-                            {[
-                                'DPhil Engineering, Oxford',
-                                'First Class, Engineering Science, Oxford',
-                                'A-Level · IB · ESAT · TMUA',
-                            ].map((pill) => (
-                                <span
-                                    key={pill}
-                                    className="text-xs text-slate-300 border border-slate-600 px-3 py-1 rounded-full"
+                    <Link to="/admissions">
+                        <div className="h-full border border-slate-200 rounded-xl bg-white overflow-hidden hover:shadow-xl hover:scale-[1.02] transition-all cursor-pointer group">
+                            <div
+                                className="h-1"
+                                style={{ backgroundColor: PERIWINKLE }}
+                            />
+                            <div className="p-6 md:p-8 flex flex-col h-full">
+                                <p className="text-xl md:text-2xl font-bold mb-1">
+                                    Get into a top university
+                                </p>
+                                <p className="text-xs font-medium text-slate-400 uppercase tracking-widest mb-4">
+                                    Admissions tests · ESAT / TMUA
+                                </p>
+                                <p className="text-slate-500 text-sm leading-relaxed mb-4">
+                                    Timed diagnostics mapped to the exact skills
+                                    these tests examine — sit one and see
+                                    precisely where you stand.
+                                </p>
+                                <ul className="text-sm text-slate-600 flex flex-col gap-2 mb-6">
+                                    <li className="flex gap-2">
+                                        <span style={{ color: PERIWINKLE }}>
+                                            →
+                                        </span>
+                                        For Cambridge, Imperial, LSE, Warwick
+                                        &amp; more
+                                    </li>
+                                    <li className="flex gap-2">
+                                        <span style={{ color: PERIWINKLE }}>
+                                            →
+                                        </span>
+                                        Skills report, not just a score
+                                    </li>
+                                    <li className="flex gap-2">
+                                        <span style={{ color: PERIWINKLE }}>
+                                            →
+                                        </span>
+                                        One-to-one tutoring with an Oxford DPhil
+                                    </li>
+                                </ul>
+                                <div
+                                    className="mt-auto flex items-center group-hover:translate-x-1 transition-transform text-sm font-semibold"
+                                    style={{ color: PERIWINKLE }}
                                 >
-                                    {pill}
-                                </span>
-                            ))}
+                                    Choose your test →
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                    <div className="flex-shrink-0">
-                        <Button
-                            className="bg-white text-slate-900 hover:bg-slate-100 cursor-pointer font-medium"
-                            onClick={() => navigate('/about')}
-                        >
-                            Meet Hazel →
-                        </Button>
-                    </div>
+                    </Link>
                 </div>
-            </div>
 
-            {/* ── SPM SUBJECTS SECTION ── */}
-            <div className="mt-12 md:mt-16 w-full">
-                <div className="px-4 md:px-[50px] xl:px-[150px] mb-2">
-                    <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest">
-                        SPM Practice
-                    </p>
-                </div>
-                <SubjectsPage embedded />
+                {/* Undecided escape hatch */}
+                <p className="text-sm text-slate-500 mt-8">
+                    Not sure yet?{' '}
+                    <Link
+                        to="/esat-tmua"
+                        className="font-semibold text-slate-700 underline underline-offset-4 hover:text-slate-900"
+                    >
+                        See how diagnostics work
+                    </Link>{' '}
+                    or{' '}
+                    <Link
+                        to="/revision"
+                        className="font-semibold text-slate-700 underline underline-offset-4 hover:text-slate-900"
+                    >
+                        browse revision exams
+                    </Link>
+                    .
+                </p>
             </div>
-
         </LandingLayout>
     )
 }

--- a/src/pages/RevisionPickerPage.tsx
+++ b/src/pages/RevisionPickerPage.tsx
@@ -1,0 +1,105 @@
+import { LandingLayout } from '@/components/layout/landing/LandingLayout.tsx'
+import { Link, useNavigate } from 'react-router-dom'
+import { Button } from '@/components/ui/button.tsx'
+import { useEffect } from 'react'
+
+/**
+ * Step 1 of the revision track: pick your curriculum. Only SPM is live —
+ * A-Level and IB are signposted as coming soon so the catalogue reads as a
+ * roadmap, not a gap. New curricula are added here, never as new doors on
+ * the landing fork.
+ */
+export function RevisionPickerPage() {
+    const navigate = useNavigate()
+
+    useEffect(() => {
+        document.title = 'Choose Your Exam | JomExam Revision'
+    }, [])
+
+    return (
+        <LandingLayout>
+            <div className="px-4 md:px-[50px] xl:px-[150px] py-12 md:py-20 max-w-5xl">
+                <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-4">
+                    Revision · step 1 of 2
+                </p>
+
+                <p className="text-3xl md:text-5xl font-bold mb-4 leading-tight">
+                    Which exam are you revising for?
+                </p>
+
+                <p className="text-sm md:text-lg text-slate-500 mb-10 max-w-2xl">
+                    Everything after this — subjects, topics, progress — is
+                    scoped to your exam.
+                </p>
+
+                <div className="grid md:grid-cols-3 gap-6">
+                    {/* SPM — live */}
+                    <div className="border border-slate-200 rounded-xl p-6 bg-white flex flex-col hover:shadow-xl hover:scale-[1.02] transition-all">
+                        <div className="flex items-center gap-3 mb-2">
+                            <p className="text-lg font-bold">SPM</p>
+                            <span className="text-xs font-medium bg-green-100 text-green-700 px-2.5 py-0.5 rounded-full border border-green-200">
+                                Live
+                            </span>
+                        </div>
+                        <p className="text-slate-500 text-sm leading-relaxed mb-6 flex-1">
+                            Malaysian secondary, Form 4–5. Mathematics and
+                            Additional Mathematics live now; sciences on the
+                            way.
+                        </p>
+                        <Button
+                            className="cursor-pointer w-full"
+                            onClick={() => navigate('/subjects')}
+                        >
+                            Enter SPM →
+                        </Button>
+                    </div>
+
+                    {/* A-Level — coming soon */}
+                    <div className="border border-slate-200 rounded-xl p-6 bg-white flex flex-col opacity-70">
+                        <div className="flex items-center gap-3 mb-2">
+                            <p className="text-lg font-bold">A-Level</p>
+                            <span className="text-xs font-medium bg-amber-100 text-amber-700 px-2.5 py-0.5 rounded-full border border-amber-200">
+                                Coming soon
+                            </span>
+                        </div>
+                        <p className="text-slate-500 text-sm leading-relaxed mb-6 flex-1">
+                            Cambridge, Edexcel and AQA STEM subjects —
+                            Mathematics first, in development now.
+                        </p>
+                        <p className="text-xs text-slate-400 font-medium">
+                            In development
+                        </p>
+                    </div>
+
+                    {/* IB — coming soon */}
+                    <div className="border border-slate-200 rounded-xl p-6 bg-white flex flex-col opacity-70">
+                        <div className="flex items-center gap-3 mb-2">
+                            <p className="text-lg font-bold">IB Diploma</p>
+                            <span className="text-xs font-medium bg-amber-100 text-amber-700 px-2.5 py-0.5 rounded-full border border-amber-200">
+                                Coming soon
+                            </span>
+                        </div>
+                        <p className="text-slate-500 text-sm leading-relaxed mb-6 flex-1">
+                            Math AA and AI at SL and HL — planned after A-Level
+                            Mathematics.
+                        </p>
+                        <p className="text-xs text-slate-400 font-medium">
+                            Planned
+                        </p>
+                    </div>
+                </div>
+
+                <p className="text-sm text-slate-500 mt-10">
+                    Preparing for university admissions instead?{' '}
+                    <Link
+                        to="/admissions"
+                        className="font-semibold underline underline-offset-4"
+                        style={{ color: '#4E77B4' }}
+                    >
+                        Switch to admissions tests →
+                    </Link>
+                </p>
+            </div>
+        </LandingLayout>
+    )
+}


### PR DESCRIPTION
## What this is
First slice of the approved redesign (per the interactive mockup): the public site now routes visitors by **goal**, not by exam — so SPM students and admissions students each get their own journey instead of one blended scroll.

## Changes
- **`/` (landing)** — replaced the blended landing (hero + track cards + ESAT section + tutoring strip + full SPM subject grid) with a clean two-door goal fork:
  - *Revise my exams* (Curriculum · SPM / A-Level / IB, green) → `/revision`
  - *Get into a top university* (Admissions tests · ESAT / TMUA, periwinkle) → `/admissions`
- **`/revision`** (new) — curriculum picker: SPM live → `/subjects`; A-Level and IB as coming-soon cards. Cross-links to the admissions track.
- **`/admissions`** (new) — test picker: ESAT live → `/esat-tmua`; TMUA coming soon; MAT/STEP/PAT roadmap card. Cross-links to revision.
- **Header menu** — `Subjects / ESAT & TMUA / About` → `Revision / Admissions / About`, mirroring the fork.

No existing route was removed — `/subjects`, `/esat-tmua`, `/diagnostics`, `/about` all untouched, so no deep links break. The fork never grows: future exams join the pickers.

## Verification
- `tsc --noEmit` clean; **250/250 tests pass** (49 files).
- Live-verified in the browser: fork renders (desktop + mobile stack), both pickers render with correct live/coming-soon states, header menu updated, and *Enter SPM* → `/subjects` shows the subject grid.
- Only console error is the pre-existing logged-out `current-user` query noise (present on main).

## Out of scope (follow-ups)
- Track-scoped headers on `/subjects` and `/esat-tmua` (the "Exam: SPM · switch" chip from the mockup).
- Copy cleanup on `/esat-tmua` (still says "free"; the new pages avoid pricing language per the mockup decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)