### PR TITLE
feat: make paid sets legible before the click

### DIFF
--- a/src/hooks/diagnostic/useStartOrResumeAttemptMutation.test.tsx
+++ b/src/hooks/diagnostic/useStartOrResumeAttemptMutation.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import useStartOrResumeAttemptMutation from './useStartOrResumeAttemptMutation'
+
+const mockStart = vi.fn()
+vi.mock('@/client', () => ({
+    startOrResumeAttemptDiagnosticAttemptsPost: (...a: unknown[]) => mockStart(...a),
+}))
+vi.mock('@/lib/authHeaders.ts', () => ({
+    getAuthHeaders: () => ({ Authorization: 'Bearer x' }),
+}))
+
+function wrapper({ children }: { children: ReactNode }) {
+    const client = new QueryClient({
+        defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+    })
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+const body = { diagnosticSetId: 'set-1', agreedToTerms: true }
+
+describe('useStartOrResumeAttemptMutation', () => {
+    beforeEach(() => mockStart.mockReset())
+
+    it('returns the attempt state on success', async () => {
+        mockStart.mockResolvedValue({
+            data: { attempt: { id: 'a1' } },
+            error: undefined,
+            response: { status: 200 },
+        })
+        const { result } = renderHook(() => useStartOrResumeAttemptMutation(), { wrapper })
+        act(() => result.current.mutate(body))
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+        expect(result.current.data).toEqual({ attempt: { id: 'a1' } })
+    })
+
+    it('rejects with status 402 for a premium set so the caller can upsell', async () => {
+        mockStart.mockResolvedValue({
+            data: undefined,
+            error: { upsell: 'season_pass_2026' },
+            response: { status: 402 },
+        })
+        const { result } = renderHook(() => useStartOrResumeAttemptMutation(), { wrapper })
+        act(() => result.current.mutate(body))
+        await waitFor(() => expect(result.current.isError).toBe(true))
+        // Without this the start button was a silent no-op.
+        expect(result.current.error?.status).toBe(402)
+    })
+})

--- a/src/hooks/diagnostic/useStartOrResumeAttemptMutation.ts
+++ b/src/hooks/diagnostic/useStartOrResumeAttemptMutation.ts
@@ -4,6 +4,7 @@ import {
     type StartAttemptBody,
 } from '@/client'
 import { getAuthHeaders } from '@/lib/authHeaders.ts'
+import { toDiagnosticApiError } from '@/lib/diagnosticApiError.ts'
 
 /**
  * Start-or-resume (§7): the backend endpoint is idempotent per
@@ -12,15 +13,27 @@ import { getAuthHeaders } from '@/lib/authHeaders.ts'
  * created. The caller reads the returned attempt id and navigates to the
  * stable /diagnostic/attempts/{id} URL; a reload there re-fetches via
  * useGetAttemptStateQuery rather than re-POSTing.
+ *
+ * Throws on error, carrying the status: the generated client resolves
+ * { data: undefined, error } instead of rejecting, so returning `.data`
+ * blindly made a rejected start a silent no-op — the button did nothing at
+ * all. The caller needs the status to tell a 402 (premium set, no Season
+ * Pass) apart from a genuine failure.
  */
 export default function useStartOrResumeAttemptMutation() {
     return useMutation({
-        mutationFn: async (body: StartAttemptBody) =>
-            (
-                await startOrResumeAttemptDiagnosticAttemptsPost({
-                    body,
-                    headers: getAuthHeaders(),
-                })
-            ).data,
+        mutationFn: async (body: StartAttemptBody) => {
+            const result = await startOrResumeAttemptDiagnosticAttemptsPost({
+                body,
+                headers: getAuthHeaders(),
+            })
+            if (result.error !== undefined) {
+                throw toDiagnosticApiError(
+                    result,
+                    'Could not start the diagnostic.'
+                )
+            }
+            return result.data
+        },
     })
 }

--- a/src/pages/Diagnostic/SetInstructionsPage.tsx
+++ b/src/pages/Diagnostic/SetInstructionsPage.tsx
@@ -35,8 +35,18 @@ export function SetInstructionsPage() {
                 onSuccess: (state) => {
                     if (state) navigate(`/diagnostic/attempts/${state.attempt.id}`)
                 },
-                onError: () =>
-                    toast.error('Could not start the diagnostic. Please try again.'),
+                onError: (err) => {
+                    // 402 = premium set without a Season Pass. Telling the
+                    // student to "try again" would be a lie: retrying can
+                    // never work, so say what is actually needed.
+                    if ((err as { status?: number }).status === 402) {
+                        toast.error(
+                            'This paper is part of the Season Pass. Unlock it to sit this mock.'
+                        )
+                        return
+                    }
+                    toast.error('Could not start the diagnostic. Please try again.')
+                },
             }
         )
     }

