### PR TITLE
fix: all five ESAT modules are live, so stop saying otherwise

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -173,13 +173,12 @@ const ROUTES = [
         path: '/admissions',
         title: 'Choose Your Test | JomExam Admissions',
         description:
-            'Pick your admissions test — ESAT and TMUA diagnostics both live, with Paper 1 and Paper 2 for TMUA. Timed papers with a skills report, not just a score.',
+            'Pick your admissions test — all five ESAT modules and both TMUA papers are live. Timed papers with a skills report, not just a score, and Set A of every paper free to sit.',
         body: `<h1>Which test are you preparing for?</h1>
 <p>Each test gets its own diagnostics, skills report and catalogue.</p>
 <ul>
-<li><a href="/diagnostics/esat"><strong>ESAT</strong></a> — Engineering and Science Admissions Test, for Cambridge, Imperial and others. Mathematics 1, Mathematics 2, Physics, Chemistry and Biology.</li>
-<li><a href="/diagnostics/tmua"><strong>TMUA</strong></a> — Test of Mathematics for University Admission, for Cambridge, LSE, Warwick, Durham and Bath. Paper 1 and Paper 2.</li>
-<li><strong>ESAT Chemistry</strong> — further diagnostics in development.</li>
+<li><a href="/diagnostics/esat"><strong>ESAT</strong></a> — Engineering and Science Admissions Test, for Cambridge, Imperial and others. All five modules are live: Mathematics 1, Mathematics 2, Physics, Chemistry and Biology.</li>
+<li><a href="/diagnostics/tmua"><strong>TMUA</strong></a> — Test of Mathematics for University Admission, for Cambridge, LSE, Warwick, Durham and others. Both papers are live: Paper 1 (Applications) and Paper 2 (Reasoning).</li>
 </ul>
 <p>Not sure what these tests involve? <a href="/guides">Read the ESAT and TMUA guides</a>.</p>`,
     },
