### PR TITLE
feat: TMUA Paper 1 and Paper 2 skill frameworks

### DIFF
--- a/src/lib/diagnosticSkillFrameworks.test.ts
+++ b/src/lib/diagnosticSkillFrameworks.test.ts
@@ -39,3 +39,35 @@ describe('frameworkFor', () => {
         expect(frameworkFor('Biology')).toBeNull()
     })
 })
+
+describe('TMUA frameworks', () => {
+    it('names all nine Paper 1 skills', () => {
+        expect(skillName('TMUA Paper 1', 'S1')).toContain('Algebraic Manipulation')
+        expect(skillName('TMUA Paper 1', 'S8')).toContain('Calculus')
+        expect(skillName('TMUA Paper 1', 'S9')).toContain('Graphs & Functions')
+    })
+
+    it('names all eight Paper 2 skills, distinctly from Paper 1', () => {
+        expect(skillName('TMUA Paper 2', 'S2')).toBe(
+            'Necessary & Sufficient Conditions'
+        )
+        expect(skillName('TMUA Paper 2', 'S8')).toContain('Computational Fluency')
+        // Same code, different paper, different meaning.
+        expect(skillName('TMUA Paper 2', 'S5')).not.toBe(
+            skillName('TMUA Paper 1', 'S5')
+        )
+    })
+
+    it('leaves the ESAT Maths taxonomy untouched', () => {
+        // The docx says Paper 1 shares ESAT Maths 2's spec, but the existing
+        // ESAT questions are tagged against the abstract names — reusing the
+        // TMUA labels would re-interpret every historic tag.
+        expect(skillName('ESAT Math 2', 'S2')).toBe(
+            'Strategic & Efficient Problem Solving'
+        )
+    })
+
+    it('still falls back to the bare code for an unknown subject', () => {
+        expect(skillName('TMUA Paper 3', 'S1')).toBe('S1')
+    })
+})

--- a/src/lib/diagnosticSkillFrameworks.ts
+++ b/src/lib/diagnosticSkillFrameworks.ts
@@ -20,6 +20,40 @@ const MATHS_SHARED: Record<string, string> = {
     S7: 'Functions, Sequences & Structure',
 }
 
+/** TMUA Paper 1 — Applications of Mathematical Knowledge. Nine topic-named
+ * skills, from the TMUA Skills Frameworks reference.
+ *
+ * Note these are deliberately NOT reused for ESAT Maths 2 even though the two
+ * share a specification: the existing ESAT Maths questions are tagged against
+ * the more abstract MATHS_SHARED taxonomy above, so borrowing these names
+ * would silently re-interpret every historic ESAT tag and change what past
+ * reports mean. */
+const TMUA_PAPER_1: Record<string, string> = {
+    S1: 'Algebraic Manipulation (Indices, Surds & Partial Fractions)',
+    S2: 'Quadratics & Polynomial Equations',
+    S3: 'Inequalities & Case Analysis',
+    S4: 'Coordinate Geometry (Lines & Circles)',
+    S5: 'Trigonometry (Exact Values & Equations)',
+    S6: 'Sequences & Series',
+    S7: 'Exponential & Logarithmic Equations',
+    S8: 'Calculus (Differentiation & Integration)',
+    S9: 'Graphs & Functions (Transformations)',
+}
+
+/** TMUA Paper 2 — Mathematical Reasoning. Eight skills: the same AS-level
+ * content seen through a reasoning lens, so the codes mean something quite
+ * different from Paper 1's. */
+const TMUA_PAPER_2: Record<string, string> = {
+    S1: 'Logical Connectives & Conditional Statements',
+    S2: 'Necessary & Sufficient Conditions',
+    S3: 'Quantifiers & Negation',
+    S4: 'Proof Construction & Strategy',
+    S5: 'Identifying Errors in Proofs',
+    S6: 'Deduction & Valid Inference',
+    S7: 'Logic Puzzles & Systematic Case-Work',
+    S8: 'Computational Fluency Under a Reasoning Frame',
+}
+
 const FRAMEWORKS: Record<string, Record<string, string>> = {
     // Maths 1 — no S6 (no calculus in the spec).
     'esat math 1': { ...MATHS_SHARED },
@@ -35,6 +69,9 @@ const FRAMEWORKS: Record<string, Record<string, string>> = {
         S6: 'Units & Dimensional Reasoning',
         S7: 'Graphical & Data Interpretation',
     },
+    // TMUA — its own taxonomy per paper, and the papers differ from each other.
+    'tmua paper 1': { ...TMUA_PAPER_1 },
+    'tmua paper 2': { ...TMUA_PAPER_2 },
 }
 
 /** Fold subject-name drift to a stable key: lowercase, collapse spaces, and


### PR DESCRIPTION
Depends on **math-be#32** (widening `CORE_SKILLS` to S1–S9) for the S8/S9 axes to exist at all.

## Problem
TMUA reports showed bare codes — *"S4 — 0%"*, *"S7 — 0%"* — on both the free summary and the Season Pass radar, because no framework existed for the TMUA subjects. Charging for a "skill-by-skill diagnosis" and delivering S-codes undercuts the feature.

## Change
Both frameworks from your **TMUA Skills Frameworks** reference:
- **Paper 1** — nine topic-named skills (Algebraic Manipulation → Graphs & Functions)
- **Paper 2** — eight reasoning skills (Logical Connectives → Computational Fluency Under a Reasoning Frame)

The same code means different things per paper (`S5` is *Trigonometry* in Paper 1, *Identifying Errors in Proofs* in Paper 2), which the per-subject keying already handles.

## ESAT Maths deliberately untouched
The reference states Paper 1 shares ESAT Maths 2's specification and could double as its framework. I did **not** do that: existing ESAT Maths questions are tagged against the abstract `MATHS_SHARED` taxonomy (`S2 = Strategic & Efficient Problem Solving`, not `Quadratics`), so adopting these labels would silently re-interpret every historic tag and change what past reports mean. A test pins that.

**267/267 tests pass** · `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)