### PR TITLE
fix: repair the production build (deploys failing since #48)

### DIFF
--- a/src/components/diagnostic/report/SkillsRadarPaywall.tsx
+++ b/src/components/diagnostic/report/SkillsRadarPaywall.tsx
@@ -25,7 +25,9 @@ const DECOY_WIDTHS = [82, 74, 66, 58, 47, 39, 31]
  * so this is a genuine gate and not a CSS trick.
  */
 export function SkillsRadarPaywall({ subject, onUnlock }: Props) {
-    const framework = frameworkFor(subject)
+    // frameworkFor returns null for a subject we don't recognise; fall back
+    // to no rows rather than crashing, so the unlock card still renders.
+    const framework = frameworkFor(subject) ?? {}
     const skills = Object.keys(framework).slice(0, DECOY_WIDTHS.length)
 
     return (

--- a/src/hooks/diagnostic/useStartOrResumeAttemptMutation.test.tsx
+++ b/src/hooks/diagnostic/useStartOrResumeAttemptMutation.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import useStartOrResumeAttemptMutation from './useStartOrResumeAttemptMutation'
+import type { DiagnosticApiError } from '@/lib/diagnosticApiError.ts'
 
 const mockStart = vi.fn()
 vi.mock('@/client', () => ({
@@ -46,6 +47,6 @@ describe('useStartOrResumeAttemptMutation', () => {
         act(() => result.current.mutate(body))
         await waitFor(() => expect(result.current.isError).toBe(true))
         // Without this the start button was a silent no-op.
-        expect(result.current.error?.status).toBe(402)
+        expect((result.current.error as DiagnosticApiError | null)?.status).toBe(402)
     })
 })


### PR DESCRIPTION
## Impact
**Railway deployments have been failing since #48.** Production is still serving the bundle from around #46 — so the paywall (#48), the paid-set badge and 402 handling (#49), and the TMUA skill frameworks (#50) never reached users. The GitHub check links to Railway's dashboard, which is why clicking it 404s rather than showing a log.

## Cause — two type errors, both mine
- `SkillsRadarPaywall` called `Object.keys(frameworkFor(subject))`, but that returns `null` for an unrecognised subject.
- `useStartOrResumeAttemptMutation.test.tsx` read `.status` off the base `Error` type instead of `DiagnosticApiError`.

## Why my verification missed them
I checked with `tsc --noEmit`; the build script is **`tsc -b && vite build`**. Build mode also type-checks the test files and applies project references, so an entire class of error was invisible to my check. **Verifying with `pnpm build` from now on** — it's the command that actually gates deployment.

## Verification
`pnpm build` succeeds (`✓ built in 7.93s`) · **267/267 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)