### PR TITLE
feat: present locked sets as coming soon until billing is live

### DIFF
--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -1,0 +1,10 @@
+/**
+ * Whether the Season Pass can actually be bought. Flip to true when Stripe
+ * checkout ships (needs the Stripe account, a Price, and the keys in
+ * Railway — see the paywall build plan).
+ *
+ * While false, paid sets are still locked server-side (starting one 402s),
+ * but the UI presents them as "coming soon" rather than dangling an unlock
+ * CTA that leads nowhere.
+ */
+export const BILLING_LIVE = false

--- a/src/pages/Diagnostic/SetInstructionsPage.tsx
+++ b/src/pages/Diagnostic/SetInstructionsPage.tsx
@@ -7,6 +7,7 @@ import { Checkbox } from '@/components/ui/checkbox.tsx'
 import useGetSetPreviewQuery from '@/hooks/diagnostic/useGetSetPreviewQuery.ts'
 import useStartOrResumeAttemptMutation from '@/hooks/diagnostic/useStartOrResumeAttemptMutation.ts'
 import { toast } from 'sonner'
+import { BILLING_LIVE } from '@/lib/billing.ts'
 
 /**
  * Landing/instructions screen (§2), before an attempt exists. Shows the
@@ -41,7 +42,9 @@ export function SetInstructionsPage() {
                     // never work, so say what is actually needed.
                     if ((err as { status?: number }).status === 402) {
                         toast.error(
-                            'This paper is part of the Season Pass. Unlock it to sit this mock.'
+                            BILLING_LIVE
+                                ? 'This paper is part of the Season Pass. Unlock it to sit this mock.'
+                                : 'This paper is part of the Season Pass, which launches soon. Set A is free to sit now.'
                         )
                         return
                     }

--- a/src/pages/DiagnosticsCatalogPage.test.tsx
+++ b/src/pages/DiagnosticsCatalogPage.test.tsx
@@ -75,3 +75,28 @@ describe('DiagnosticsCatalogPage', () => {
         expect(screen.getByText(/No diagnostics are available/i)).toBeInTheDocument()
     })
 })
+
+describe('paid sets before billing is live', () => {
+    it('shows a disabled coming-soon button, not an unlock CTA', async () => {
+        mockSets.mockReturnValue({
+            data: [
+                {
+                    id: 'set-paid', title: 'ESAT Biology — Diagnostic Set B',
+                    subject: 'ESAT Biology', description: null,
+                    timeLimitMinutes: 40, questionCount: 27, isFree: false,
+                },
+            ],
+            isLoading: false,
+        })
+        render(
+            <MemoryRouter>
+                <DiagnosticsCatalogPage />
+            </MemoryRouter>
+        )
+        const btn = screen.getByRole('button', { name: /coming soon/i })
+        expect(btn).toBeDisabled()
+        expect(
+            screen.queryByRole('button', { name: /Unlock with Season Pass/i })
+        ).not.toBeInTheDocument()
+    })
+})

--- a/src/pages/DiagnosticsCatalogPage.tsx
+++ b/src/pages/DiagnosticsCatalogPage.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button.tsx'
 import useListPublishedSetsQuery from '@/hooks/diagnostic/useListPublishedSetsQuery.ts'
 import type { DiagnosticTest } from '@/hooks/diagnostic/useListPublishedSetsQuery.ts'
 import type { PublishedDiagnosticSet } from '@/client'
+import { BILLING_LIVE } from '@/lib/billing.ts'
 
 /** Group published sets by subject, subjects sorted, uncategorised last. */
 function groupBySubject(
@@ -31,30 +32,33 @@ type Props = {
  * its own heading, blurb and search metadata rather than sharing one. */
 const COPY: Record<
     'all' | DiagnosticTest,
-    { lead: string; heading: string; title: string; description: string; path: string }
+    { headPrefix: string; heading: string; lead: string; title: string; description: string; path: string }
 > = {
     all: {
+        headPrefix: 'Timed',
         heading: 'diagnostics.',
-        lead: 'Sit a timed diagnostic and get a report mapped to specific skills — so you know exactly where to focus. Pick a paper to begin.',
+        lead: 'Sit a timed diagnostic and get a report mapped to specific skills — so you know exactly where to focus. Set A of every subject is free to sit.',
         title: 'Diagnostic Tests | JomExam',
         description:
             'Sit a timed ESAT or TMUA diagnostic and get a report mapped to specific skills, so you know exactly where you stand before you start prepping.',
         path: '/diagnostics',
     },
     esat: {
-        heading: 'ESAT diagnostics.',
-        lead: 'Timed ESAT papers — Mathematics 1, Mathematics 2 and Physics — each mapped to the skills the test examines. Sit one and see exactly where you stand.',
+        headPrefix: 'ESAT',
+        heading: 'diagnostics.',
+        lead: 'Timed ESAT papers — Mathematics 1, Mathematics 2, Physics, Chemistry and Biology — each mapped to the skills the test examines. Set A of every subject is free to sit.',
         title: 'ESAT Practice Tests & Diagnostics | JomExam',
         description:
-            'Free timed ESAT diagnostics for Mathematics 1, Mathematics 2 and Physics. Sit a paper under exam conditions and get a skills report showing exactly where to focus.',
+            'Timed ESAT diagnostics for Mathematics 1, Mathematics 2, Physics, Chemistry and Biology. Sit a paper under exam conditions and get a skills report showing exactly where to focus.',
         path: '/diagnostics/esat',
     },
     tmua: {
-        heading: 'TMUA diagnostics.',
-        lead: 'Timed TMUA papers — Paper 1 (Applications of Mathematical Knowledge) and Paper 2 (Mathematical Reasoning) — mapped to the skills each paper examines.',
+        headPrefix: 'TMUA',
+        heading: 'diagnostics.',
+        lead: 'Timed TMUA papers — Paper 1 (Applications of Mathematical Knowledge) and Paper 2 (Mathematical Reasoning) — mapped to the skills each paper examines. Set A of each paper is free to sit.',
         title: 'TMUA Practice Tests & Diagnostics | JomExam',
         description:
-            'Free timed TMUA diagnostics for Paper 1 and Paper 2. Sit a paper under exam conditions and get a skills report showing exactly where to focus.',
+            'Timed TMUA diagnostics for Paper 1 and Paper 2. Sit a paper under exam conditions and get a skills report showing exactly where to focus.',
         path: '/diagnostics/tmua',
     },
 }
@@ -82,7 +86,7 @@ export function DiagnosticsCatalogPage({ test }: Props) {
             />
             <div className="px-4 md:px-[50px] xl:px-[150px] py-12 md:py-20 max-w-4xl">
                 <p className="text-4xl md:text-6xl font-bold mb-6 leading-tight">
-                    Free{' '}
+                    {copy.headPrefix}{' '}
                     <span style={{ color: '#799ED1' }}>{copy.heading}</span>
                 </p>
                 <p className="text-lg md:text-xl text-slate-500 mb-10 leading-relaxed max-w-2xl">
@@ -137,16 +141,26 @@ export function DiagnosticsCatalogPage({ test }: Props) {
                                         </p>
                                     )}
                                     <div className="mt-auto">
-                                        <Button
-                                            className="cursor-pointer"
-                                            onClick={() =>
-                                                navigate(`/diagnostic/sets/${s.id}`)
-                                            }
-                                        >
-                                            {s.isFree
-                                                ? 'Start diagnostic →'
-                                                : 'Unlock with Season Pass →'}
-                                        </Button>
+                                        {s.isFree || BILLING_LIVE ? (
+                                            <Button
+                                                className="cursor-pointer"
+                                                onClick={() =>
+                                                    navigate(`/diagnostic/sets/${s.id}`)
+                                                }
+                                            >
+                                                {s.isFree
+                                                    ? 'Start diagnostic →'
+                                                    : 'Unlock with Season Pass →'}
+                                            </Button>
+                                        ) : (
+                                            /* Locked but not yet buyable: an
+                                               unlock CTA would dead-end, so
+                                               say so instead of implying a
+                                               purchase path exists. */
+                                            <Button variant="outline" disabled>
+                                                Season Pass — coming soon
+                                            </Button>
+                                        )}
                                     </div>
                                 </div>
                             ))}


