### PR TITLE
feat: admin waitlist screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { DiagnosticSetQuestionsPage } from '@/pages/Admin/Diagnostic/DiagnosticS
 import { DiagnosticSetReviewPage } from '@/pages/Admin/Diagnostic/DiagnosticSetReviewPage.tsx'
 import { DiagnosticSubjectsPage } from '@/pages/Admin/Diagnostic/DiagnosticSubjectsPage.tsx'
 import { DiagnosticResultsPage } from '@/pages/Admin/Diagnostic/DiagnosticResultsPage.tsx'
+import { WaitlistPage } from '@/pages/Admin/Diagnostic/WaitlistPage.tsx'
 import { DiagnosticAdminReportPage } from '@/pages/Admin/Diagnostic/DiagnosticAdminReportPage.tsx'
 import { DiagnosticQuestionCreatePage } from '@/pages/Admin/Diagnostic/DiagnosticQuestionCreatePage.tsx'
 import { DiagnosticQuestionEditPage } from '@/pages/Admin/Diagnostic/DiagnosticQuestionEditPage.tsx'
@@ -163,6 +164,7 @@ function App() {
                     <Route path="admin/sets" element={<DiagnosticSetsListPage />} />
                     <Route path="admin/subjects" element={<DiagnosticSubjectsPage />} />
                     <Route path="admin/results" element={<DiagnosticResultsPage />} />
+                    <Route path="admin/waitlist" element={<WaitlistPage />} />
                     <Route
                         path="admin/attempts/:attemptId/report"
                         element={<DiagnosticAdminReportPage />}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
     Inbox,
     Layers,
     LucideCodesandbox,
+    Mail,
     PencilIcon,
     Settings,
 } from 'lucide-react'
@@ -64,6 +65,11 @@ const ITEMS = [
         title: 'Results',
         url: '/admin/results',
         icon: BarChart3,
+    },
+    {
+        title: 'Waitlist',
+        url: '/admin/waitlist',
+        icon: Mail,
     },
 ]
 

--- a/src/hooks/diagnostic/useListWaitlistQuery.ts
+++ b/src/hooks/diagnostic/useListWaitlistQuery.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query'
+import { listWaitlistWaitlistGet } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
+
+/**
+ * Every waitlist signup, newest first — admin only (the endpoint requires an
+ * admin token). Feeds the admin waitlist screen so signups can be read and
+ * exported without hand-rolling an API call.
+ */
+export default function useListWaitlistQuery() {
+    return useQuery({
+        queryKey: ['waitlist-signups'],
+        queryFn: async () =>
+            (await listWaitlistWaitlistGet({ headers: getAuthHeaders() })).data,
+    })
+}

--- a/src/lib/waitlistCsv.test.ts
+++ b/src/lib/waitlistCsv.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { waitlistToCsv } from './waitlistCsv'
+import type { WaitlistEntry } from '@/client'
+
+function entry(over: Partial<WaitlistEntry> = {}): WaitlistEntry {
+    return {
+        id: '1',
+        email: 'a@b.com',
+        product: 'tmua',
+        createdAt: '2026-07-26T10:00:00Z',
+        ...over,
+    } as WaitlistEntry
+}
+
+describe('waitlistToCsv', () => {
+    it('writes a header and one row per signup', () => {
+        const csv = waitlistToCsv([
+            entry(),
+            entry({ email: 'c@d.com', product: 'esat-chemistry' }),
+        ])
+        const lines = csv.split('\n')
+        expect(lines[0]).toBe('Email,Product,Signed up')
+        expect(lines).toHaveLength(3)
+        expect(lines[1]).toContain('a@b.com')
+        expect(lines[2]).toContain('esat-chemistry')
+    })
+
+    it('escapes a comma in a field so columns cannot shift', () => {
+        const csv = waitlistToCsv([entry({ email: 'weird,name@b.com' })])
+        expect(csv).toContain('"weird,name@b.com"')
+    })
+
+    it('is just a header when there are no signups', () => {
+        expect(waitlistToCsv([])).toBe('Email,Product,Signed up')
+    })
+})

