### PR TITLE
feat: create a subject from the syllabus page

### DIFF
--- a/src/components/questionManager/syllabus/CreateSubjectDialog.test.tsx
+++ b/src/components/questionManager/syllabus/CreateSubjectDialog.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CreateSubjectDialog } from './CreateSubjectDialog'
+
+const mockMutateAsync = vi.fn()
+vi.mock('@/hooks/useCreateSubjectMutation.ts', () => ({
+    default: () => ({ mutateAsync: mockMutateAsync, isPending: false }),
+}))
+const mockToastError = vi.fn()
+vi.mock('sonner', () => ({
+    toast: { error: (...args: unknown[]) => mockToastError(...args) },
+}))
+
+async function openDialog() {
+    render(<CreateSubjectDialog syllabusId="syl-1" />)
+    await userEvent.click(screen.getByRole('button', { name: 'Create Subject' }))
+}
+
+describe('CreateSubjectDialog', () => {
+    beforeEach(() => {
+        mockMutateAsync.mockReset()
+        mockToastError.mockReset()
+    })
+
+    it('creates a subject with the name and code entered', async () => {
+        mockMutateAsync.mockResolvedValue({})
+        await openDialog()
+
+        await userEvent.type(screen.getByLabelText('Name'), 'SPM Chemistry')
+        await userEvent.type(screen.getByLabelText('Code'), 'SPMCHEM')
+        await userEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+        expect(mockMutateAsync).toHaveBeenCalledWith({
+            name: 'SPM Chemistry',
+            code: 'SPMCHEM',
+        })
+    })
+
+    it('trims whitespace, since bulk import matches the subject name exactly', async () => {
+        mockMutateAsync.mockResolvedValue({})
+        await openDialog()
+
+        await userEvent.type(screen.getByLabelText('Name'), '  SPM Chemistry  ')
+        await userEvent.type(screen.getByLabelText('Code'), ' SPMCHEM ')
+        await userEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+        expect(mockMutateAsync).toHaveBeenCalledWith({
+            name: 'SPM Chemistry',
+            code: 'SPMCHEM',
+        })
+    })
+
+    it('cannot submit until both fields have a value', async () => {
+        await openDialog()
+
+        expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled()
+        await userEvent.type(screen.getByLabelText('Name'), 'SPM Chemistry')
+        expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled()
+        await userEvent.type(screen.getByLabelText('Code'), 'SPMCHEM')
+        expect(screen.getByRole('button', { name: 'Create' })).toBeEnabled()
+    })
+
+    it('keeps the dialog open and reports the failure when the create fails', async () => {
+        // A closed dialog reads as success; the subject would not exist and
+        // nothing would have said so.
+        mockMutateAsync.mockRejectedValue(new Error('duplicate key value'))
+        await openDialog()
+
+        await userEvent.type(screen.getByLabelText('Name'), 'SPM Chemistry')
+        await userEvent.type(screen.getByLabelText('Code'), 'SPMCHEM')
+        await userEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+        expect(mockToastError).toHaveBeenCalledWith('duplicate key value')
+        expect(screen.getByLabelText('Name')).toHaveValue('SPM Chemistry')
+    })
+})

