### PR TITLE
fix: send auth headers on every admin write

### DIFF
--- a/src/components/questionManager/UploadQuestion.tsx
+++ b/src/components/questionManager/UploadQuestion.tsx
@@ -34,6 +34,7 @@ import axios from 'axios'
 import { useQueryClient } from '@tanstack/react-query'
 import Dropzone from 'react-dropzone'
 import type { PaperInstance, BaseTopic, QuestionResponse } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Inputs = {
     file: FileList
@@ -117,6 +118,7 @@ export const UploadQuestion = ({ paperInstance, topicsByLevel }: Props) => {
                 {
                     headers: {
                         'Content-Type': 'multipart/form-data',
+                        ...getAuthHeaders(),
                     },
                     timeout: 60_000,
                 }

--- a/src/hooks/questionOptions/useAddQuestionOptionMutation.ts
+++ b/src/hooks/questionOptions/useAddQuestionOptionMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { createOptionQuestionsQuestionIdOptionPost } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Props = {
     questionId: string
@@ -17,6 +18,7 @@ export default function useAddQuestionOptionMutation({ questionId }: Props) {
         mutationFn: async ({ optionValue, position }: MutationFunctionProps) =>
             (
                 await createOptionQuestionsQuestionIdOptionPost({
+                headers: getAuthHeaders(),
                     path: {
                         question_id: questionId,
                     },

--- a/src/hooks/questionOptions/useRemoveQuestionOptionMutation.ts
+++ b/src/hooks/questionOptions/useRemoveQuestionOptionMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { deleteOptionQuestionsQuestionIdOptionOptionIdDelete } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Props = {
     questionId: string
@@ -16,6 +17,7 @@ export default function useRemoveQuestionOptionMutation({ questionId }: Props) {
         mutationFn: async ({ optionId }: MutationFunctionProps) =>
             (
                 await deleteOptionQuestionsQuestionIdOptionOptionIdDelete({
+                headers: getAuthHeaders(),
                     path: {
                         question_id: questionId,
                         option_id: optionId,

--- a/src/hooks/questionOptions/useUpdateQuestionOptionMutation.ts
+++ b/src/hooks/questionOptions/useUpdateQuestionOptionMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { updateOptionQuestionsQuestionIdOptionOptionIdPatch } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Props = {
     questionId: string
@@ -22,6 +23,7 @@ export default function useUpdateQuestionOptionMutation({ questionId }: Props) {
         }: MutationFunctionProps) =>
             (
                 await updateOptionQuestionsQuestionIdOptionOptionIdPatch({
+                headers: getAuthHeaders(),
                     path: {
                         question_id: questionId,
                         option_id: optionId,

--- a/src/hooks/useCreateLevelMutation.ts
+++ b/src/hooks/useCreateLevelMutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { createLevelLevelsPost } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Props = {
     syllabusId: string
@@ -11,7 +12,8 @@ export default function useCreateLevelMutation({ syllabusId }: Props) {
 
     return useMutation({
         mutationFn: async (name: string) =>
-            await createLevelLevelsPost({ body: { name, syllabusId } }),
+            await createLevelLevelsPost({
+                headers: getAuthHeaders(), body: { name, syllabusId } }),
         onSuccess: () =>
             queryClient.invalidateQueries({ queryKey: ['syllabus'] }),
     })

--- a/src/hooks/useCreatePaperInstanceMutation.ts
+++ b/src/hooks/useCreatePaperInstanceMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { createPaperInstancePapersInstancePost } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Props = {
     subjectId: string
@@ -16,6 +17,7 @@ export default function useCreatePaperInstanceMutation({ subjectId }: Props) {
             paperVariantId: string
         }) =>
             await createPaperInstancePapersInstancePost({
+                headers: getAuthHeaders(),
                 body: {
                     paperId,
                     variantId: paperVariantId,

--- a/src/hooks/useCreatePaperMutation.ts
+++ b/src/hooks/useCreatePaperMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { createPaperPapersPost } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Props = {
     subjectId: string
@@ -11,6 +12,7 @@ export default function useCreatePaperMutation({ subjectId }: Props) {
     return useMutation({
         mutationFn: async ({ name }: { name: string }) =>
             await createPaperPapersPost({
+                headers: getAuthHeaders(),
                 body: {
                     name,
                     subjectId,

--- a/src/hooks/useCreatePaperVariantMutation.ts
+++ b/src/hooks/useCreatePaperVariantMutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { createPaperVariantPapersVariantPost } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Props = {
     syllabusId: string
@@ -12,6 +13,7 @@ export default function useCreatePaperVariantMutation({ syllabusId }: Props) {
     return useMutation({
         mutationFn: async ({ name, year }: { name: string; year: number }) =>
             await createPaperVariantPapersVariantPost({
+                headers: getAuthHeaders(),
                 body: {
                     syllabusId,
                     name,

--- a/src/hooks/useCreateTopicMutation.ts
+++ b/src/hooks/useCreateTopicMutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { createTopicTopicsPost } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Props = {
     subjectId: string
@@ -20,6 +21,7 @@ export default function useCreateTopicMutation({ subjectId }: Props) {
             sortOrder: number
         }) =>
             await createTopicTopicsPost({
+                headers: getAuthHeaders(),
                 body: {
                     subjectId,
                     name,

--- a/src/hooks/useDeleteLevelMutation.ts
+++ b/src/hooks/useDeleteLevelMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { deleteLevelLevelsLevelIdDelete } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 export default function useDeleteLevelMutation() {
     const queryClient = useQueryClient()
@@ -7,6 +8,7 @@ export default function useDeleteLevelMutation() {
     return useMutation({
         mutationFn: async (levelId: string) =>
             await deleteLevelLevelsLevelIdDelete({
+                headers: getAuthHeaders(),
                 path: {
                     level_id: levelId,
                 },

--- a/src/hooks/useDeletePaperInstanceMutation.ts
+++ b/src/hooks/useDeletePaperInstanceMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { deletePaperPapersInstanceInstanceIdDelete } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Props = {
     subjectId: string
@@ -10,6 +11,7 @@ export default function useDeletePaperInstanceMutation({ subjectId }: Props) {
     return useMutation({
         mutationFn: async (paperInstanceId: string) =>
             await deletePaperPapersInstanceInstanceIdDelete({
+                headers: getAuthHeaders(),
                 path: {
                     instance_id: paperInstanceId,
                 },

--- a/src/hooks/useDeletePaperMutation.ts
+++ b/src/hooks/useDeletePaperMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { deletePaperPapersPaperIdDelete } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 export default function useDeletePaperMutation() {
     const queryClient = useQueryClient()
@@ -7,6 +8,7 @@ export default function useDeletePaperMutation() {
     return useMutation({
         mutationFn: async (paperId: string) =>
             await deletePaperPapersPaperIdDelete({
+                headers: getAuthHeaders(),
                 path: { paper_id: paperId },
             }),
         onSuccess: () =>

--- a/src/hooks/useDeletePaperVariantMutation.ts
+++ b/src/hooks/useDeletePaperVariantMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { deleteVariantPapersVariantVariantIdDelete } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 export default function useDeletePaperVariantMutation() {
     const queryClient = useQueryClient()
@@ -7,6 +8,7 @@ export default function useDeletePaperVariantMutation() {
     return useMutation({
         mutationFn: async (paperVariantId: string) =>
             await deleteVariantPapersVariantVariantIdDelete({
+                headers: getAuthHeaders(),
                 path: { variant_id: paperVariantId },
             }),
         onSuccess: () =>

--- a/src/hooks/useDeleteQuestionMutation.ts
+++ b/src/hooks/useDeleteQuestionMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { deleteQuestionQuestionsQuestionIdDelete } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Props = { paperInstanceId: string }
 
@@ -9,6 +10,7 @@ export default function useDeleteQuestionMutation({ paperInstanceId }: Props) {
     return useMutation({
         mutationFn: async (questionId: string) =>
             await deleteQuestionQuestionsQuestionIdDelete({
+                headers: getAuthHeaders(),
                 path: {
                     question_id: questionId,
                 },

--- a/src/hooks/useDeleteTopicMutation.ts
+++ b/src/hooks/useDeleteTopicMutation.ts
@@ -1,12 +1,16 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { deleteTopicTopicsTopicIdDelete } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 export default function useDeleteTopicMutation() {
     const queryClient = useQueryClient()
 
     return useMutation({
         mutationFn: async (topicId: string) =>
-            deleteTopicTopicsTopicIdDelete({ path: { topic_id: topicId } }),
+            deleteTopicTopicsTopicIdDelete({
+                path: { topic_id: topicId },
+                headers: getAuthHeaders(),
+            }),
         onSuccess: () =>
             queryClient.invalidateQueries({ queryKey: ['subject'] }),
     })

--- a/src/hooks/useUpdateQuestionMutation.ts
+++ b/src/hooks/useUpdateQuestionMutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import type { Difficulty } from '@/lib/types.ts'
 import { updateQuestionQuestionsQuestionIdPatch } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Props = {
     questionId: string
@@ -31,6 +32,7 @@ export default function useUpdateQuestionMutation({
         }: MutationFunctionProps) =>
             (
                 await updateQuestionQuestionsQuestionIdPatch({
+                headers: getAuthHeaders(),
                     path: {
                         question_id: questionId,
                     },

--- a/src/hooks/useUpdateTopicMutation.ts
+++ b/src/hooks/useUpdateTopicMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { updateTopicTopicsTopicIdPatch } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Props = {
     topicId: string
@@ -20,6 +21,7 @@ export default function useUpdateTopicMutation({ topicId }: Props) {
         }) =>
             (
                 await updateTopicTopicsTopicIdPatch({
+                headers: getAuthHeaders(),
                     path: { topic_id: topicId },
                     body: {
                         name,

--- a/src/lib/adminAuthHeaders.test.ts
+++ b/src/lib/adminAuthHeaders.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Every hook that writes to an admin endpoint must send an Authorization
+ * header.
+ *
+ * This exists because the whole question-manager section was built without
+ * one: sixteen mutation hooks and the converter upload called write endpoints
+ * unauthenticated, which went unnoticed for as long as the backend didn't
+ * check. Adding `require_admin` server-side turns a missing header from
+ * invisible into a 403 the admin hits at the worst moment — mid-edit — so the
+ * rule is pinned here rather than left to whoever writes the next hook.
+ *
+ * A file-level check rather than a per-hook test on purpose: the failure mode
+ * is a *new* hook forgetting, and only something that walks the directory can
+ * catch a file that doesn't exist yet.
+ */
+
+const HOOKS_DIR = join(process.cwd(), 'src/hooks')
+
+/**
+ * Hooks that legitimately call a write endpoint without an admin token.
+ * Each needs a reason — this list is the only way to opt out, so an entry
+ * added without one is the thing to question in review.
+ */
+const PUBLIC_OR_STUDENT: Record<string, string> = {
+    'useJoinWaitlistMutation.ts':
+        'public — a prospective student signing up has no account yet',
+    'useGenerateHintMutation.ts':
+        'student-facing hint on a question in the bank, not an admin action',
+    'useUpdateQuestionStatusMutation.ts':
+        "student's own progress; reads the token itself rather than via getAuthHeaders",
+}
+
+function walk(dir: string): string[] {
+    return readdirSync(dir).flatMap((entry) => {
+        const full = join(dir, entry)
+        if (statSync(full).isDirectory()) return walk(full)
+        return full.endsWith('.ts') && !full.endsWith('.test.ts') ? [full] : []
+    })
+}
+
+describe('admin mutations send auth headers', () => {
+    it('every hook calling a write endpoint sends an Authorization header', () => {
+        const offenders: string[] = []
+
+        for (const file of walk(HOOKS_DIR)) {
+            const source = readFileSync(file, 'utf8')
+            const writes = /\w+(?:Post|Patch|Delete)\(/.test(source)
+            if (!writes) continue
+
+            const name = file.slice(HOOKS_DIR.length + 1)
+            const base = name.split('/').pop() as string
+            if (base in PUBLIC_OR_STUDENT) continue
+
+            if (!source.includes('getAuthHeaders')) offenders.push(name)
+        }
+
+        expect(offenders).toEqual([])
+    })
+
+    it('the converter upload sends one too', () => {
+        // Not a hook: it posts a multipart form with axios directly, so the
+        // sweep above can't see it, and it's the single most damaging one to
+        // leave open — it writes files into the questions storage bucket.
+        const source = readFileSync(
+            join(process.cwd(), 'src/components/questionManager/UploadQuestion.tsx'),
+            'utf8'
+        )
+        expect(source).toContain('getAuthHeaders()')
+    })
+})


### PR DESCRIPTION
Prerequisite for the backend gating PR. Safe to merge on its own: sending an Authorization header to an endpoint that doesn't check one changes nothing.

## Why

The whole question-manager section was built without auth headers. Sixteen mutation hooks and the converter upload call write endpoints unauthenticated — creating and deleting subjects, topics, levels, papers, paper variants, paper instances, questions and question options. It went unnoticed because the backend never checked.

It has to land **before** the backend starts checking, or every admin action 403s.

## What

`getAuthHeaders()` added to 16 admin mutation hooks, and to the converter upload in `UploadQuestion.tsx` — which isn't a hook (it posts a multipart form with axios directly to a hardcoded prod URL) and is the most damaging one to leave open, since it writes files into the `questions` storage bucket.

Deliberately **not** changed, because they aren't admin actions:

| Hook | Why |
|---|---|
| `useJoinWaitlistMutation` | public — a prospective student has no account yet |
| `useGenerateHintMutation` | student-facing hint on a bank question |
| `useUpdateQuestionStatusMutation` | student's own progress; already reads the token itself |

## Guard

`src/lib/adminAuthHeaders.test.ts` walks `src/hooks` and fails if any hook calling a `*Post/Patch/Delete` endpoint lacks `getAuthHeaders`, with the three exemptions listed above and a stated reason each.

A directory walk rather than a test per hook on purpose: the failure mode is a *new* hook forgetting, and only something enumerating the directory can catch a file that doesn't exist yet. Once the backend gates these, a missing header stops being invisible and becomes a 403 the admin hits mid-edit.

`pnpm build` clean, `58 files / 295 tests` passing.

## Not in this PR

`POST /chat/hint` is also ungated. It's student-facing so it shouldn't need admin, but it calls an LLM on every request, which is a cost-abuse surface rather than a data-integrity one — different problem, different fix.