### PR TITLE
feat: link the guides from the site

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -25,6 +25,9 @@
     <loc>https://www.jomexam.com/about</loc>
   </url>
   <url>
+    <loc>https://www.jomexam.com/guides</loc>
+  </url>
+  <url>
     <loc>https://www.jomexam.com/guides/esat-practice-tests</loc>
   </url>
   <url>

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -20,12 +20,7 @@
 import { readFile, writeFile, mkdir } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { GUIDE as ESAT_GUIDE } from '../src/content/esatPracticeGuide.mjs'
-import { GUIDE as TMUA_GUIDE } from '../src/content/tmuaPracticeGuide.mjs'
-
-/** Every search-facing guide, rendered from the same modules the React
- * pages use. Adding one here and in App.tsx is the whole job. */
-const GUIDES = [ESAT_GUIDE, TMUA_GUIDE]
+import { GUIDES } from '../src/content/guides.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const DIST = join(ROOT, 'dist')
@@ -111,7 +106,12 @@ function guideMarkup(GUIDE) {
         `<h1>${esc(GUIDE.h1)}</h1><p>${esc(GUIDE.standfirst)}</p>` +
         sections +
         faq +
-        `<p><a href="${esc(GUIDE.ctaPath)}">${esc(GUIDE.ctaLabel)}</a></p>`
+        `<p><a href="${esc(GUIDE.ctaPath)}">${esc(GUIDE.ctaLabel)}</a></p>` +
+        '<section><h2>More guides</h2><ul>' +
+        GUIDES.filter((g) => g.path !== GUIDE.path)
+            .map((g) => `<li><a href="${esc(g.path)}">${esc(g.h1)}</a> — ${esc(g.description)}</li>`)
+            .join('') +
+        '</ul></section>'
     )
 }
 
@@ -130,6 +130,21 @@ function faqJsonLd(GUIDE) {
         })),
     }
     return `<script type="application/ld+json">${JSON.stringify(data)}</script>`
