### PR TITLE
fix: the ESAT/TMUA page only offered ESAT

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -225,7 +225,7 @@ const ROUTES = [
 <li><strong>Get a skills report</strong> — a breakdown by the specific skills the test examines, with your timing on each question.</li>
 <li><strong>Focus where it counts</strong> — see your strengths and the areas to drill first.</li>
 </ol>
-<p><a href="/diagnostics/esat">Start an ESAT diagnostic</a></p>
+<p><a href="/diagnostics/esat">Start a free ESAT diagnostic</a> · <a href="/diagnostics/tmua">Start a free TMUA diagnostic</a></p>
 <p><a href="/guides">Read the ESAT and TMUA guides</a></p>`,
     },
     {

--- a/src/pages/EsatTmuaPage.tsx
+++ b/src/pages/EsatTmuaPage.tsx
@@ -18,7 +18,7 @@ export function EsatTmuaPage() {
                 {/* Eyebrow */}
                 <div className="mb-5">
                     <span className="inline-block bg-emerald-50 text-emerald-700 text-xs md:text-sm font-medium px-4 py-1.5 rounded-full border border-emerald-200">
-                        ESAT diagnostics — now live
+                        ESAT &amp; TMUA diagnostics — all now live
                     </span>
                 </div>
 
@@ -36,12 +36,22 @@ export function EsatTmuaPage() {
                     skills, with Set A of every paper free to sit.
                 </p>
 
-                <div className="mb-12">
+                {/* Both tests are live, so this page must not funnel every
+                    reader to ESAT — a TMUA candidate arriving here had no
+                    route to their own papers. */}
+                <div className="mb-12 flex flex-col sm:flex-row gap-3">
                     <Button
                         className="cursor-pointer font-medium"
                         onClick={() => navigate('/diagnostics/esat')}
                     >
                         Start a free ESAT diagnostic →
+                    </Button>
+                    <Button
+                        variant="outline"
+                        className="cursor-pointer font-medium"
+                        onClick={() => navigate('/diagnostics/tmua')}
+                    >
+                        Start a free TMUA diagnostic →
                     </Button>
                 </div>
 


### PR DESCRIPTION
Two things on `/esat-tmua` still assumed only ESAT was live.

## The eyebrow
Read **"ESAT diagnostics — now live"** on a page titled *ESAT & TMUA preparation*, with both TMUA papers live. Now: **"ESAT & TMUA diagnostics — all now live"**.

## The call to action
There was a **single button** sending everyone to the ESAT catalogue. A TMUA candidate landing on the page about their own test had no route to their papers — they'd have to notice the TMUA card lower down and navigate from there. Now two buttons: **Start a free ESAT diagnostic** and **Start a free TMUA diagnostic**.

The prerendered copy links to both catalogues too, so the crawler-visible version matches — and `/diagnostics/tmua` gains another internal link, which it can use.

`pnpm build` clean · **284/284 tests** · verified in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)