### PR TITLE
Open the SPM v2 quiz to logged-out students

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,15 +75,20 @@ function App() {
                     path="questions/:subjectId"
                     element={<QuestionBankPage />}
                 />
+                {/* The SPM quiz is open like the v1 bank: the flow is
+                    read-only (answers checked client-side, no progress
+                    saved), so a login wall here was pure friction. Login
+                    still gates everything that writes — quizzes that save,
+                    and all diagnostic attempts. */}
+                <Route
+                    path="questions/v2/:subjectId"
+                    element={<QuizGeneratorPage />}
+                />
+                <Route
+                    path="questions/v2/:subjectId/quiz"
+                    element={<QuizPage />}
+                />
                 <Route element={<StudentProtectedRoute />}>
-                    <Route
-                        path="questions/v2/:subjectId"
-                        element={<QuizGeneratorPage />}
-                    />
-                    <Route
-                        path="questions/v2/:subjectId/quiz"
-                        element={<QuizPage />}
-                    />
                     <Route
                         path="diagnostic/sets/:setId"
                         element={<SetInstructionsPage />}


### PR DESCRIPTION
## Problem
The two SPM subject cards led to inconsistent experiences: **Add Math** → the v1 question bank (public), **Mathematics** → the v2 quiz generator (login-walled). A logged-out student could drill one subject but hit a login redirect on the other — an artifact of the v1→v2 migration, not a decision.

## Why un-gating is safe
The v2 flow is read-only end to end, verified in code and live:
- Questions come from the paginated endpoint (auth **optional**, returns 200 with no/empty token)
- Options come from a public endpoint (200 without token)
- Answers are checked client-side; nothing is persisted — the only auth-required endpoint (`POST /questions/set-status`) is never called by the v3 quiz components (the `setQuestionStatus` in Quiz.tsx is local React state)

## Change
Move `questions/v2/:subjectId` and `questions/v2/:subjectId/quiz` out of `StudentProtectedRoute` (one file). Diagnostic attempts/exams/reports remain gated — enforced server-side, not just in the router.

## Verification (logged out, token cleared)
- `/questions/v2/…` renders the generator (topic/level form) — no login redirect
- `/questions/v2/…/quiz` loads a real quiz: question, A–D options, progress, navigation
- `/questions/…` (v1 bank) unchanged, still public
- `/diagnostic/sets/…` still redirects to `/auth/login` ✓
- `tsc` clean · 250/250 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)