### PR TITLE
feat: ESAT practice-tests guide page

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -24,4 +24,7 @@
   <url>
     <loc>https://www.jomexam.com/about</loc>
   </url>
+  <url>
+    <loc>https://www.jomexam.com/guides/esat-practice-tests</loc>
+  </url>
 </urlset>

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -20,6 +20,7 @@
 import { readFile, writeFile, mkdir } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { GUIDE } from '../src/content/esatPracticeGuide.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const DIST = join(ROOT, 'dist')
@@ -69,6 +70,61 @@ function setsMarkup(sets) {
                 '</ul></section>'
         )
         .join('')
+}
+
+
+/** The guide, rendered from the same content module the React page uses, so
+ * the static copy and the live page can never disagree. */
+function guideMarkup() {
+    const sections = GUIDE.sections
+        .map((section) => {
+            const paras = section.paras.map((p) => `<p>${esc(p)}</p>`).join('')
+            const table = section.table
+                ? `<table><caption>${esc(section.table.caption)}</caption><thead><tr>` +
+                  section.table.head.map((h) => `<th scope="col">${esc(h)}</th>`).join('') +
+                  '</tr></thead><tbody>' +
+                  section.table.rows
+                      .map((r) => `<tr>${r.map((c) => `<td>${esc(c)}</td>`).join('')}</tr>`)
+                      .join('') +
+                  '</tbody></table>'
+                : ''
+            return `<section id="${esc(section.id)}"><h2>${esc(section.h2)}</h2>${paras}${table}</section>`
+        })
+        .join('')
+    const faq =
+        '<section><h2>Common questions</h2><dl>' +
+        GUIDE.faq
+            .map((f) => {
+                const link = f.link
+                    ? ` <a href="${esc(f.link.url)}" rel="noopener">${esc(f.link.label)}</a>`
+                    : ''
+                return `<dt>${esc(f.q)}</dt><dd>${esc(f.a)}${link}</dd>`
+            })
+            .join('') +
+        '</dl></section>'
+    return (
+        `<h1>${esc(GUIDE.h1)}</h1><p>${esc(GUIDE.standfirst)}</p>` +
+        sections +
+        faq +
+        `<p><a href="/diagnostics/esat">Sit a free ESAT diagnostic</a></p>`
+    )
+}
+
+/** FAQPage structured data — makes the answers eligible for rich results. */
+function faqJsonLd() {
+    const data = {
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        mainEntity: GUIDE.faq.map((f) => ({
+            '@type': 'Question',
+            name: f.q,
+            acceptedAnswer: {
+                '@type': 'Answer',
+                text: f.link ? `${f.a} See: ${f.link.url}` : f.a,
+            },
+        })),
+    }
+    return `<script type="application/ld+json">${JSON.stringify(data)}</script>`
 }
 
 const ROUTES = [
@@ -148,6 +204,15 @@ const ROUTES = [
 <p>Work through Mathematics and Additional Mathematics questions organised by topic — with Physics, Chemistry and Biology on the way. Start straight away; signing in just saves your progress.</p>`,
     },
     {
+        path: GUIDE.path,
+        title: GUIDE.title,
+        description: GUIDE.description,
+        jsonLd: faqJsonLd(),
+        get body() {
+            return guideMarkup()
+        },
+    },
+    {
         path: '/about',
         title: 'About | JomExam — Oxford-Trained, Diagnostic-First STEM Prep',
         description:
@@ -199,6 +264,9 @@ async function main() {
             '<div id="root"></div>',
             `<div id="root">${body}</div>`
         )
+        if (route.jsonLd) {
+            html = html.replace('</head>', `${route.jsonLd}</head>`)
+        }
 
         const outDir = route.path === '/' ? DIST : join(DIST, route.path)
         await mkdir(outDir, { recursive: true })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import SubjectsPage from '@/pages/SubjectsPage.tsx'
 import { AboutPage } from '@/pages/AboutPage.tsx'
 import { EsatTmuaPage } from '@/pages/EsatTmuaPage.tsx'
 import { DiagnosticsCatalogPage } from '@/pages/DiagnosticsCatalogPage.tsx'
+import { EsatPracticeGuidePage } from '@/pages/EsatPracticeGuidePage.tsx'
 import { StudentProtectedRoute } from '@/components/auth/StudentProtectedRoute.tsx'
 import { DiagnosticQuestionsListPage } from '@/pages/Admin/Diagnostic/DiagnosticQuestionsListPage.tsx'
 import { DiagnosticSetsListPage } from '@/pages/Admin/Diagnostic/DiagnosticSetsListPage.tsx'
@@ -84,6 +85,12 @@ function App() {
                 <Route path="about" element={<AboutPage />} />
                 <Route path="esat-tmua" element={<EsatTmuaPage />} />
                 <Route path="diagnostics" element={<DiagnosticsCatalogPage />} />
+                {/* Guides are written to be found in search, so they are
+                    prerendered in full — see scripts/prerender.mjs. */}
+                <Route
+                    path="guides/esat-practice-tests"
+                    element={<EsatPracticeGuidePage />}
+                />
                 {/* ESAT and TMUA are separate products, so each has its own
                     catalogue page (own heading, copy and search metadata);
                     /diagnostics stays as the combined listing. */}

--- a/src/content/esatPracticeGuide.d.mts
+++ b/src/content/esatPracticeGuide.d.mts
@@ -1,0 +1,35 @@
+/**
+ * Types for the guide content. The content itself is plain .mjs so the
+ * build-time prerenderer (Node, no TypeScript) can import the very same
+ * module the React page renders; this file gives the page real types back.
+ */
+export type GuideSection = {
+    id: string
+    h2: string
+    paras: string[]
+    table?: {
+        caption: string
+        head: string[]
+        rows: string[][]
+    }
+}
+
+export type GuideFaqItem = {
+    q: string
+    a: string
+    /** An official source backing the answer, rendered after it. */
+    link?: { label: string; url: string }
+}
+
+export type Guide = {
+    path: string
+    title: string
+    description: string
+    h1: string
+    standfirst: string
+    sections: GuideSection[]
+    faq: GuideFaqItem[]
+    sources: { label: string; url: string }[]
+}
+
+export declare const GUIDE: Guide

--- a/src/content/esatPracticeGuide.mjs
+++ b/src/content/esatPracticeGuide.mjs
@@ -1,0 +1,142 @@
+/**
+ * Content for the ESAT practice-tests guide.
+ *
+ * Plain data in .mjs, not JSX, so the React page and the build-time
+ * prerenderer can share one source: a guide whose static HTML disagreed with
+ * what a reader sees would be worse than having no static copy at all.
+ *
+ * Every factual claim here comes from UAT-UK (the body that runs the test)
+ * or the Cambridge and Imperial admissions pages, checked August 2026: the
+ * 1-9 reporting scale, 27 questions per 40-minute module, no calculator, no
+ * negative marking, the October and January windows, the fees, and which
+ * courses need which modules. Deliberately absent are the "average is 4.5"
+ * and "aim for 7.0" figures that circulate on prep-company sites — UAT-UK
+ * does not publish them, so this page does not repeat them as fact.
+ * Re-check everything each admissions cycle; the dates move every year.
+ */
+
+export const GUIDE = {
+    path: '/guides/esat-practice-tests',
+    title: 'ESAT Practice Tests — Free Diagnostics for Every Module | JomExam',
+    description:
+        'Free ESAT practice tests for Maths 1, Maths 2, Physics, Chemistry and Biology — 27 questions in 40 minutes, matching the real format. Sit one and get a skills report showing exactly what to work on.',
+    h1: 'ESAT practice tests',
+    standfirst:
+        'Start with the official specimen papers — then the problem becomes what to do next, because the ESAT is new and the back catalogue is shallow. This guide explains what the test actually asks of you, and gives you a timed paper for every module: free, and with a report naming the specific skills to fix rather than just a mark.',
+    sections: [
+        {
+            id: 'what-practice-exists',
+            h2: 'What ESAT practice actually exists',
+            paras: [
+                'UAT-UK publishes official preparation material, and it should be the first thing you use: a content specification setting out exactly what can be assessed, an ESAT guide to the underlying maths and science, specimen and practice tests through Pearson, and an archive of past papers.',
+                'What the ESAT does not have is depth. It replaced the older ENGAA and NSAA tests only recently, so there is nothing like the twenty-year back catalogue you would get with an A-level subject — and once you have sat the official papers under timed conditions, they are spent.',
+                'That scarcity changes what good preparation looks like. Rather than hoarding papers to sit near the exam, the useful move early on is to find out which skills are actually weak, fix those, and keep a paper or two in reserve for timed rehearsal later.',
+                'Every JomExam diagnostic is written to the real format — 27 multiple-choice questions in 40 minutes, no calculator — so the timing pressure you feel in practice is the timing pressure on the day.',
+            ],
+        },
+        {
+            id: 'format',
+            h2: 'The format you are practising for',
+            paras: [
+                'The ESAT is computer-based and sat at a Pearson VUE test centre. It is built from separate 40-minute modules, each containing 27 multiple-choice questions, and you sit your modules back to back on the day.',
+                'Everyone takes Mathematics 1. Which further modules you take depends on the course you have applied to, and you will normally sit two or three modules in total — so around 80 to 120 minutes of testing.',
+                'There is no calculator and no dictionary. There is also no negative marking: you do not lose marks for a wrong answer, so leaving a question blank is never better than guessing.',
+                'Each module is scored separately and reported on a scale from 1 (low) to 9 (high), to one decimal place. There is no pass mark and no published cut-off — universities read the score alongside the rest of your application.',
+            ],
+            table: {
+                caption: 'Modules by course (2026 entry)',
+                head: ['Course', 'Modules'],
+                rows: [
+                    ['Cambridge — Engineering', 'Maths 1, Maths 2, Physics'],
+                    [
+                        'Cambridge — Natural Sciences, Chemical Engineering & Biotechnology, Veterinary Medicine',
+                        'Maths 1, plus two from Biology, Chemistry, Physics, Maths 2',
+                    ],
+                    [
+                        'Imperial — Engineering (Aeronautics, Civil & Environmental, Electrical & Electronic, Mechanical) and Physics',
+                        'Maths 1, Maths 2, Physics',
+                    ],
+                    [
+                        'Imperial — Engineering (Chemical, Design)',
+                        'Maths 1, Maths 2',
+                    ],
+                    ['Imperial — Life Sciences', 'Maths 1, Chemistry, Biology'],
+                ],
+            },
+        },
+        {
+            id: 'how-to-use',
+            h2: 'How to use a practice test properly',
+            paras: [
+                'Sitting a paper and marking it out of 27 tells you almost nothing you can act on. A score of 15 does not tell you whether you are losing marks to shaky algebra, to misreading multi-step questions, or simply to running out of time.',
+                'The more useful approach is to treat the first paper as a diagnostic rather than a rehearsal. Sit it under real conditions, then look at the pattern: which skills the wrong answers cluster around, and how long you spent on the questions you got wrong.',
+                'Every JomExam diagnostic produces exactly that — a per-skill breakdown with your timing on each question, and for each wrong answer the specific misconception that answer represents. Not "you found mechanics hard", but the particular faulty step you took.',
+            ],
+        },
+        {
+            id: 'per-module',
+            h2: 'Practice by module',
+            paras: [
+                'Mathematics 1 is compulsory for every candidate and is the foundation the other modules lean on, so it is the sensible place to start. Mathematics 2 goes further into calculus, logic and proof. Physics, Chemistry and Biology each test applied, multi-step reasoning rather than recall.',
+                'Set A of every module is free to sit. There is no trick to it: sit one, read the report, and you will know where you stand before you spend months revising.',
+            ],
+        },
+    ],
+    faq: [
+        {
+            q: 'Are there official ESAT past papers?',
+            a: 'Yes — UAT-UK publishes a content specification, an ESAT guide, specimen and practice tests through Pearson, and an archive of past papers. Use them first. The catch is depth: the ESAT only replaced the ENGAA and NSAA recently, so there is no twenty-year back catalogue, and once you have sat the official papers under timed conditions you cannot un-see them.',
+            link: {
+                label: 'Official ESAT preparation materials (UAT-UK)',
+                url: 'https://esat-tmua.ac.uk/prepare/',
+            },
+        },
+        {
+            q: 'How long is the ESAT?',
+            a: 'Each module is 40 minutes and contains 27 multiple-choice questions. You sit two or three modules depending on your course, so the test runs about 80 to 120 minutes in total.',
+        },
+        {
+            q: 'Can I use a calculator in the ESAT?',
+            a: 'No. No calculator or dictionary is allowed, which is why every JomExam diagnostic is written to be answered without one.',
+        },
+        {
+            q: 'Is there negative marking in the ESAT?',
+            a: 'No. You do not lose marks for a wrong answer, so you should never leave a question blank — an educated guess costs nothing.',
+        },
+        {
+            q: 'What score do I need to pass the ESAT?',
+            a: 'There is no pass mark, and no university publishes a cut-off. Each module is reported separately on a scale from 1 (low) to 9 (high), to one decimal place, and UAT-UK states that scores are used alongside the rest of your application — your predicted grades, personal statement and, at Cambridge, your interview. Two things follow. A score is only meaningful relative to everyone else who sat the test that year, so a figure that was competitive one cycle may not be the next. And because there is no threshold to clear, the useful question is not "what score do I need" but "which modules am I losing marks in, and why" — which is what a diagnostic answers and a raw score does not.',
+            link: {
+                label: 'How ESAT results are reported (UAT-UK)',
+                url: 'https://esat-tmua.ac.uk/about-the-tests/esat-test/',
+            },
+        },
+        {
+            q: 'When is the ESAT sat, and does it differ for international students?',
+            a: 'There are two sittings: 12–16 October 2026 and 4–8 January 2027. If you are applying to Cambridge or Oxford you must sit the October window. Booking for October closes 28 September 2026 (6pm BST); the January deadline is 21 December 2026 (6pm GMT). You register yourself — create a UAT-UK account, then book a seat through Pearson — as your school will not do it for you. The test itself is identical wherever you sit it, but three things differ by location. Candidates in China, Hong Kong and Macau are restricted to specific days within each window (12 or 13 October, and 6 January). The fee is £78 at test centres in the UK and the Republic of Ireland and £133 elsewhere, and it is set by the test centre\'s location rather than your nationality. And while Pearson VUE has centres in over 180 countries, seats fill: book early, and if you are in the UK and cannot find a test within 40 miles of your postcode, contact Pearson Customer Services. Confirm every date on the official site before you rely on it — they move each cycle.',
+            link: {
+                label: 'Official ESAT dates and registration (UAT-UK)',
+                url: 'https://esat-tmua.ac.uk/register/',
+            },
+        },
+        {
+            q: 'Are the JomExam ESAT practice tests free?',
+            a: 'Set A of every module is free to sit, including the full skills report. Further sets are part of the Season Pass.',
+        },
+    ],
+    /** Verified against these primary sources; re-check each cycle. */
+    sources: [
+        {
+            label: 'UAT-UK (the official ESAT body)',
+            url: 'https://esat-tmua.ac.uk/about-the-tests/esat-test/',
+        },
+        {
+            label: 'University of Cambridge — ESAT',
+            url: 'https://www.undergraduate.study.cam.ac.uk/apply/how/science-engineering-admission-test',
+        },
+        {
+            label: 'Imperial College London — ESAT',
+            url: 'https://www.imperial.ac.uk/study/apply/undergraduate/process/admissions-tests/esat/',
+        },
+    ],
+}

--- a/src/lib/serveJsonCoverage.test.ts
+++ b/src/lib/serveJsonCoverage.test.ts
@@ -23,6 +23,7 @@ const PRERENDERED = new Set([
     'diagnostics',
     'esat-tmua',
     'subjects',
+    'guides',
 ])
 
 function routeSegments(): string[] {

--- a/src/pages/EsatPracticeGuidePage.tsx
+++ b/src/pages/EsatPracticeGuidePage.tsx
@@ -1,0 +1,184 @@
+import { Link, useNavigate } from 'react-router-dom'
+import { LandingLayout } from '@/components/layout/landing/LandingLayout.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { Seo } from '@/components/Seo.tsx'
+import { GUIDE } from '@/content/esatPracticeGuide.mjs'
+
+const PERIWINKLE = '#799ED1'
+
+/**
+ * The ESAT practice-tests guide — the first content page written to be found
+ * in search rather than navigated to. Its copy lives in
+ * content/esatPracticeGuide.mjs so the build-time prerenderer renders exactly
+ * what a reader sees; a static copy that drifted from the page would be worse
+ * than none.
+ */
+export function EsatPracticeGuidePage() {
+    const navigate = useNavigate()
+
+    return (
+        <LandingLayout>
+            <Seo
+                title={GUIDE.title}
+                description={GUIDE.description}
+                path={GUIDE.path}
+            />
+            <article className="px-4 md:px-[50px] xl:px-[150px] py-12 md:py-16 max-w-3xl">
+                <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-4">
+                    ESAT guide
+                </p>
+                <h1 className="text-3xl md:text-5xl font-bold mb-5 leading-tight">
+                    {GUIDE.h1}
+                </h1>
+                <p className="text-lg text-slate-600 leading-relaxed mb-8">
+                    {GUIDE.standfirst}
+                </p>
+
+                <div className="flex flex-col sm:flex-row gap-3 mb-12">
+                    <Button
+                        className="cursor-pointer"
+                        onClick={() => navigate('/diagnostics/esat')}
+                    >
+                        Sit a free ESAT diagnostic →
+                    </Button>
+                    <Button
+                        variant="outline"
+                        className="cursor-pointer"
+                        onClick={() => navigate('/diagnostics/tmua')}
+                    >
+                        TMUA diagnostics
+                    </Button>
+                </div>
+
+                {GUIDE.sections.map((section) => (
+                    <section key={section.id} id={section.id} className="mb-10">
+                        <h2 className="text-xl md:text-2xl font-bold mb-3">
+                            {section.h2}
+                        </h2>
+                        {section.paras.map((para, i) => (
+                            <p
+                                key={i}
+                                className="text-slate-600 leading-relaxed mb-3"
+                            >
+                                {para}
+                            </p>
+                        ))}
+                        {section.table && (
+                            <div className="overflow-x-auto mt-5">
+                                <table className="w-full text-sm border border-slate-200 rounded-lg">
+                                    <caption className="sr-only">
+                                        {section.table.caption}
+                                    </caption>
+                                    <thead className="bg-slate-50">
+                                        <tr>
+                                            {section.table.head.map((h) => (
+                                                <th
+                                                    key={h}
+                                                    scope="col"
+                                                    className="text-left font-semibold px-4 py-2 border-b border-slate-200"
+                                                >
+                                                    {h}
+                                                </th>
+                                            ))}
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {section.table.rows.map((row) => (
+                                            <tr key={row[0]}>
+                                                <td className="px-4 py-2 border-b border-slate-100 align-top">
+                                                    {row[0]}
+                                                </td>
+                                                <td className="px-4 py-2 border-b border-slate-100 align-top text-slate-600">
+                                                    {row[1]}
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )}
+                    </section>
+                ))}
+
+                <section className="mb-10">
+                    <h2 className="text-xl md:text-2xl font-bold mb-4">
+                        Common questions
+                    </h2>
+                    <dl>
+                        {GUIDE.faq.map((item) => (
+                            <div key={item.q} className="mb-5">
+                                <dt className="font-semibold text-slate-900 mb-1">
+                                    {item.q}
+                                </dt>
+                                <dd className="text-slate-600 leading-relaxed">
+                                    {item.a}
+                                    {item.link && (
+                                        <>
+                                            {' '}
+                                            <a
+                                                href={item.link.url}
+                                                className="underline underline-offset-2"
+                                                style={{ color: PERIWINKLE }}
+                                                rel="noopener"
+                                            >
+                                                {item.link.label}
+                                            </a>
+                                        </>
+                                    )}
+                                </dd>
+                            </div>
+                        ))}
+                    </dl>
+                </section>
+
+                <div
+                    className="rounded-2xl p-8 mb-10"
+                    style={{ backgroundColor: '#1a1f2e' }}
+                >
+                    <h2 className="text-xl md:text-2xl font-bold text-white mb-3">
+                        Find out where you stand
+                    </h2>
+                    <p className="text-slate-400 leading-relaxed mb-6">
+                        Set A of every ESAT module is free to sit — 27
+                        questions, 40 minutes, no calculator, exactly like the
+                        real thing. You get a skills report naming what to work
+                        on, not just a score.
+                    </p>
+                    <Button
+                        className="bg-white text-slate-900 hover:bg-slate-100 cursor-pointer font-medium"
+                        onClick={() => navigate('/diagnostics/esat')}
+                    >
+                        Start a free diagnostic →
+                    </Button>
+                </div>
+
+                <p className="text-xs text-slate-400 leading-relaxed">
+                    Test format, dates and course requirements verified against{' '}
+                    {GUIDE.sources.map((s, i) => (
+                        <span key={s.url}>
+                            <a
+                                href={s.url}
+                                className="underline underline-offset-2"
+                                style={{ color: PERIWINKLE }}
+                                rel="noopener"
+                            >
+                                {s.label}
+                            </a>
+                            {i < GUIDE.sources.length - 2
+                                ? ', '
+                                : i === GUIDE.sources.length - 2
+                                  ? ' and '
+                                  : ''}
+                        </span>
+                    ))}
+                    . Dates change each admissions cycle — always confirm on the
+                    official site before registering.{' '}
+                    <Link to="/about" className="underline underline-offset-2">
+                        About JomExam
+                    </Link>
+                    .
+                </p>
+            </article>
+        </LandingLayout>
+    )
+}


### PR DESCRIPTION
The first content page written to be **found** in search rather than navigated to.

## Why this page
Search Console shows the site already appearing for **`tmua practice test`** and even for a competitor's name plus "esat" — but with nothing to rank: no page answered what the ESAT is or what practice exists. Every impression sat too low to earn a click.

## `/guides/esat-practice-tests`
890 words covering: what practice actually exists (the ESAT replaced ENGAA/NSAA, so there is no deep past-paper back catalogue — that scarcity is the page's angle), the real format, a **module-by-course table**, how to use a paper as a diagnostic rather than a rehearsal, and a 7-question FAQ.

## Every fact verified against primary sources
27 multiple-choice questions per 40-minute module · no calculator · no negative marking · no pass mark · 2–3 modules per course · 12–16 October 2026 and 4–8 January 2027 windows · registration 20 July–28 September 2026 · which Cambridge and Imperial courses need which modules.

Taken from the [Cambridge](https://www.undergraduate.study.cam.ac.uk/apply/how/science-engineering-admission-test) and [Imperial](https://www.imperial.ac.uk/study/apply/undergraduate/process/admissions-tests/esat/) admissions pages, **cited on the page**, with a visible note that dates move each cycle. Worth a final read from you as the domain expert before merge.

Nice detail this surfaced: your diagnostics are **27 questions / 40 minutes**, which matches the real format exactly — so the page can say that truthfully.

## Built to be indexable
- Copy lives in `content/esatPracticeGuide.mjs` as plain data, imported by **both** the React page and the prerenderer — so the static copy can't drift from what a reader sees.
- Prerendered with **`FAQPage` structured data** (7 questions), making the answers eligible for rich results.
- Added to the sitemap (9 URLs) and the serve-coverage test.

## Verification
`pnpm build` passes and prerenders 10 routes · **284/284 tests** · crawler view of the built file: correct title, canonical, h1, 5 `<h2>` sections, 7 FAQ items, valid JSON-LD, all four spot-checked facts present · browser: table renders with 5 rows, 3 CTAs, both sources linked.

Note: `tsc -b` initially failed on the untyped `.mjs` import — caught by running the real build, not the tests. Added a `.d.mts` declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)