### PR DESCRIPTION
## Problem
Bio and Chemistry Set B imported as `isFree: false` (per the authoring prompt), so the catalogue showed **"Unlock with Season Pass →"** — a CTA that dead-ends: Stripe doesn't exist yet, so the instructions page 402s with no way to pay.

## Change
- **`BILLING_LIVE` flag** (`src/lib/billing.ts`, `false` until Stripe ships). While off, a paid set's card shows a **disabled "Season Pass — coming soon"** button instead of the unlock CTA, and the 402 toast reads *"…launches soon. Set A is free to sit now."* Flipping the one flag restores the real unlock flow.
- **Copy refresh while here**: the hero said "Free … diagnostics" above cards carrying Season Pass badges — the heading prefix now comes from per-test copy ("ESAT diagnostics."). The ESAT lead named 3 subjects when 5 are live — Chemistry and Biology added, plus "Set A of every subject is free to sit" so the funnel is explicit. SEO descriptions updated to match.

## Verification
**282/282 tests** (new: paid set renders the disabled coming-soon button and no unlock CTA) · **`pnpm build` passes** · screenshot against live data shows Bio Set A "Start diagnostic →" beside Set B "Season Pass — coming soon".

## After merge + deploy
Flip Set B/C of ESAT Maths 1/2, Physics and TMUA Paper 1/2 Set B to `isFree: false` (data-only) — Set A stays free everywhere. The gate is already live server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)