+}
+
+const GUIDES_INDEX = {
+    path: '/guides',
+    title: 'ESAT & TMUA Guides | JomExam',
+    description:
+        'Straight answers on the ESAT and TMUA — what each test asks of you, the format, how results are reported, and how to use a practice paper properly.',
+    body:
+        '<h1>ESAT &amp; TMUA, explained.</h1>' +
+        '<p>What each test actually asks of you, how it is scored, and how to get something useful out of a practice paper.</p>' +
+        '<ul>' +
+        GUIDES.map(
+            (g) => `<li><a href="${esc(g.path)}"><strong>${esc(g.h1)}</strong></a> — ${esc(g.description)}</li>`
+        ).join('') +
+        '</ul>',
 }
 
 const GUIDE_ROUTES = GUIDES.map((g) => ({
@@ -225,7 +240,7 @@ const ROUTES = [
 <p>JomExam began in Malaysia as SPM practice, and now builds timed diagnostics for the ESAT and TMUA admissions tests. Every diagnostic produces a skills report naming the specific gaps to work on.</p>
 <p>One-to-one tutoring is available with Hazel — Oxford DPhil in Engineering, with over 5,000 hours teaching maths, physics and chemistry online.</p>`,
     },
-].concat(GUIDE_ROUTES)
+].concat([GUIDES_INDEX], GUIDE_ROUTES)
 
 async function main() {
     const template = await readFile(join(DIST, 'index.html'), 'utf8')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import SubjectsPage from '@/pages/SubjectsPage.tsx'
 import { AboutPage } from '@/pages/AboutPage.tsx'
 import { EsatTmuaPage } from '@/pages/EsatTmuaPage.tsx'
 import { DiagnosticsCatalogPage } from '@/pages/DiagnosticsCatalogPage.tsx'
+import { GuidesIndexPage } from '@/pages/GuidesIndexPage.tsx'
 import { EsatPracticeGuidePage } from '@/pages/EsatPracticeGuidePage.tsx'
 import { TmuaPracticeGuidePage } from '@/pages/TmuaPracticeGuidePage.tsx'
 import { StudentProtectedRoute } from '@/components/auth/StudentProtectedRoute.tsx'
@@ -88,6 +89,7 @@ function App() {
                 <Route path="diagnostics" element={<DiagnosticsCatalogPage />} />
                 {/* Guides are written to be found in search, so they are
                     prerendered in full — see scripts/prerender.mjs. */}
+                <Route path="guides" element={<GuidesIndexPage />} />
                 <Route
                     path="guides/esat-practice-tests"
                     element={<EsatPracticeGuidePage />}

--- a/src/components/guides/GuideArticle.tsx
+++ b/src/components/guides/GuideArticle.tsx
@@ -2,6 +2,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button.tsx'
 import { Seo } from '@/components/Seo.tsx'
 import type { Guide } from '@/content/guideTypes.ts'
+import { GUIDES } from '@/content/guides.mjs'
 
 const PERIWINKLE = '#799ED1'
 
@@ -149,6 +150,35 @@ export function GuideArticle({ guide }: { guide: Guide }) {
                         {guide.ctaLabel}
                     </Button>
                 </div>
+
+                {/* Somewhere to go next: a reader who wanted this guide
+                    usually wants the neighbouring one too. */}
+                {GUIDES.filter((g) => g.path !== guide.path).length > 0 && (
+                    <section className="mb-10">
+                        <h2 className="text-xl md:text-2xl font-bold mb-4">
+                            More guides
+                        </h2>
+                        <ul className="flex flex-col gap-2">
+                            {GUIDES.filter((g) => g.path !== guide.path).map(
+                                (g) => (
+                                    <li key={g.path}>
+                                        <Link
+                                            to={g.path}
+                                            className="font-semibold underline underline-offset-4"
+                                            style={{ color: PERIWINKLE }}
+                                        >
+                                            {g.h1}
+                                        </Link>
+                                        <span className="text-slate-500 text-sm">
+                                            {' '}
+                                            — {g.description}
+                                        </span>
+                                    </li>
+                                )
+                            )}
+                        </ul>
+                    </section>
+                )}
 
                 <p className="text-xs text-slate-400 leading-relaxed">
                     Test format, dates and requirements verified against{' '}

--- a/src/components/layout/landing/LandingHeader.tsx
+++ b/src/components/layout/landing/LandingHeader.tsx
@@ -17,6 +17,10 @@ const MENU_ITEMS: { text: string; link: string }[] = [
         link: '/admissions',
     },
     {
+        text: 'Guides',
+        link: '/guides',
+    },
+    {
         text: 'About',
         link: '/about',
     },

--- a/src/content/guides.d.mts
+++ b/src/content/guides.d.mts
@@ -1,0 +1,2 @@
+import type { Guide } from './guideTypes'
+export declare const GUIDES: Guide[]

--- a/src/content/guides.mjs
+++ b/src/content/guides.mjs
@@ -1,0 +1,12 @@
+import { GUIDE as esatPracticeGuide } from './esatPracticeGuide.mjs'
+import { GUIDE as tmuaPracticeGuide } from './tmuaPracticeGuide.mjs'
+
+/**
+ * Every search-facing guide, in the order they are listed on /guides.
+ *
+ * One list, read by the guides index, the cross-links at the foot of each
+ * guide, and the build-time prerenderer — so a new guide is a content module
+ * plus a route, and it appears everywhere it should without anyone having to
+ * remember the other places.
+ */
+export const GUIDES = [esatPracticeGuide, tmuaPracticeGuide]

--- a/src/pages/AdmissionsPickerPage.tsx
+++ b/src/pages/AdmissionsPickerPage.tsx
@@ -97,6 +97,16 @@ export function AdmissionsPickerPage() {
                 </div>
 
                 <p className="text-sm text-slate-500 mt-10">
+                    Not sure what these tests involve?{' '}
+                    <Link
+                        to="/guides"
+                        className="font-semibold underline underline-offset-4"
+                        style={{ color: '#4E77B4' }}
+                    >
+                        Read the ESAT and TMUA guides →
+                    </Link>
+                </p>
+                <p className="text-sm text-slate-500 mt-3">
                     Revising for SPM instead?{' '}
                     <Link
                         to="/subjects"

--- a/src/pages/DiagnosticsCatalogPage.tsx
+++ b/src/pages/DiagnosticsCatalogPage.tsx
@@ -32,9 +32,20 @@ type Props = {
  * its own heading, blurb and search metadata rather than sharing one. */
 const COPY: Record<
     'all' | DiagnosticTest,
-    { headPrefix: string; heading: string; lead: string; title: string; description: string; path: string }
+    {
+        headPrefix: string
+        heading: string
+        lead: string
+        title: string
+        description: string
+        path: string
+        guidePath: string
+        guideLabel: string
+    }
 > = {
     all: {
+        guidePath: '/guides',
+        guideLabel: 'New to these tests? Read the guides',
         headPrefix: 'Timed',
         heading: 'diagnostics.',
         lead: 'Sit a timed diagnostic and get a report mapped to specific skills — so you know exactly where to focus. Set A of every subject is free to sit.',
@@ -44,6 +55,8 @@ const COPY: Record<
         path: '/diagnostics',
     },
     esat: {
+        guidePath: '/guides/esat-practice-tests',
+        guideLabel: 'New to the ESAT? Read the ESAT practice guide',
         headPrefix: 'ESAT',
         heading: 'diagnostics.',
         lead: 'Timed ESAT papers — Mathematics 1, Mathematics 2, Physics, Chemistry and Biology — each mapped to the skills the test examines. Set A of every subject is free to sit.',
@@ -53,6 +66,8 @@ const COPY: Record<
         path: '/diagnostics/esat',
     },
     tmua: {
+        guidePath: '/guides/tmua-practice-tests',
+        guideLabel: 'New to the TMUA? Read the TMUA practice guide',
         headPrefix: 'TMUA',
         heading: 'diagnostics.',
         lead: 'Timed TMUA papers — Paper 1 (Applications of Mathematical Knowledge) and Paper 2 (Mathematical Reasoning) — mapped to the skills each paper examines. Set A of each paper is free to sit.',
@@ -89,8 +104,19 @@ export function DiagnosticsCatalogPage({ test }: Props) {
                     {copy.headPrefix}{' '}
                     <span style={{ color: '#799ED1' }}>{copy.heading}</span>
                 </p>
-                <p className="text-lg md:text-xl text-slate-500 mb-10 leading-relaxed max-w-2xl">
+                <p className="text-lg md:text-xl text-slate-500 mb-4 leading-relaxed max-w-2xl">
                     {copy.lead}
+                </p>
+                {/* The guides are the top of this funnel: someone who does not
+                    yet know the format needs them before a timed paper. */}
+                <p className="mb-10">
+                    <Link
+                        to={copy.guidePath}
+                        className="text-sm font-semibold underline underline-offset-4"
+                        style={{ color: '#4E77B4' }}
+                    >
+                        {copy.guideLabel} →
+                    </Link>
                 </p>
 
                 {isLoading && <p className="text-slate-500">Loading…</p>}

--- a/src/pages/GuidesIndexPage.tsx
+++ b/src/pages/GuidesIndexPage.tsx
@@ -1,0 +1,57 @@
+import { Link } from 'react-router-dom'
+import { LandingLayout } from '@/components/layout/landing/LandingLayout.tsx'
+import { Seo } from '@/components/Seo.tsx'
+import { GUIDES } from '@/content/guides.mjs'
+
+/**
+ * The guides index. Exists so the guides are reachable from the site rather
+ * than only from a search result: they were orphan pages, which is bad for a
+ * reader who wants to browse and bad for crawling, since a page nothing links
+ * to reads as unimportant.
+ */
+export function GuidesIndexPage() {
+    return (
+        <LandingLayout>
+            <Seo
+                title="ESAT & TMUA Guides | JomExam"
+                description="Straight answers on the ESAT and TMUA — what each test asks of you, the format, how results are reported, and how to use a practice paper properly."
+                path="/guides"
+            />
+            <div className="px-4 md:px-[50px] xl:px-[150px] py-12 md:py-20 max-w-4xl">
+                <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-4">
+                    Guides
+                </p>
+                <h1 className="text-3xl md:text-5xl font-bold mb-5 leading-tight">
+                    ESAT &amp; TMUA, explained.
+                </h1>
+                <p className="text-lg text-slate-500 mb-10 leading-relaxed max-w-2xl">
+                    What each test actually asks of you, how it is scored, and
+                    how to get something useful out of a practice paper. Written
+                    against the official specifications and linked to their
+                    sources.
+                </p>
+
+                <div className="grid md:grid-cols-2 gap-6">
+                    {GUIDES.map((guide) => (
+                        <Link key={guide.path} to={guide.path}>
+                            <div className="h-full border border-slate-200 rounded-xl p-6 bg-white hover:shadow-xl hover:scale-[1.02] transition-all cursor-pointer group flex flex-col">
+                                <p className="text-xs font-medium text-slate-400 uppercase tracking-widest mb-2">
+                                    {guide.eyebrow}
+                                </p>
+                                <p className="text-xl font-bold mb-2">
+                                    {guide.h1}
+                                </p>
+                                <p className="text-slate-500 text-sm leading-relaxed mb-4 flex-1">
+                                    {guide.description}
+                                </p>
+                                <span className="text-sm font-semibold text-slate-700 group-hover:translate-x-1 transition-transform">
+                                    Read the guide →
+                                </span>
+                            </div>
+                        </Link>
+                    ))}
+                </div>
+            </div>
+        </LandingLayout>
+    )
+}


### PR DESCRIPTION
Good catch — the guides were **orphan pages**. Nothing on the site linked to them, so a reader could only arrive from a search result, and a page nothing links to also reads to a crawler as unimportant. Verified before the fix: **0 links** to `/guides` from the homepage, admissions picker, or either catalogue page.

## Now reachable five ways
- **`/guides` index** listing every guide, prerendered like the rest
- **"Guides" in the site header**
- **Each catalogue page links to its own guide**, above the papers — someone who does not yet know the format needs the guide *before* a timed paper, so this is the right order
- **Admissions picker** points at the index
- **Each guide cross-links to the others** at the foot

One shared `GUIDES` list feeds the index, the cross-links and the prerenderer, so a new guide appears in all of them without anyone having to remember.

## Verified in-browser
| Page | Links to guides |
|---|---|
| `/` | `/guides` |
| `/admissions` | `/guides` |
| `/diagnostics/esat` | `/guides`, `/guides/esat-practice-tests` |
| `/diagnostics/tmua` | `/guides`, `/guides/tmua-practice-tests` |
| `/guides/esat-practice-tests` | `/guides`, `/guides/tmua-practice-tests` |

`pnpm build` prerenders **11 routes** · **284/284 tests** · sitemap now 11 URLs.

Internal links matter here beyond navigation: they are how crawl authority reaches a page, and the guides had none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)