--- a/src/lib/waitlistCsv.ts
+++ b/src/lib/waitlistCsv.ts
@@ -1,0 +1,45 @@
+import type { WaitlistEntry } from '@/client'
+
+/** RFC-4180 field escaping: wrap in quotes and double any embedded quote when
+ * the value contains a comma, quote, or newline. */
+function csvField(value: string | number | null | undefined): string {
+    const s = value === null || value === undefined ? '' : String(value)
+    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+}
+
+const HEADERS = ['Email', 'Product', 'Signed up'] as const
+
+/**
+ * Turn waitlist signups into a CSV string — one row per signup, the columns
+ * the table shows. Kept pure (no DOM) so it's unit-testable; the page wires
+ * the Blob download around it. The export is what you paste into an email
+ * tool when a product opens.
+ */
+export function waitlistToCsv(entries: WaitlistEntry[]): string {
+    const lines = [HEADERS.join(',')]
+    for (const e of entries) {
+        lines.push(
+            [
+                csvField(e.email),
+                csvField(e.product),
+                csvField(e.createdAt),
+            ].join(',')
+        )
+    }
+    return lines.join('\n')
+}
+
+/** Trigger a client-side download of the signups as a CSV file. */
+export function downloadWaitlistCsv(entries: WaitlistEntry[]): void {
+    const blob = new Blob([waitlistToCsv(entries)], {
+        type: 'text/csv;charset=utf-8;',
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `waitlist-${new Date().toISOString().slice(0, 10)}.csv`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+}

--- a/src/pages/Admin/Diagnostic/WaitlistPage.tsx
+++ b/src/pages/Admin/Diagnostic/WaitlistPage.tsx
@@ -1,0 +1,144 @@
+import { useMemo, useState } from 'react'
+import { Download } from 'lucide-react'
+import { AdminLayout } from '@/components/layout/AdminLayout.tsx'
+import { Badge } from '@/components/ui/badge.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table.tsx'
+import useListWaitlistQuery from '@/hooks/diagnostic/useListWaitlistQuery.ts'
+import { downloadWaitlistCsv } from '@/lib/waitlistCsv.ts'
+
+/** Human labels for the products the backend accepts. Unknown values still
+ * render (as their raw slug) so a product added server-side is never hidden. */
+const PRODUCT_LABELS: Record<string, string> = {
+    tmua: 'TMUA',
+    'esat-chemistry': 'ESAT Chemistry',
+    'esat-biology': 'ESAT Biology',
+}
+
+function label(product: string): string {
+    return PRODUCT_LABELS[product] ?? product
+}
+
+/**
+ * Admin waitlist screen: who has asked to be told when an upcoming product
+ * opens, filterable by product, with a CSV export to paste into an email
+ * tool on launch day. Read-only — signups arrive from the public form.
+ */
+export function WaitlistPage() {
+    const { data, isLoading, isError, error } = useListWaitlistQuery()
+    const [product, setProduct] = useState<string | null>(null)
+
+    const entries = data ?? []
+
+    /** Signup counts per product, for the filter chips. */
+    const counts = useMemo(() => {
+        const by = new Map<string, number>()
+        for (const e of entries) by.set(e.product, (by.get(e.product) ?? 0) + 1)
+        return [...by.entries()].sort(([a], [b]) => a.localeCompare(b))
+    }, [entries])
+
+    const shown = product
+        ? entries.filter((e) => e.product === product)
+        : entries
+
+    return (
+        <AdminLayout>
+            <div className="flex flex-col gap-6 p-6">
+                <div className="flex items-start justify-between gap-4 flex-wrap">
+                    <div>
+                        <h1 className="text-2xl font-bold">Waitlist</h1>
+                        <p className="text-sm text-gray-500 mt-1">
+                            Students waiting to hear when an upcoming product
+                            opens. Export the list to email them on launch.
+                        </p>
+                    </div>
+                    <Button
+                        variant="outline"
+                        className="cursor-pointer"
+                        disabled={shown.length === 0}
+                        onClick={() => downloadWaitlistCsv(shown)}
+                    >
+                        <Download className="h-4 w-4" /> Export CSV
+                    </Button>
+                </div>
+
+                {/* Product filter — the counts double as the at-a-glance
+                    demand signal for what to build next. */}
+                {counts.length > 0 && (
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <Button
+                            variant={product === null ? 'default' : 'outline'}
+                            size="sm"
+                            className="cursor-pointer"
+                            onClick={() => setProduct(null)}
+                        >
+                            All <Badge variant="secondary">{entries.length}</Badge>
+                        </Button>
+                        {counts.map(([p, n]) => (
+                            <Button
+                                key={p}
+                                variant={product === p ? 'default' : 'outline'}
+                                size="sm"
+                                className="cursor-pointer"
+                                onClick={() => setProduct(p)}
+                            >
+                                {label(p)} <Badge variant="secondary">{n}</Badge>
+                            </Button>
+                        ))}
+                    </div>
+                )}
+
+                {isLoading && <p className="text-gray-500">Loading…</p>}
+
+                {isError && (
+                    <p className="text-red-600 text-sm">
+                        Could not load the waitlist: {error?.message}
+                    </p>
+                )}
+
+                {!isLoading && !isError && entries.length === 0 && (
+                    <p className="text-gray-500">
+                        No signups yet. They arrive from the waitlist form on
+                        the admissions pages.
+                    </p>
+                )}
+
+                {shown.length > 0 && (
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Email</TableHead>
+                                <TableHead>Product</TableHead>
+                                <TableHead>Signed up</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {shown.map((e) => (
+                                <TableRow key={`${e.email}-${e.product}`}>
+                                    <TableCell className="font-medium">
+                                        {e.email}
+                                    </TableCell>
+                                    <TableCell>
+                                        <Badge variant="secondary">
+                                            {label(e.product)}
+                                        </Badge>
+                                    </TableCell>
+                                    <TableCell className="text-gray-500">
+                                        {e.createdAt.slice(0, 16).replace('T', ' ')}
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                )}
+            </div>
+        </AdminLayout>
+    )
+}


### PR DESCRIPTION
## Why
Waitlist signups could only be read by hand-calling `GET /waitlist` with an admin token — no use on launch day.

## What
**`/admin/waitlist`** (new sidebar entry, Mail icon), following the Results-page patterns:
- Table of every signup — email, product badge, signup date, newest first
- **Per-product filter chips with counts** (`All 4 · TMUA 2 · ESAT Chemistry 1 · ESAT Biology 1`) — the counts double as the demand signal for what to build next
- **CSV export** that respects the active filter, so you can export just the TMUA list and paste it into an email tool on launch
- Read-only by design; unknown product slugs render raw rather than being hidden, so a product added server-side is never silently dropped

## Verification
`tsc` clean · **257/257 tests** (3 new for the CSV helper: header + one row per signup, comma escaping, empty case).

Live-checked against production with four seeded signups across all three products:

| Check | Result |
|---|---|
| Table rows (All) | 4 |
| Click TMUA chip | narrows to **2** |
| CSV header | `Email,Product,Signed up` |
| CSV after filtering | **2 rows, TMUA only** — export honours the filter |

Seeded rows deleted afterwards; `waitlist_signups` back to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)