--- a/src/components/questionManager/syllabus/CreateSubjectDialog.tsx
+++ b/src/components/questionManager/syllabus/CreateSubjectDialog.tsx
@@ -1,0 +1,100 @@
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { Label } from '@/components/ui/label.tsx'
+import { Input } from '@/components/ui/input.tsx'
+import { useState } from 'react'
+import useCreateSubjectMutation from '@/hooks/useCreateSubjectMutation.ts'
+import { LoadingButton } from '@/components/common/LoadingButton.tsx'
+import { toast } from 'sonner'
+
+type Props = {
+    syllabusId: string
+}
+
+export const CreateSubjectDialog = ({ syllabusId }: Props) => {
+    const [dialogOpen, setDialogOpen] = useState(false)
+    const [name, setName] = useState('')
+    const [code, setCode] = useState('')
+    const { mutateAsync, isPending } = useCreateSubjectMutation({ syllabusId })
+
+    const handleCreateSubject = async () => {
+        try {
+            await mutateAsync({ name: name.trim(), code: code.trim() })
+            setName('')
+            setCode('')
+            setDialogOpen(false)
+        } catch (error) {
+            toast.error(
+                error instanceof Error
+                    ? error.message
+                    : 'Could not create the subject.'
+            )
+        }
+    }
+
+    return (
+        <Dialog open={dialogOpen} onOpenChange={(open) => setDialogOpen(open)}>
+            <Button className="w-full" onClick={() => setDialogOpen(true)}>
+                Create Subject
+            </Button>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Create Subject</DialogTitle>
+                    <DialogDescription>
+                        A subject holds the topics, papers and questions for one
+                        exam subject. Bulk import matches its{' '}
+                        <code>questionBank.subject</code> against this name
+                        exactly, so name it the way the import files do — e.g.
+                        "SPM Chemistry".
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="grid gap-4">
+                    <div className="grid gap-3">
+                        <Label htmlFor="subject-name">Name</Label>
+                        <Input
+                            placeholder="SPM Chemistry"
+                            id="subject-name"
+                            name="name"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                        />
+                    </div>
+                    <div className="grid gap-3">
+                        <Label htmlFor="subject-code">Code</Label>
+                        <Input
+                            placeholder="SPMCHEM"
+                            id="subject-code"
+                            name="code"
+                            value={code}
+                            onChange={(e) => setCode(e.target.value)}
+                        />
+                    </div>
+                </div>
+                <DialogFooter>
+                    <Button
+                        onClick={() => setDialogOpen(false)}
+                        variant="outline"
+                    >
+                        Cancel
+                    </Button>
+
+                    <LoadingButton
+                        isLoading={isPending}
+                        text={'Create'}
+                        onClick={handleCreateSubject}
+                        // Both fields are required by the API; a blank one
+                        // would 500 rather than say what's missing.
+                        disabled={!name.trim() || !code.trim()}
+                    />
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/hooks/useCreateSubjectMutation.ts
+++ b/src/hooks/useCreateSubjectMutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { createSubjectSubjectsPost } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Props = {
     syllabusId: string
@@ -18,6 +19,7 @@ export default function useCreateSubjectMutation({ syllabusId }: Props) {
         mutationFn: async ({ name, code }: CreateSubjectInput) => {
             const result = await createSubjectSubjectsPost({
                 body: { name, code, syllabusId },
+                headers: getAuthHeaders(),
             })
             // The generated client resolves { data: undefined, error } on an
             // HTTP error instead of throwing, so returning `.data` blindly

--- a/src/hooks/useCreateSubjectMutation.ts
+++ b/src/hooks/useCreateSubjectMutation.ts
@@ -1,0 +1,41 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { createSubjectSubjectsPost } from '@/client'
+
+type Props = {
+    syllabusId: string
+}
+
+type CreateSubjectInput = {
+    name: string
+    code: string
+}
+
+export default function useCreateSubjectMutation({ syllabusId }: Props) {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: async ({ name, code }: CreateSubjectInput) => {
+            const result = await createSubjectSubjectsPost({
+                body: { name, code, syllabusId },
+            })
+            // The generated client resolves { data: undefined, error } on an
+            // HTTP error instead of throwing, so returning `.data` blindly
+            // would report a failed create as a success and close the dialog
+            // on a subject that was never made.
+            if (result.error !== undefined) {
+                throw new Error(
+                    typeof result.error === 'object' &&
+                    result.error !== null &&
+                    'detail' in result.error &&
+                    typeof result.error.detail === 'string'
+                        ? result.error.detail
+                        : 'Could not create the subject.'
+                )
+            }
+            return result.data
+        },
+        onSuccess: () =>
+            queryClient.invalidateQueries({ queryKey: ['syllabus'] }),
+    })
+}

--- a/src/pages/Admin/SyllabusPage.tsx
+++ b/src/pages/Admin/SyllabusPage.tsx
@@ -11,6 +11,8 @@ import { SubjectTable } from '@/components/questionManager/syllabus/SubjectTable
 import { LevelsTable } from '@/components/questionManager/syllabus/LevelsTable.tsx'
 import { PaperVariantTable } from '@/components/questionManager/syllabus/PaperVariantTable.tsx'
 import { BreadCrumbs } from '@/components/questionManager/BreadCrumbs.tsx'
+import { CreateSubjectDialog } from '@/components/questionManager/syllabus/CreateSubjectDialog.tsx'
+import { CardFooter } from '@/components/ui/card.tsx'
 
 export function SyllabusPage() {
     const { syllabusId } = useParams()
@@ -50,6 +52,11 @@ export function SyllabusPage() {
                                 <SubjectTable subjects={data?.subjects ?? []} />
                             </CardContent>
                         </CardHeader>
+                        <CardFooter>
+                            <CreateSubjectDialog
+                                syllabusId={syllabusId ?? ''}
+                            />
+                        </CardFooter>
                     </Card>
                 </div>
             </div>


### PR DESCRIPTION
## Why

There was no way to create a subject in the admin UI. Levels, paper variants, topics, papers and paper instances all have create dialogs; subjects were the one thing in the hierarchy you couldn't add — `POST /subjects` existed in the generated client but nothing called it. Since bulk import (#63) deliberately refuses to auto-create a subject, this was a dead end: you can't import SPM Chemistry questions without an SPM Chemistry subject, and there was no way to make one.

## What

A **Create Subject** button in the Subjects card on the syllabus page, matching the `CreateLevelDialog` pattern next to it.

- Name and code, both required — the API 500s on a missing field rather than saying what's wrong, so the button stays disabled until both have a value.
- Both are trimmed. Bulk import matches `questionBank.subject` against this name **exactly**, so a trailing space would produce a subject that no import file could ever match.
- The dialog says so, and suggests naming it the way the import files do.
- On failure the dialog **stays open** and toasts the error. The generated client resolves `{ data: undefined, error }` rather than throwing, so returning `.data` blindly would close the dialog on a subject that was never created — the same false-success trap fixed in #37.

## Verified

`POST /subjects` exercised against prod with the exact body the hook sends, confirming the camelCase `syllabusId` alias resolves to `syllabus_id`:

```
{"name":"ZZ Probe Subject","code":"ZZPROBE","syllabus_id":"1a978850-..."}
```

Probe subject deleted afterwards; subject list back to its four rows.

`pnpm build` clean, `58 files / 297 tests` passing including 4 new ones covering the happy path, trimming, the disabled state, and the failure case keeping the dialog open.

## Noted, not fixed here

None of the question-manager routers (`subjects`, `topics`, `levels`, `papers`, `syllabus`) have any auth dependency — `POST /subjects` is callable unauthenticated, as demonstrated above. That's pre-existing and platform-wide rather than anything this PR introduces, and gating them needs the admin hooks to start sending auth headers, so it wants its own PR.