@@ -217,9 +216,9 @@ const ROUTES = [
         path: '/esat-tmua',
         title: 'ESAT & TMUA Preparation | JomExam',
         description:
-            'Prepare for the ESAT and TMUA with timed diagnostics mapped to the skills the tests examine — ESAT and TMUA Paper 1 & 2 all live. Sit a paper, get a skills report, and know exactly where to focus.',
+            'Prepare for the ESAT and TMUA with timed diagnostics mapped to the skills each test examines — all five ESAT modules and both TMUA papers are live. Sit a paper, get a skills report, and know exactly where to focus.',
         body: `<h1>ESAT &amp; TMUA preparation.</h1>
-<p>ESAT diagnostics are live now — timed papers mapped to specific skills, so you know exactly where to focus. TMUA Paper 1 and Paper 2 diagnostics are live too.</p>
+<p>ESAT diagnostics are live for all five modules — Mathematics 1, Mathematics 2, Physics, Chemistry and Biology — as are TMUA Paper 1 and Paper 2. Timed papers mapped to specific skills, with Set A of every paper free to sit.</p>
 <h2>How a diagnostic works</h2>
 <ol>
 <li><strong>Sit a timed paper</strong> — a real, timed set of questions under exam conditions.</li>

--- a/src/pages/AdmissionsPickerPage.tsx
+++ b/src/pages/AdmissionsPickerPage.tsx
@@ -2,7 +2,6 @@ import { LandingLayout } from '@/components/layout/landing/LandingLayout.tsx'
 import { Link, useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button.tsx'
 import { Seo } from '@/components/Seo.tsx'
-import { TmuaWaitlistForm } from '@/components/TmuaWaitlistForm.tsx'
 
 /**
  * Step 1 of the admissions track: pick your test. ESAT is live; TMUA and
@@ -17,7 +16,7 @@ export function AdmissionsPickerPage() {
         <LandingLayout>
             <Seo
                 title="Choose Your Test | JomExam Admissions"
-                description="Pick your admissions test — ESAT and TMUA diagnostics both live, with Paper 1 and Paper 2 for TMUA. Timed papers with a skills report, not just a score."
+                description="Pick your admissions test — all five ESAT modules and both TMUA papers are live. Timed papers with a skills report, not just a score, and Set A of every paper free to sit."
                 path="/admissions"
             />
             <div className="px-4 md:px-[50px] xl:px-[150px] py-12 md:py-20 max-w-5xl">
@@ -34,7 +33,7 @@ export function AdmissionsPickerPage() {
                     catalogue.
                 </p>
 
-                <div className="grid md:grid-cols-3 gap-6">
+                <div className="grid md:grid-cols-2 gap-6">
                     {/* ESAT — live */}
                     <div className="border border-slate-200 rounded-xl p-6 bg-white flex flex-col hover:shadow-xl hover:scale-[1.02] transition-all">
                         <div className="flex items-center gap-3 mb-2">
@@ -45,7 +44,9 @@ export function AdmissionsPickerPage() {
                         </div>
                         <p className="text-slate-500 text-sm leading-relaxed mb-6 flex-1">
                             Engineering and Science Admissions Test — Cambridge,
-                            Imperial and others. Diagnostics live now.
+                            Imperial and others. All five modules are live:
+                            Mathematics 1, Mathematics 2, Physics, Chemistry
+                            and Biology.
                         </p>
                         <Button
                             className="cursor-pointer w-full"
@@ -65,8 +66,9 @@ export function AdmissionsPickerPage() {
                         </div>
                         <p className="text-slate-500 text-sm leading-relaxed mb-6 flex-1">
                             Test of Mathematics for University Admission —
-                            Cambridge, LSE, Warwick, Durham, Bath. Paper 1
-                            &amp; Paper 2 diagnostics, live now.
+                            Cambridge, LSE, Warwick, Durham and others. Both
+                            papers are live: Paper 1 (Applications) and
+                            Paper 2 (Reasoning).
                         </p>
                         <Button
                             className="cursor-pointer w-full"
@@ -76,24 +78,6 @@ export function AdmissionsPickerPage() {
                         </Button>
                     </div>
 
-                    {/* ESAT Chemistry — secondary, in development */}
-                    <div className="border border-slate-200 rounded-xl p-6 bg-white flex flex-col">
-                        <div className="flex items-center gap-3 mb-2">
-                            <p className="text-lg font-bold">ESAT Chemistry</p>
-                            <span className="text-xs font-medium bg-amber-100 text-amber-700 px-2.5 py-0.5 rounded-full border border-amber-200">
-                                In development
-                            </span>
-                        </div>
-                        <p className="text-slate-500 text-sm leading-relaxed mb-4 flex-1">
-                            Chemistry diagnostics in the same format, mapped to
-                            the ESAT specification. Join the list and we&apos;ll
-                            email you when they open.
-                        </p>
-                        <TmuaWaitlistForm
-                            product="esat-chemistry"
-                            successMessage="You're on the list — we'll email you when ESAT Chemistry opens."
-                        />
-                    </div>
                 </div>
 
                 <p className="text-sm text-slate-500 mt-10">

--- a/src/pages/EsatTmuaPage.tsx
+++ b/src/pages/EsatTmuaPage.tsx
@@ -2,7 +2,6 @@ import { LandingLayout } from '@/components/layout/landing/LandingLayout.tsx'
 import { Button } from '@/components/ui/button.tsx'
 import { useNavigate } from 'react-router-dom'
 import { Seo } from '@/components/Seo.tsx'
-import { TmuaWaitlistForm } from '@/components/TmuaWaitlistForm.tsx'
 
 export function EsatTmuaPage() {
     const navigate = useNavigate()
@@ -11,7 +10,7 @@ export function EsatTmuaPage() {
         <LandingLayout>
             <Seo
                 title="ESAT & TMUA Preparation | JomExam"
-                description="Prepare for the ESAT and TMUA with timed diagnostics mapped to the skills the tests examine — ESAT and TMUA Paper 1 & 2 all live. Sit a paper, get a skills report, and know exactly where to focus."
+                description="Prepare for the ESAT and TMUA with timed diagnostics mapped to the skills each test examines — all five ESAT modules and both TMUA papers are live. Sit a paper, get a skills report, and know exactly where to focus."
                 path="/esat-tmua"
             />
             <div className="px-4 md:px-[50px] xl:px-[150px] py-12 md:py-20 max-w-4xl">
@@ -29,11 +28,12 @@ export function EsatTmuaPage() {
                 </p>
 
                 <p className="text-lg md:text-xl text-slate-500 mb-8 leading-relaxed max-w-2xl">
-                    Free <span className="font-medium text-slate-600">ESAT</span>{' '}
-                    diagnostics are live now — timed papers mapped to specific
-                    skills, so you know exactly where to focus.{' '}
+                    <span className="font-medium text-slate-600">ESAT</span>{' '}
+                    diagnostics are live for all five modules — Mathematics 1,
+                    Mathematics 2, Physics, Chemistry and Biology — as are{' '}
                     <span className="font-medium text-slate-600">TMUA</span>{' '}
-                    Paper 1 &amp; Paper 2 diagnostics are live too.
+                    Paper 1 and Paper 2. Timed papers mapped to specific
+                    skills, with Set A of every paper free to sit.
                 </p>
 
                 <div className="mb-12">
@@ -56,8 +56,10 @@ export function EsatTmuaPage() {
                         <p className="text-slate-500 text-sm leading-relaxed mb-3">
                             Engineering and Science Admissions Test. Required
                             for Engineering, Natural Sciences, Chemical
-                            Engineering, and Veterinary Medicine at Cambridge,
-                            and for Engineering at Imperial.
+                            Engineering and Veterinary Medicine at Cambridge,
+                            and for engineering courses at Imperial. All five
+                            modules are live: Mathematics 1, Mathematics 2,
+                            Physics, Chemistry and Biology.
                         </p>
                         <p className="text-xs text-slate-400 font-medium">
                             Cambridge · Imperial · and others
@@ -80,25 +82,6 @@ export function EsatTmuaPage() {
                         <p className="text-xs text-slate-400 font-medium mb-4">
                             Cambridge · LSE · Warwick · Durham · Bath
                         </p>
-                    </div>
-                </div>
-
-                <div className="border border-slate-200 rounded-xl p-6 bg-white mb-12 -mt-6">
-                    <div className="flex items-center gap-2 mb-2">
-                        <p className="text-base font-bold">ESAT Chemistry</p>
-                        <span className="inline-block bg-amber-50 text-amber-700 text-[11px] font-medium px-2 py-0.5 rounded-full border border-amber-200">
-                            In development
-                        </span>
-                    </div>
-                    <p className="text-slate-500 text-sm leading-relaxed mb-4">
-                        Chemistry diagnostics in the same format. Join the list
-                        and we&apos;ll email you when they open.
-                    </p>
-                    <div className="max-w-md">
-                        <TmuaWaitlistForm
-                            product="esat-chemistry"
-                            successMessage="You're on the list — we'll email you when ESAT Chemistry opens."
-                        />
                     </div>
                 </div>
 


### PR DESCRIPTION
Chemistry and Biology diagnostics are published (**15 sets across 7 subjects, 7 free**), but the site still said otherwise.

## Removed
The **"ESAT Chemistry — in development"** card, on both the admissions picker and the ESAT/TMUA page, along with its waitlist form. The `esat-chemistry` waitlist had **no signups**, so nothing is lost — and leaving a waitlist for a product you can already sit would be actively confusing.

## Updated
- **ESAT card**: "All five modules are live: Mathematics 1, Mathematics 2, Physics, Chemistry and Biology"
- **TMUA card**: "Both papers are live: Paper 1 (Applications) and Paper 2 (Reasoning)"
- **ESAT/TMUA hero**: named all five modules, and dropped the leading "**Free** ESAT diagnostics" — that stopped being the whole story when Sets B and C moved behind the Season Pass. Now: "Set A of every paper free to sit", which is accurate.
- Meta descriptions on both pages updated to match.
- Admissions picker is now a **2-card grid**, not 3.

Prerendered copies updated alongside — they are hand-written, so they drift unless changed in the same pass (the lesson from #60).

## Verification
`pnpm build` clean, prerenders 11 routes, no link warnings · **284/284 tests** · in-browser on both pages: **no "in development"/"coming soon" text, no waitlist form, all five modules named, 2 cards**.

Note: `TmuaWaitlistForm` is now unused by any page. Kept — with the backend endpoint and admin screen it is ready for the next genuinely-unreleased product, and deleting it would mean rebuilding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)