### PR TITLE
SEO follow-up: tags for the fork landing + exam pickers

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -4,6 +4,12 @@
     <loc>https://www.jomexam.com/</loc>
   </url>
   <url>
+    <loc>https://www.jomexam.com/revision</loc>
+  </url>
+  <url>
+    <loc>https://www.jomexam.com/admissions</loc>
+  </url>
+  <url>
     <loc>https://www.jomexam.com/esat-tmua</loc>
   </url>
   <url>

--- a/src/pages/AdmissionsPickerPage.tsx
+++ b/src/pages/AdmissionsPickerPage.tsx
@@ -1,7 +1,7 @@
 import { LandingLayout } from '@/components/layout/landing/LandingLayout.tsx'
 import { Link, useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button.tsx'
-import { useEffect } from 'react'
+import { Seo } from '@/components/Seo.tsx'
 
 /**
  * Step 1 of the admissions track: pick your test. ESAT is live; TMUA and
@@ -12,12 +12,13 @@ import { useEffect } from 'react'
 export function AdmissionsPickerPage() {
     const navigate = useNavigate()
 
-    useEffect(() => {
-        document.title = 'Choose Your Test | JomExam Admissions'
-    }, [])
-
     return (
         <LandingLayout>
+            <Seo
+                title="Choose Your Test | JomExam Admissions"
+                description="Pick your admissions test — ESAT diagnostics live now for Cambridge and Imperial applicants; TMUA coming soon. Timed papers with a skills report, not just a score."
+                path="/admissions"
+            />
             <div className="px-4 md:px-[50px] xl:px-[150px] py-12 md:py-20 max-w-5xl">
                 <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-4">
                     Admissions · step 1 of 2

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,6 +1,6 @@
 import { LandingLayout } from '@/components/layout/landing/LandingLayout.tsx'
 import { Link } from 'react-router-dom'
-import { useEffect } from 'react'
+import { Seo } from '@/components/Seo.tsx'
 
 const PERIWINKLE = '#799ED1'
 
@@ -11,13 +11,13 @@ const PERIWINKLE = '#799ED1'
  * these two doors — the fork itself never grows.
  */
 export function LandingPage() {
-    useEffect(() => {
-        document.title =
-            'JomExam — STEM Exam Prep, from SPM to University Admissions'
-    }, [])
-
     return (
         <LandingLayout>
+            <Seo
+                title="JomExam — STEM Exam Prep: ESAT Diagnostics & SPM Practice"
+                description="STEM exam prep from SPM to university admissions. Sit timed ESAT diagnostics mapped to real exam skills, get a skills report, and practise SPM Maths by topic."
+                path="/"
+            />
             <div className="px-4 md:px-[50px] xl:px-[150px] py-10 md:py-16 w-full">
                 {/* Eyebrow */}
                 <div className="mb-5">

--- a/src/pages/RevisionPickerPage.tsx
+++ b/src/pages/RevisionPickerPage.tsx
@@ -1,7 +1,7 @@
 import { LandingLayout } from '@/components/layout/landing/LandingLayout.tsx'
 import { Link, useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button.tsx'
-import { useEffect } from 'react'
+import { Seo } from '@/components/Seo.tsx'
 
 /**
  * Step 1 of the revision track: pick your curriculum. Only SPM is live —
@@ -12,12 +12,13 @@ import { useEffect } from 'react'
 export function RevisionPickerPage() {
     const navigate = useNavigate()
 
-    useEffect(() => {
-        document.title = 'Choose Your Exam | JomExam Revision'
-    }, [])
-
     return (
         <LandingLayout>
+            <Seo
+                title="Choose Your Exam | JomExam Revision"
+                description="Pick your curriculum — SPM live now with Mathematics and Add Maths, A-Level and IB Maths coming soon. Practice scoped to your exact exam, organised by topic."
+                path="/revision"
+            />
             <div className="px-4 md:px-[50px] xl:px-[150px] py-12 md:py-20 max-w-5xl">
                 <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-4">
                     Revision · step 1 of 2


### PR DESCRIPTION
The small follow-up promised in #39, now that #38 (fork IA) and #39 (SEO tier 1) have both merged:

- `<Seo>` (title, description, canonical, OG) on `/`, `/revision` and `/admissions`, replacing their bare `document.title` effects
- `/revision` + `/admissions` added to `sitemap.xml` (now 7 URLs)

## Verification
`tsc` clean · 250/250 tests pass · all three routes verified in-browser setting unique title/description/canonical on route change.

This completes SEO tier 1 coverage: every public route now has unique per-page tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)