--- a/src/pages/DiagnosticsCatalogPage.tsx
+++ b/src/pages/DiagnosticsCatalogPage.tsx
@@ -108,7 +108,24 @@ export function DiagnosticsCatalogPage({ test }: Props) {
                                     key={s.id}
                                     className="bg-slate-50 border border-slate-100 rounded-xl p-6 flex flex-col"
                                 >
-                                    <p className="text-lg font-bold mb-1">{s.title}</p>
+                                    <div className="flex items-start justify-between gap-3 mb-1">
+                                        <p className="text-lg font-bold">{s.title}</p>
+                                        {/* Paid sets say so up front: a
+                                            student should never click Start
+                                            only to meet a paywall. */}
+                                        {!s.isFree && (
+                                            <span
+                                                className="shrink-0 text-[11px] font-medium px-2 py-0.5 rounded-full border"
+                                                style={{
+                                                    backgroundColor: '#EEF3FB',
+                                                    color: '#4E77B4',
+                                                    borderColor: '#CFDDF1',
+                                                }}
+                                            >
+                                                Season Pass
+                                            </span>
+                                        )}
+                                    </div>
                                     <p className="text-sm text-slate-500 mb-4">
                                         {s.questionCount} questions ·{' '}
                                         {s.timeLimitMinutes} min
@@ -126,7 +143,9 @@ export function DiagnosticsCatalogPage({ test }: Props) {
                                                 navigate(`/diagnostic/sets/${s.id}`)
                                             }
                                         >
-                                            Start diagnostic →
+                                            {s.isFree
+                                                ? 'Start diagnostic →'
+                                                : 'Unlock with Season Pass →'}
                                         </Button>
                                     </div>
                                 </div>


### PR DESCRIPTION
**Prerequisite for flipping Set B/C to paid** — this must deploy first.

## Why: flipping now would have failed in three ways
Investigating before changing the data, I found the paid path was broken end to end:

1. The catalogue card for a paid set looked **identical** to a free one — the only difference was the absence of "· free".
2. `useStartOrResumeAttemptMutation` returned `.data` blindly (the false-success trap from #37/#44 again), so a **402 resolved as success** with `undefined` data → `if (state)` was falsy → **the Start button did nothing at all**. No error, no navigation, no feedback.
3. Even once it threw, the handler said *"Could not start the diagnostic. Please try again."* — advice that can never work for a paywalled paper.

## Changes
- **Catalogue**: paid sets carry a **Season Pass** badge, and their CTA reads *"Unlock with Season Pass →"* — the gate is visible before a student invests any effort.
- **`useStartOrResumeAttemptMutation`**: throws on error, carrying `status`, so a 402 is distinguishable. Tests for both the success and 402 paths.
- **Instructions page**: a 402 says *"This paper is part of the Season Pass. Unlock it to sit this mock."*; anything else keeps the generic retry message.

## Verification
`tsc` clean · **263/263 tests** (2 new for the mutation).

## Deploy order
Merge and let this deploy, **then** flip Set B/C to `isFree: false` (a data-only change). Doing it the other way round would show students a dead button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)