### PR TITLE
Unify SPM practice on the question bank

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from 'react-router-dom'
+import { Navigate, Route, Routes, useParams } from 'react-router-dom'
 import { QuestionBankPage } from '@/pages/QuestionBankPage.tsx'
 import { QuestionManagerPage } from '@/pages/Admin/QuestionManagerPage.tsx'
 import { SandboxPage } from '@/pages/SandboxPage.tsx'
@@ -18,8 +18,6 @@ import { LandingPage } from '@/pages/LandingPage.tsx'
 import { RevisionPickerPage } from '@/pages/RevisionPickerPage.tsx'
 import { AdmissionsPickerPage } from '@/pages/AdmissionsPickerPage.tsx'
 import SubjectsPage from '@/pages/SubjectsPage.tsx'
-import { QuizGeneratorPage } from '@/pages/v3/QuizGeneratorPage.tsx'
-import { QuizPage } from './components/questionBank/v3/Quiz'
 import { AboutPage } from '@/pages/AboutPage.tsx'
 import { EsatTmuaPage } from '@/pages/EsatTmuaPage.tsx'
 import { DiagnosticsCatalogPage } from '@/pages/DiagnosticsCatalogPage.tsx'
@@ -37,6 +35,16 @@ import { DiagnosticQuestionEditPage } from '@/pages/Admin/Diagnostic/DiagnosticQ
 import { SetInstructionsPage } from '@/pages/Diagnostic/SetInstructionsPage.tsx'
 import { ExamPage } from '@/pages/Diagnostic/ExamPage.tsx'
 import { DiagnosticReportPage } from '@/pages/Diagnostic/DiagnosticReportPage.tsx'
+
+/** The v2 quiz routes are retired: the guided-quiz UI only works for
+ * subjects with authored MCQ options (Modern Maths: 507/513; Add Math:
+ * 0/560), so the browsable bank is the one SPM experience. Old links and
+ * bookmarks land on the bank for the same subject. The v3 quiz components
+ * stay in the tree, parked for the future drill tier. */
+function LegacyQuizRedirect() {
+    const { subjectId } = useParams()
+    return <Navigate to={`/questions/${subjectId}`} replace />
+}
 
 function App() {
     useEffect(() => {
@@ -75,18 +83,13 @@ function App() {
                     path="questions/:subjectId"
                     element={<QuestionBankPage />}
                 />
-                {/* The SPM quiz is open like the v1 bank: the flow is
-                    read-only (answers checked client-side, no progress
-                    saved), so a login wall here was pure friction. Login
-                    still gates everything that writes — quizzes that save,
-                    and all diagnostic attempts. */}
                 <Route
                     path="questions/v2/:subjectId"
-                    element={<QuizGeneratorPage />}
+                    element={<LegacyQuizRedirect />}
                 />
                 <Route
                     path="questions/v2/:subjectId/quiz"
-                    element={<QuizPage />}
+                    element={<LegacyQuizRedirect />}
                 />
                 <Route element={<StudentProtectedRoute />}>
                     <Route

--- a/src/pages/SubjectsPage.tsx
+++ b/src/pages/SubjectsPage.tsx
@@ -36,7 +36,7 @@ interface Subject {
 export const subjectsPage: Subject[] = [
     {
         id: '8d4a1938-789f-4c57-96b2-1c079941a59e',
-        url: '/questions/v2/8d4a1938-789f-4c57-96b2-1c079941a59e',
+        url: '/questions/8d4a1938-789f-4c57-96b2-1c079941a59e',
         name: 'Mathematics',
         description: 'Master fundamental mathematics concepts for SPM',
         icon: Calculator,


### PR DESCRIPTION
## Problem
The two SPM subject cards opened different experiences — Add Math the browsable bank (v1), Mathematics the guided quiz (v2). Investigation showed the split is **data-driven**, not intentional UI drift: the quiz needs authored A–D options, and the subjects differ starkly:

| Subject | Questions | With MCQ options |
|---|---|---|
| Modern Mathematics | 513 | 507 |
| Additional Mathematics | 560 | **0** |

The v2 quiz rendered a completely empty shell for Add Math (verified live), while the v1 bank works for both subjects.

## Change
- The Mathematics card now opens the **v1 bank**, same as Add Math — one consistent SPM experience.
- The two `/questions/v2/*` routes now **redirect** to `/questions/:subjectId`, so old links and bookmarks land on the bank for the same subject.
- The v3 quiz components stay in the tree, **parked**: the MCQ + instant-checking flow (and the 507 authored option sets) are exactly what the future paid drill tier needs — nothing is thrown away.

## Verification
- `tsc` clean · **250/250 tests pass** (the parked components' own tests still run and pass)
- Live-verified: both v2 URLs redirect to the bank and render question cards; both subject cards link to v1 paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)