### PR TITLE
feat: data-driven subject catalogue, admin questions list, and bank fixes

### DIFF
--- a/src/client/sdk.gen.ts
+++ b/src/client/sdk.gen.ts
@@ -2,7 +2,7 @@
 
 import { type Client, formDataBodySerializer, type Options as Options2, type TDataShape } from './client';
 import { client } from './client.gen';
-import type { BulkDeleteAttemptsDiagnosticAdminAttemptsBulkDeletePostData, BulkDeleteAttemptsDiagnosticAdminAttemptsBulkDeletePostErrors, BulkDeleteAttemptsDiagnosticAdminAttemptsBulkDeletePostResponses, BulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPostData, BulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPostErrors, BulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPostResponses, BulkImportSpmQuestionsQuestionsBulkImportPostData, BulkImportSpmQuestionsQuestionsBulkImportPostErrors, BulkImportSpmQuestionsQuestionsBulkImportPostResponses, BulkSetQuestionStatusDiagnosticQuestionsBulkStatusPostData, BulkSetQuestionStatusDiagnosticQuestionsBulkStatusPostErrors, BulkSetQuestionStatusDiagnosticQuestionsBulkStatusPostResponses, ConvertLatexConverterPostData, ConvertLatexConverterPostErrors, ConvertLatexConverterPostResponses, CreateDiagnosticQuestionDiagnosticQuestionsPostData, CreateDiagnosticQuestionDiagnosticQuestionsPostErrors, CreateDiagnosticQuestionDiagnosticQuestionsPostResponses, CreateDiagnosticSetDiagnosticSetsPostData, CreateDiagnosticSetDiagnosticSetsPostErrors, CreateDiagnosticSetDiagnosticSetsPostResponses, CreateLevelLevelsPostData, CreateLevelLevelsPostErrors, CreateLevelLevelsPostResponses, CreateOptionQuestionsQuestionIdOptionPostData, CreateOptionQuestionsQuestionIdOptionPostErrors, CreateOptionQuestionsQuestionIdOptionPostResponses, CreatePaperInstancePapersInstancePostData, CreatePaperInstancePapersInstancePostErrors, CreatePaperInstancePapersInstancePostResponses, CreatePaperPapersPostData, CreatePaperPapersPostErrors, CreatePaperPapersPostResponses, CreatePaperVariantPapersVariantPostData, CreatePaperVariantPapersVariantPostErrors, CreatePaperVariantPapersVariantPostResponses, CreateSubjectSubjectsPostData, CreateSubjectSubjectsPostErrors, CreateSubjectSubjectsPostResponses, CreateSyllabusSyllabusPostData, CreateSyllabusSyllabusPostErrors, CreateSyllabusSyllabusPostResponses, CreateTopicTopicsPostData, CreateTopicTopicsPostErrors, CreateTopicTopicsPostResponses, DeleteDiagnosticQuestionDiagnosticQuestionsQuestionIdDeleteData, DeleteDiagnosticQuestionDiagnosticQuestionsQuestionIdDeleteErrors, DeleteDiagnosticQuestionDiagnosticQuestionsQuestionIdDeleteResponses, DeleteDiagnosticSetDiagnosticSetsSetIdDeleteData, DeleteDiagnosticSetDiagnosticSetsSetIdDeleteErrors, DeleteDiagnosticSetDiagnosticSetsSetIdDeleteResponses, DeleteLevelLevelsLevelIdDeleteData, DeleteLevelLevelsLevelIdDeleteErrors, DeleteLevelLevelsLevelIdDeleteResponses, DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteData, DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteErrors, DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteResponses, DeletePaperPapersInstanceInstanceIdDeleteData, DeletePaperPapersInstanceInstanceIdDeleteErrors, DeletePaperPapersInstanceInstanceIdDeleteResponses, DeletePaperPapersPaperIdDeleteData, DeletePaperPapersPaperIdDeleteErrors, DeletePaperPapersPaperIdDeleteResponses, DeleteQuestionQuestionsQuestionIdDeleteData, DeleteQuestionQuestionsQuestionIdDeleteErrors, DeleteQuestionQuestionsQuestionIdDeleteResponses, DeleteTopicTopicsTopicIdDeleteData, DeleteTopicTopicsTopicIdDeleteErrors, DeleteTopicTopicsTopicIdDeleteResponses, DeleteVariantPapersVariantVariantIdDeleteData, DeleteVariantPapersVariantVariantIdDeleteErrors, DeleteVariantPapersVariantVariantIdDeleteResponses, GetAllLevelsLevelsGetData, GetAllLevelsLevelsGetResponses, GetAllSyllabusSyllabusGetData, GetAllSyllabusSyllabusGetResponses, GetAttemptDetailDiagnosticAdminAttemptsAttemptIdDetailGetData, GetAttemptDetailDiagnosticAdminAttemptsAttemptIdDetailGetErrors, GetAttemptDetailDiagnosticAdminAttemptsAttemptIdDetailGetResponses, GetAttemptRadarDiagnosticAttemptsAttemptIdRadarGetData, GetAttemptRadarDiagnosticAttemptsAttemptIdRadarGetErrors, GetAttemptRadarDiagnosticAttemptsAttemptIdRadarGetResponses, GetAttemptReportAdminDiagnosticAdminAttemptsAttemptIdReportGetData, GetAttemptReportAdminDiagnosticAdminAttemptsAttemptIdReportGetErrors, GetAttemptReportAdminDiagnosticAdminAttemptsAttemptIdReportGetResponses, GetAttemptReportDiagnosticAttemptsAttemptIdReportGetData, GetAttemptReportDiagnosticAttemptsAttemptIdReportGetErrors, GetAttemptReportDiagnosticAttemptsAttemptIdReportGetResponses, GetAttemptStateDiagnosticAttemptsAttemptIdGetData, GetAttemptStateDiagnosticAttemptsAttemptIdGetErrors, GetAttemptStateDiagnosticAttemptsAttemptIdGetResponses, GetCurrentUserUsersCurrentGetData, GetCurrentUserUsersCurrentGetResponses, GetDiagnosticQuestionDiagnosticQuestionsQuestionIdGetData, GetDiagnosticQuestionDiagnosticQuestionsQuestionIdGetErrors, GetDiagnosticQuestionDiagnosticQuestionsQuestionIdGetResponses, GetDiagnosticSetDiagnosticSetsSetIdGetData, GetDiagnosticSetDiagnosticSetsSetIdGetErrors, GetDiagnosticSetDiagnosticSetsSetIdGetResponses, GetHintChatHintPostData, GetHintChatHintPostErrors, GetHintChatHintPostResponses, GetPaperInstancePapersInstanceInstanceIdGetData, GetPaperInstancePapersInstanceInstanceIdGetErrors, GetPaperInstancePapersInstanceInstanceIdGetResponses, GetPaperInstancesBySubjectIdPapersInstanceSubjectSubjectIdGetData, GetPaperInstancesBySubjectIdPapersInstanceSubjectSubjectIdGetErrors, GetPaperInstancesBySubjectIdPapersInstanceSubjectSubjectIdGetResponses, GetQuestionOptionsQuestionsQuestionIdOptionsGetData, GetQuestionOptionsQuestionsQuestionIdOptionsGetErrors, GetQuestionOptionsQuestionsQuestionIdOptionsGetResponses, GetQuestionQuestionsQuestionIdGetData, GetQuestionQuestionsQuestionIdGetErrors, GetQuestionQuestionsQuestionIdGetResponses, GetQuestionsByPaperInstanceQuestionsPaperInstancePaperInstanceIdGetData, GetQuestionsByPaperInstanceQuestionsPaperInstancePaperInstanceIdGetErrors, GetQuestionsByPaperInstanceQuestionsPaperInstancePaperInstanceIdGetResponses, GetQuestionsBySubjectPaginatedQuestionsSubjectPaginatedSubjectIdGetData, GetQuestionsBySubjectPaginatedQuestionsSubjectPaginatedSubjectIdGetErrors, GetQuestionsBySubjectPaginatedQuestionsSubjectPaginatedSubjectIdGetResponses, GetQuestionsByTopicQuestionsTopicsTopicIdGetData, GetQuestionsByTopicQuestionsTopicsTopicIdGetErrors, GetQuestionsByTopicQuestionsTopicsTopicIdGetResponses, GetSubjectSubjectsSubjectIdGetData, GetSubjectSubjectsSubjectIdGetErrors, GetSubjectSubjectsSubjectIdGetResponses, GetSyllabusSyllabusSyllabusIdGetData, GetSyllabusSyllabusSyllabusIdGetErrors, GetSyllabusSyllabusSyllabusIdGetResponses, GetTopicsBySubjectTopicsSubjectIdGetData, GetTopicsBySubjectTopicsSubjectIdGetErrors, GetTopicsBySubjectTopicsSubjectIdGetResponses, IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostData, IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostErrors, IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostResponses, JoinWaitlistWaitlistPostData, JoinWaitlistWaitlistPostErrors, JoinWaitlistWaitlistPostResponses, ListAttemptResultsDiagnosticAdminResultsGetData, ListAttemptResultsDiagnosticAdminResultsGetResponses, ListDiagnosticQuestionsDiagnosticQuestionsGetData, ListDiagnosticQuestionsDiagnosticQuestionsGetErrors, ListDiagnosticQuestionsDiagnosticQuestionsGetResponses, ListDiagnosticSetsDiagnosticSetsGetData, ListDiagnosticSetsDiagnosticSetsGetErrors, ListDiagnosticSetsDiagnosticSetsGetResponses, ListPublishedDiagnosticSetsDiagnosticSetsPublishedGetData, ListPublishedDiagnosticSetsDiagnosticSetsPublishedGetErrors, ListPublishedDiagnosticSetsDiagnosticSetsPublishedGetResponses, ListWaitlistWaitlistGetData, ListWaitlistWaitlistGetResponses, LoginUsersLoginPostData, LoginUsersLoginPostErrors, LoginUsersLoginPostResponses, MoreInfoUsersMoreInfoPostData, MoreInfoUsersMoreInfoPostErrors, MoreInfoUsersMoreInfoPostResponses, PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetData, PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetErrors, PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetResponses, ResendVerificationUsersResendVerificationPostData, ResendVerificationUsersResendVerificationPostErrors, ResendVerificationUsersResendVerificationPostResponses, RootGetData, RootGetResponses, SetQuestionStatusQuestionsSetStatusPostData, SetQuestionStatusQuestionsSetStatusPostErrors, SetQuestionStatusQuestionsSetStatusPostResponses, SignupUsersPostData, SignupUsersPostErrors, SignupUsersPostResponses, StartOrResumeAttemptDiagnosticAttemptsPostData, StartOrResumeAttemptDiagnosticAttemptsPostErrors, StartOrResumeAttemptDiagnosticAttemptsPostResponses, SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostData, SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostErrors, SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostResponses, UpdateDiagnosticQuestionDiagnosticQuestionsQuestionIdPatchData, UpdateDiagnosticQuestionDiagnosticQuestionsQuestionIdPatchErrors, UpdateDiagnosticQuestionDiagnosticQuestionsQuestionIdPatchResponses, UpdateDiagnosticSetDiagnosticSetsSetIdPatchData, UpdateDiagnosticSetDiagnosticSetsSetIdPatchErrors, UpdateDiagnosticSetDiagnosticSetsSetIdPatchResponses, UpdateOptionQuestionsQuestionIdOptionOptionIdPatchData, UpdateOptionQuestionsQuestionIdOptionOptionIdPatchErrors, UpdateOptionQuestionsQuestionIdOptionOptionIdPatchResponses, UpdateQuestionQuestionsQuestionIdPatchData, UpdateQuestionQuestionsQuestionIdPatchErrors, UpdateQuestionQuestionsQuestionIdPatchResponses, UpdateTopicTopicsTopicIdPatchData, UpdateTopicTopicsTopicIdPatchErrors, UpdateTopicTopicsTopicIdPatchResponses, UploadDiagnosticQuestionDiagramDiagnosticQuestionsQuestionIdDiagramPostData, UploadDiagnosticQuestionDiagramDiagnosticQuestionsQuestionIdDiagramPostErrors, UploadDiagnosticQuestionDiagramDiagnosticQuestionsQuestionIdDiagramPostResponses, UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchData, UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchErrors, UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchResponses, VerifyEmailUsersVerifyPostData, VerifyEmailUsersVerifyPostErrors, VerifyEmailUsersVerifyPostResponses } from './types.gen';
+import type { BulkDeleteAttemptsDiagnosticAdminAttemptsBulkDeletePostData, BulkDeleteAttemptsDiagnosticAdminAttemptsBulkDeletePostErrors, BulkDeleteAttemptsDiagnosticAdminAttemptsBulkDeletePostResponses, BulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPostData, BulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPostErrors, BulkImportDiagnosticQuestionsDiagnosticQuestionsBulkImportPostResponses, BulkImportSpmQuestionsQuestionsBulkImportPostData, BulkImportSpmQuestionsQuestionsBulkImportPostErrors, BulkImportSpmQuestionsQuestionsBulkImportPostResponses, BulkSetQuestionStatusDiagnosticQuestionsBulkStatusPostData, BulkSetQuestionStatusDiagnosticQuestionsBulkStatusPostErrors, BulkSetQuestionStatusDiagnosticQuestionsBulkStatusPostResponses, ConvertLatexConverterPostData, ConvertLatexConverterPostErrors, ConvertLatexConverterPostResponses, CreateDiagnosticQuestionDiagnosticQuestionsPostData, CreateDiagnosticQuestionDiagnosticQuestionsPostErrors, CreateDiagnosticQuestionDiagnosticQuestionsPostResponses, CreateDiagnosticSetDiagnosticSetsPostData, CreateDiagnosticSetDiagnosticSetsPostErrors, CreateDiagnosticSetDiagnosticSetsPostResponses, CreateLevelLevelsPostData, CreateLevelLevelsPostErrors, CreateLevelLevelsPostResponses, CreateOptionQuestionsQuestionIdOptionPostData, CreateOptionQuestionsQuestionIdOptionPostErrors, CreateOptionQuestionsQuestionIdOptionPostResponses, CreatePaperInstancePapersInstancePostData, CreatePaperInstancePapersInstancePostErrors, CreatePaperInstancePapersInstancePostResponses, CreatePaperPapersPostData, CreatePaperPapersPostErrors, CreatePaperPapersPostResponses, CreatePaperVariantPapersVariantPostData, CreatePaperVariantPapersVariantPostErrors, CreatePaperVariantPapersVariantPostResponses, CreateSubjectSubjectsPostData, CreateSubjectSubjectsPostErrors, CreateSubjectSubjectsPostResponses, CreateSyllabusSyllabusPostData, CreateSyllabusSyllabusPostErrors, CreateSyllabusSyllabusPostResponses, CreateTopicTopicsPostData, CreateTopicTopicsPostErrors, CreateTopicTopicsPostResponses, DeleteDiagnosticQuestionDiagnosticQuestionsQuestionIdDeleteData, DeleteDiagnosticQuestionDiagnosticQuestionsQuestionIdDeleteErrors, DeleteDiagnosticQuestionDiagnosticQuestionsQuestionIdDeleteResponses, DeleteDiagnosticSetDiagnosticSetsSetIdDeleteData, DeleteDiagnosticSetDiagnosticSetsSetIdDeleteErrors, DeleteDiagnosticSetDiagnosticSetsSetIdDeleteResponses, DeleteLevelLevelsLevelIdDeleteData, DeleteLevelLevelsLevelIdDeleteErrors, DeleteLevelLevelsLevelIdDeleteResponses, DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteData, DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteErrors, DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteResponses, DeletePaperInstancePapersInstanceInstanceIdDeleteData, DeletePaperInstancePapersInstanceInstanceIdDeleteErrors, DeletePaperInstancePapersInstanceInstanceIdDeleteResponses, DeletePaperPapersPaperIdDeleteData, DeletePaperPapersPaperIdDeleteErrors, DeletePaperPapersPaperIdDeleteResponses, DeleteQuestionQuestionsQuestionIdDeleteData, DeleteQuestionQuestionsQuestionIdDeleteErrors, DeleteQuestionQuestionsQuestionIdDeleteResponses, DeleteTopicTopicsTopicIdDeleteData, DeleteTopicTopicsTopicIdDeleteErrors, DeleteTopicTopicsTopicIdDeleteResponses, DeleteVariantPapersVariantVariantIdDeleteData, DeleteVariantPapersVariantVariantIdDeleteErrors, DeleteVariantPapersVariantVariantIdDeleteResponses, GetAllLevelsLevelsGetData, GetAllLevelsLevelsGetResponses, GetAllSyllabusSyllabusGetData, GetAllSyllabusSyllabusGetResponses, GetAttemptDetailDiagnosticAdminAttemptsAttemptIdDetailGetData, GetAttemptDetailDiagnosticAdminAttemptsAttemptIdDetailGetErrors, GetAttemptDetailDiagnosticAdminAttemptsAttemptIdDetailGetResponses, GetAttemptRadarDiagnosticAttemptsAttemptIdRadarGetData, GetAttemptRadarDiagnosticAttemptsAttemptIdRadarGetErrors, GetAttemptRadarDiagnosticAttemptsAttemptIdRadarGetResponses, GetAttemptReportAdminDiagnosticAdminAttemptsAttemptIdReportGetData, GetAttemptReportAdminDiagnosticAdminAttemptsAttemptIdReportGetErrors, GetAttemptReportAdminDiagnosticAdminAttemptsAttemptIdReportGetResponses, GetAttemptReportDiagnosticAttemptsAttemptIdReportGetData, GetAttemptReportDiagnosticAttemptsAttemptIdReportGetErrors, GetAttemptReportDiagnosticAttemptsAttemptIdReportGetResponses, GetAttemptStateDiagnosticAttemptsAttemptIdGetData, GetAttemptStateDiagnosticAttemptsAttemptIdGetErrors, GetAttemptStateDiagnosticAttemptsAttemptIdGetResponses, GetCurrentUserUsersCurrentGetData, GetCurrentUserUsersCurrentGetResponses, GetDiagnosticQuestionDiagnosticQuestionsQuestionIdGetData, GetDiagnosticQuestionDiagnosticQuestionsQuestionIdGetErrors, GetDiagnosticQuestionDiagnosticQuestionsQuestionIdGetResponses, GetDiagnosticSetDiagnosticSetsSetIdGetData, GetDiagnosticSetDiagnosticSetsSetIdGetErrors, GetDiagnosticSetDiagnosticSetsSetIdGetResponses, GetHintChatHintPostData, GetHintChatHintPostErrors, GetHintChatHintPostResponses, GetPaperInstancePapersInstanceInstanceIdGetData, GetPaperInstancePapersInstanceInstanceIdGetErrors, GetPaperInstancePapersInstanceInstanceIdGetResponses, GetPaperInstancesBySubjectIdPapersInstanceSubjectSubjectIdGetData, GetPaperInstancesBySubjectIdPapersInstanceSubjectSubjectIdGetErrors, GetPaperInstancesBySubjectIdPapersInstanceSubjectSubjectIdGetResponses, GetQuestionOptionsQuestionsQuestionIdOptionsGetData, GetQuestionOptionsQuestionsQuestionIdOptionsGetErrors, GetQuestionOptionsQuestionsQuestionIdOptionsGetResponses, GetQuestionQuestionsQuestionIdGetData, GetQuestionQuestionsQuestionIdGetErrors, GetQuestionQuestionsQuestionIdGetResponses, GetQuestionsByPaperInstanceQuestionsPaperInstancePaperInstanceIdGetData, GetQuestionsByPaperInstanceQuestionsPaperInstancePaperInstanceIdGetErrors, GetQuestionsByPaperInstanceQuestionsPaperInstancePaperInstanceIdGetResponses, GetQuestionsBySubjectPaginatedQuestionsSubjectPaginatedSubjectIdGetData, GetQuestionsBySubjectPaginatedQuestionsSubjectPaginatedSubjectIdGetErrors, GetQuestionsBySubjectPaginatedQuestionsSubjectPaginatedSubjectIdGetResponses, GetQuestionsByTopicQuestionsTopicsTopicIdGetData, GetQuestionsByTopicQuestionsTopicsTopicIdGetErrors, GetQuestionsByTopicQuestionsTopicsTopicIdGetResponses, GetSubjectSubjectsSubjectIdGetData, GetSubjectSubjectsSubjectIdGetErrors, GetSubjectSubjectsSubjectIdGetResponses, GetSyllabusSyllabusSyllabusIdGetData, GetSyllabusSyllabusSyllabusIdGetErrors, GetSyllabusSyllabusSyllabusIdGetResponses, GetTopicsBySubjectTopicsSubjectIdGetData, GetTopicsBySubjectTopicsSubjectIdGetErrors, GetTopicsBySubjectTopicsSubjectIdGetResponses, IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostData, IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostErrors, IngestDiagnosticEventsDiagnosticAttemptsAttemptIdEventsPostResponses, JoinWaitlistWaitlistPostData, JoinWaitlistWaitlistPostErrors, JoinWaitlistWaitlistPostResponses, ListAttemptResultsDiagnosticAdminResultsGetData, ListAttemptResultsDiagnosticAdminResultsGetResponses, ListDiagnosticQuestionsDiagnosticQuestionsGetData, ListDiagnosticQuestionsDiagnosticQuestionsGetErrors, ListDiagnosticQuestionsDiagnosticQuestionsGetResponses, ListDiagnosticSetsDiagnosticSetsGetData, ListDiagnosticSetsDiagnosticSetsGetErrors, ListDiagnosticSetsDiagnosticSetsGetResponses, ListPublishedDiagnosticSetsDiagnosticSetsPublishedGetData, ListPublishedDiagnosticSetsDiagnosticSetsPublishedGetErrors, ListPublishedDiagnosticSetsDiagnosticSetsPublishedGetResponses, ListPublishedSubjectsSubjectsGetData, ListPublishedSubjectsSubjectsGetResponses, ListWaitlistWaitlistGetData, ListWaitlistWaitlistGetResponses, LoginUsersLoginPostData, LoginUsersLoginPostErrors, LoginUsersLoginPostResponses, MoreInfoUsersMoreInfoPostData, MoreInfoUsersMoreInfoPostErrors, MoreInfoUsersMoreInfoPostResponses, PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetData, PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetErrors, PreviewDiagnosticSetDiagnosticSetsSetIdPreviewGetResponses, ResendVerificationUsersResendVerificationPostData, ResendVerificationUsersResendVerificationPostErrors, ResendVerificationUsersResendVerificationPostResponses, RootGetData, RootGetResponses, SetQuestionStatusQuestionsSetStatusPostData, SetQuestionStatusQuestionsSetStatusPostErrors, SetQuestionStatusQuestionsSetStatusPostResponses, SignupUsersPostData, SignupUsersPostErrors, SignupUsersPostResponses, StartOrResumeAttemptDiagnosticAttemptsPostData, StartOrResumeAttemptDiagnosticAttemptsPostErrors, StartOrResumeAttemptDiagnosticAttemptsPostResponses, SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostData, SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostErrors, SubmitAttemptDiagnosticAttemptsAttemptIdSubmitPostResponses, UpdateDiagnosticQuestionDiagnosticQuestionsQuestionIdPatchData, UpdateDiagnosticQuestionDiagnosticQuestionsQuestionIdPatchErrors, UpdateDiagnosticQuestionDiagnosticQuestionsQuestionIdPatchResponses, UpdateDiagnosticSetDiagnosticSetsSetIdPatchData, UpdateDiagnosticSetDiagnosticSetsSetIdPatchErrors, UpdateDiagnosticSetDiagnosticSetsSetIdPatchResponses, UpdateOptionQuestionsQuestionIdOptionOptionIdPatchData, UpdateOptionQuestionsQuestionIdOptionOptionIdPatchErrors, UpdateOptionQuestionsQuestionIdOptionOptionIdPatchResponses, UpdateQuestionQuestionsQuestionIdPatchData, UpdateQuestionQuestionsQuestionIdPatchErrors, UpdateQuestionQuestionsQuestionIdPatchResponses, UpdateSubjectSubjectsSubjectIdPatchData, UpdateSubjectSubjectsSubjectIdPatchErrors, UpdateSubjectSubjectsSubjectIdPatchResponses, UpdateTopicTopicsTopicIdPatchData, UpdateTopicTopicsTopicIdPatchErrors, UpdateTopicTopicsTopicIdPatchResponses, UploadDiagnosticQuestionDiagramDiagnosticQuestionsQuestionIdDiagramPostData, UploadDiagnosticQuestionDiagramDiagnosticQuestionsQuestionIdDiagramPostErrors, UploadDiagnosticQuestionDiagramDiagnosticQuestionsQuestionIdDiagramPostResponses, UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchData, UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchErrors, UpsertDiagnosticResponseDiagnosticAttemptsAttemptIdResponsesQuestionIdPatchResponses, VerifyEmailUsersVerifyPostData, VerifyEmailUsersVerifyPostErrors, VerifyEmailUsersVerifyPostResponses } from './types.gen';
 
 export type Options<TData extends TDataShape = TDataShape, ThrowOnError extends boolean = boolean> = Options2<TData, ThrowOnError> & {
     /**
@@ -24,6 +24,12 @@ export type Options<TData extends TDataShape = TDataShape, ThrowOnError extends 
 export const convertLatexConverterPost = <ThrowOnError extends boolean = false>(options: Options<ConvertLatexConverterPostData, ThrowOnError>) => {
     return (options.client ?? client).post<ConvertLatexConverterPostResponses, ConvertLatexConverterPostErrors, ThrowOnError>({
         ...formDataBodySerializer,
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/converter',
         ...options,
         headers: {
@@ -105,6 +111,12 @@ export const setQuestionStatusQuestionsSetStatusPost = <ThrowOnError extends boo
  */
 export const deleteQuestionQuestionsQuestionIdDelete = <ThrowOnError extends boolean = false>(options: Options<DeleteQuestionQuestionsQuestionIdDeleteData, ThrowOnError>) => {
     return (options.client ?? client).delete<DeleteQuestionQuestionsQuestionIdDeleteResponses, DeleteQuestionQuestionsQuestionIdDeleteErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/questions/{question_id}',
         ...options
     });
@@ -128,6 +140,12 @@ export const getQuestionQuestionsQuestionIdGet = <ThrowOnError extends boolean =
  */
 export const updateQuestionQuestionsQuestionIdPatch = <ThrowOnError extends boolean = false>(options: Options<UpdateQuestionQuestionsQuestionIdPatchData, ThrowOnError>) => {
     return (options.client ?? client).patch<UpdateQuestionQuestionsQuestionIdPatchResponses, UpdateQuestionQuestionsQuestionIdPatchErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/questions/{question_id}',
         ...options,
         headers: {
@@ -164,6 +182,12 @@ export const getQuestionOptionsQuestionsQuestionIdOptionsGet = <ThrowOnError ext
  */
 export const createOptionQuestionsQuestionIdOptionPost = <ThrowOnError extends boolean = false>(options: Options<CreateOptionQuestionsQuestionIdOptionPostData, ThrowOnError>) => {
     return (options.client ?? client).post<CreateOptionQuestionsQuestionIdOptionPostResponses, CreateOptionQuestionsQuestionIdOptionPostErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/questions/{question_id}/option',
         ...options,
         headers: {
@@ -179,6 +203,12 @@ export const createOptionQuestionsQuestionIdOptionPost = <ThrowOnError extends b
  */
 export const deleteOptionQuestionsQuestionIdOptionOptionIdDelete = <ThrowOnError extends boolean = false>(options: Options<DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteData, ThrowOnError>) => {
     return (options.client ?? client).delete<DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteResponses, DeleteOptionQuestionsQuestionIdOptionOptionIdDeleteErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/questions/{question_id}/option/{option_id}',
         ...options
     });
@@ -192,6 +222,12 @@ export const deleteOptionQuestionsQuestionIdOptionOptionIdDelete = <ThrowOnError
  */
 export const updateOptionQuestionsQuestionIdOptionOptionIdPatch = <ThrowOnError extends boolean = false>(options: Options<UpdateOptionQuestionsQuestionIdOptionOptionIdPatchData, ThrowOnError>) => {
     return (options.client ?? client).patch<UpdateOptionQuestionsQuestionIdOptionOptionIdPatchResponses, UpdateOptionQuestionsQuestionIdOptionOptionIdPatchErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/questions/{question_id}/option/{option_id}',
         ...options,
         headers: {
@@ -216,6 +252,12 @@ export const getAllSyllabusSyllabusGet = <ThrowOnError extends boolean = false>(
  */
 export const createSyllabusSyllabusPost = <ThrowOnError extends boolean = false>(options: Options<CreateSyllabusSyllabusPostData, ThrowOnError>) => {
     return (options.client ?? client).post<CreateSyllabusSyllabusPostResponses, CreateSyllabusSyllabusPostErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/syllabus',
         ...options,
         headers: {
@@ -236,6 +278,49 @@ export const getSyllabusSyllabusSyllabusIdGet = <ThrowOnError extends boolean = 
 };
 
 /**
+ * List Published Subjects
+ * The student-facing subject catalogue.
+ *
+ * Defined before /{subject_id} so the literal path wins. No auth: anyone can
+ * see what's on offer, the same as the diagnostics catalogue.
+ *
+ * Only published subjects. This list used to live in the frontend as a
+ * hard-coded array of two uuids, so every subject created afterwards was
+ * unreachable — nothing linked to it. Serving it from here means a new
+ * subject appears on the site by being published rather than by someone
+ * remembering to edit a TypeScript file.
+ *
+ * question_count is what makes an empty subject visibly empty rather than a
+ * dead end a student clicks into.
+ */
+export const listPublishedSubjectsSubjectsGet = <ThrowOnError extends boolean = false>(options?: Options<ListPublishedSubjectsSubjectsGetData, ThrowOnError>) => {
+    return (options?.client ?? client).get<ListPublishedSubjectsSubjectsGetResponses, unknown, ThrowOnError>({
+        url: '/subjects',
+        ...options
+    });
+};
+
+/**
+ * Create Subject
+ */
+export const createSubjectSubjectsPost = <ThrowOnError extends boolean = false>(options: Options<CreateSubjectSubjectsPostData, ThrowOnError>) => {
+    return (options.client ?? client).post<CreateSubjectSubjectsPostResponses, CreateSubjectSubjectsPostErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
+        url: '/subjects',
+        ...options,
+        headers: {
+            'Content-Type': 'application/json',
+            ...options.headers
+        }
+    });
+};
+
+/**
  * Get Subject
  */
 export const getSubjectSubjectsSubjectIdGet = <ThrowOnError extends boolean = false>(options: Options<GetSubjectSubjectsSubjectIdGetData, ThrowOnError>) => {
@@ -246,11 +331,22 @@ export const getSubjectSubjectsSubjectIdGet = <ThrowOnError extends boolean = fa
 };
 
 /**
- * Create Subject
+ * Update Subject
+ * Publish or unpublish a subject.
+ *
+ * Publishing is what puts a subject on the student-facing catalogue, so it is
+ * the deliberate step between "I have created this and am filling it with
+ * questions" and "students are offered it".
  */
-export const createSubjectSubjectsPost = <ThrowOnError extends boolean = false>(options: Options<CreateSubjectSubjectsPostData, ThrowOnError>) => {
-    return (options.client ?? client).post<CreateSubjectSubjectsPostResponses, CreateSubjectSubjectsPostErrors, ThrowOnError>({
-        url: '/subjects',
+export const updateSubjectSubjectsSubjectIdPatch = <ThrowOnError extends boolean = false>(options: Options<UpdateSubjectSubjectsSubjectIdPatchData, ThrowOnError>) => {
+    return (options.client ?? client).patch<UpdateSubjectSubjectsSubjectIdPatchResponses, UpdateSubjectSubjectsSubjectIdPatchErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
+        url: '/subjects/{subject_id}',
         ...options,
         headers: {
             'Content-Type': 'application/json',
@@ -274,6 +370,12 @@ export const getAllLevelsLevelsGet = <ThrowOnError extends boolean = false>(opti
  */
 export const createLevelLevelsPost = <ThrowOnError extends boolean = false>(options: Options<CreateLevelLevelsPostData, ThrowOnError>) => {
     return (options.client ?? client).post<CreateLevelLevelsPostResponses, CreateLevelLevelsPostErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/levels',
         ...options,
         headers: {
@@ -288,6 +390,12 @@ export const createLevelLevelsPost = <ThrowOnError extends boolean = false>(opti
  */
 export const deleteLevelLevelsLevelIdDelete = <ThrowOnError extends boolean = false>(options: Options<DeleteLevelLevelsLevelIdDeleteData, ThrowOnError>) => {
     return (options.client ?? client).delete<DeleteLevelLevelsLevelIdDeleteResponses, DeleteLevelLevelsLevelIdDeleteErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/levels/{level_id}',
         ...options
     });
@@ -308,6 +416,12 @@ export const getTopicsBySubjectTopicsSubjectIdGet = <ThrowOnError extends boolea
  */
 export const createTopicTopicsPost = <ThrowOnError extends boolean = false>(options: Options<CreateTopicTopicsPostData, ThrowOnError>) => {
     return (options.client ?? client).post<CreateTopicTopicsPostResponses, CreateTopicTopicsPostErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/topics',
         ...options,
         headers: {
@@ -322,6 +436,12 @@ export const createTopicTopicsPost = <ThrowOnError extends boolean = false>(opti
  */
 export const deleteTopicTopicsTopicIdDelete = <ThrowOnError extends boolean = false>(options: Options<DeleteTopicTopicsTopicIdDeleteData, ThrowOnError>) => {
     return (options.client ?? client).delete<DeleteTopicTopicsTopicIdDeleteResponses, DeleteTopicTopicsTopicIdDeleteErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/topics/{topic_id}',
         ...options
     });
@@ -335,6 +455,12 @@ export const deleteTopicTopicsTopicIdDelete = <ThrowOnError extends boolean = fa
  */
 export const updateTopicTopicsTopicIdPatch = <ThrowOnError extends boolean = false>(options: Options<UpdateTopicTopicsTopicIdPatchData, ThrowOnError>) => {
     return (options.client ?? client).patch<UpdateTopicTopicsTopicIdPatchResponses, UpdateTopicTopicsTopicIdPatchErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/topics/{topic_id}',
         ...options,
         headers: {
@@ -349,6 +475,12 @@ export const updateTopicTopicsTopicIdPatch = <ThrowOnError extends boolean = fal
  */
 export const createPaperPapersPost = <ThrowOnError extends boolean = false>(options: Options<CreatePaperPapersPostData, ThrowOnError>) => {
     return (options.client ?? client).post<CreatePaperPapersPostResponses, CreatePaperPapersPostErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/papers',
         ...options,
         headers: {
@@ -363,16 +495,28 @@ export const createPaperPapersPost = <ThrowOnError extends boolean = false>(opti
  */
 export const deletePaperPapersPaperIdDelete = <ThrowOnError extends boolean = false>(options: Options<DeletePaperPapersPaperIdDeleteData, ThrowOnError>) => {
     return (options.client ?? client).delete<DeletePaperPapersPaperIdDeleteResponses, DeletePaperPapersPaperIdDeleteErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/papers/{paper_id}',
         ...options
     });
 };
 
 /**
- * Delete Paper
+ * Delete Paper Instance
  */
-export const deletePaperPapersInstanceInstanceIdDelete = <ThrowOnError extends boolean = false>(options: Options<DeletePaperPapersInstanceInstanceIdDeleteData, ThrowOnError>) => {
-    return (options.client ?? client).delete<DeletePaperPapersInstanceInstanceIdDeleteResponses, DeletePaperPapersInstanceInstanceIdDeleteErrors, ThrowOnError>({
+export const deletePaperInstancePapersInstanceInstanceIdDelete = <ThrowOnError extends boolean = false>(options: Options<DeletePaperInstancePapersInstanceInstanceIdDeleteData, ThrowOnError>) => {
+    return (options.client ?? client).delete<DeletePaperInstancePapersInstanceInstanceIdDeleteResponses, DeletePaperInstancePapersInstanceInstanceIdDeleteErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/papers/instance/{instance_id}',
         ...options
     });
@@ -403,6 +547,12 @@ export const getPaperInstancesBySubjectIdPapersInstanceSubjectSubjectIdGet = <Th
  */
 export const createPaperInstancePapersInstancePost = <ThrowOnError extends boolean = false>(options: Options<CreatePaperInstancePapersInstancePostData, ThrowOnError>) => {
     return (options.client ?? client).post<CreatePaperInstancePapersInstancePostResponses, CreatePaperInstancePapersInstancePostErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/papers/instance',
         ...options,
         headers: {
@@ -417,6 +567,12 @@ export const createPaperInstancePapersInstancePost = <ThrowOnError extends boole
  */
 export const createPaperVariantPapersVariantPost = <ThrowOnError extends boolean = false>(options: Options<CreatePaperVariantPapersVariantPostData, ThrowOnError>) => {
     return (options.client ?? client).post<CreatePaperVariantPapersVariantPostResponses, CreatePaperVariantPapersVariantPostErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/papers/variant',
         ...options,
         headers: {
@@ -431,6 +587,12 @@ export const createPaperVariantPapersVariantPost = <ThrowOnError extends boolean
  */
 export const deleteVariantPapersVariantVariantIdDelete = <ThrowOnError extends boolean = false>(options: Options<DeleteVariantPapersVariantVariantIdDeleteData, ThrowOnError>) => {
     return (options.client ?? client).delete<DeleteVariantPapersVariantVariantIdDeleteResponses, DeleteVariantPapersVariantVariantIdDeleteErrors, ThrowOnError>({
+        security: [
+            {
+                scheme: 'bearer',
+                type: 'http'
+            }
+        ],
         url: '/papers/variant/{variant_id}',
         ...options
     });

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -247,6 +247,10 @@ export type BaseSubject = {
      * Papers
      */
     papers: Array<Paper>;
+    /**
+     * Ispublished
+     */
+    isPublished?: boolean;
 };
 
 /**
@@ -1284,6 +1288,34 @@ export type PublishedDiagnosticSet = {
 };
 
 /**
+ * PublishedSubject
+ * A subject as the student-facing catalogue needs it — enough for a card,
+ * without the full topic and paper lists the admin view carries.
+ */
+export type PublishedSubject = {
+    /**
+     * Id
+     */
+    id: string;
+    /**
+     * Name
+     */
+    name: string;
+    /**
+     * Code
+     */
+    code: string;
+    /**
+     * Topiccount
+     */
+    topicCount: number;
+    /**
+     * Questioncount
+     */
+    questionCount: number;
+};
+
+/**
  * QuestionResponse
  */
 export type QuestionResponse = {
@@ -1830,6 +1862,16 @@ export type UpdateQuestionBody = {
      * Marks
      */
     marks?: number | null;
+};
+
+/**
+ * UpdateSubjectBody
+ */
+export type UpdateSubjectBody = {
+    /**
+     * Ispublished
+     */
+    isPublished?: boolean | null;
 };
 
 /**
@@ -2540,6 +2582,46 @@ export type GetSyllabusSyllabusSyllabusIdGetResponses = {
 
 export type GetSyllabusSyllabusSyllabusIdGetResponse = GetSyllabusSyllabusSyllabusIdGetResponses[keyof GetSyllabusSyllabusSyllabusIdGetResponses];
 
+export type ListPublishedSubjectsSubjectsGetData = {
+    body?: never;
+    path?: never;
+    query?: never;
+    url: '/subjects';
+};
+
+export type ListPublishedSubjectsSubjectsGetResponses = {
+    /**
+     * Response List Published Subjects Subjects Get
+     * Successful Response
+     */
+    200: Array<PublishedSubject>;
+};
+
+export type ListPublishedSubjectsSubjectsGetResponse = ListPublishedSubjectsSubjectsGetResponses[keyof ListPublishedSubjectsSubjectsGetResponses];
+
+export type CreateSubjectSubjectsPostData = {
+    body: CreateSubjectBody;
+    path?: never;
+    query?: never;
+    url: '/subjects';
+};
+
+export type CreateSubjectSubjectsPostErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type CreateSubjectSubjectsPostError = CreateSubjectSubjectsPostErrors[keyof CreateSubjectSubjectsPostErrors];
+
+export type CreateSubjectSubjectsPostResponses = {
+    /**
+     * Successful Response
+     */
+    200: unknown;
+};
+
 export type GetSubjectSubjectsSubjectIdGetData = {
     body?: never;
     path: {
@@ -2570,23 +2652,28 @@ export type GetSubjectSubjectsSubjectIdGetResponses = {
 
 export type GetSubjectSubjectsSubjectIdGetResponse = GetSubjectSubjectsSubjectIdGetResponses[keyof GetSubjectSubjectsSubjectIdGetResponses];
 
-export type CreateSubjectSubjectsPostData = {
-    body: CreateSubjectBody;
-    path?: never;
+export type UpdateSubjectSubjectsSubjectIdPatchData = {
+    body: UpdateSubjectBody;
+    path: {
+        /**
+         * Subject Id
+         */
+        subject_id: string;
+    };
     query?: never;
-    url: '/subjects';
+    url: '/subjects/{subject_id}';
 };
 
-export type CreateSubjectSubjectsPostErrors = {
+export type UpdateSubjectSubjectsSubjectIdPatchErrors = {
     /**
      * Validation Error
      */
     422: HttpValidationError;
 };
 
-export type CreateSubjectSubjectsPostError = CreateSubjectSubjectsPostErrors[keyof CreateSubjectSubjectsPostErrors];
+export type UpdateSubjectSubjectsSubjectIdPatchError = UpdateSubjectSubjectsSubjectIdPatchErrors[keyof UpdateSubjectSubjectsSubjectIdPatchErrors];
 
-export type CreateSubjectSubjectsPostResponses = {
+export type UpdateSubjectSubjectsSubjectIdPatchResponses = {
     /**
      * Successful Response
      */
@@ -2822,7 +2909,7 @@ export type DeletePaperPapersPaperIdDeleteResponses = {
     200: unknown;
 };
 
-export type DeletePaperPapersInstanceInstanceIdDeleteData = {
+export type DeletePaperInstancePapersInstanceInstanceIdDeleteData = {
     body?: never;
     path: {
         /**
@@ -2834,16 +2921,16 @@ export type DeletePaperPapersInstanceInstanceIdDeleteData = {
     url: '/papers/instance/{instance_id}';
 };
 
-export type DeletePaperPapersInstanceInstanceIdDeleteErrors = {
+export type DeletePaperInstancePapersInstanceInstanceIdDeleteErrors = {
     /**
      * Validation Error
      */
     422: HttpValidationError;
 };
 
-export type DeletePaperPapersInstanceInstanceIdDeleteError = DeletePaperPapersInstanceInstanceIdDeleteErrors[keyof DeletePaperPapersInstanceInstanceIdDeleteErrors];
+export type DeletePaperInstancePapersInstanceInstanceIdDeleteError = DeletePaperInstancePapersInstanceInstanceIdDeleteErrors[keyof DeletePaperInstancePapersInstanceInstanceIdDeleteErrors];
 
-export type DeletePaperPapersInstanceInstanceIdDeleteResponses = {
+export type DeletePaperInstancePapersInstanceInstanceIdDeleteResponses = {
     /**
      * Successful Response
      */

--- a/src/components/questionBank/AnimatedQuestionCard.tsx
+++ b/src/components/questionBank/AnimatedQuestionCard.tsx
@@ -94,21 +94,16 @@ export function AnimatedQuestionCard({
                                 >
                                     {question.difficulty}
                                 </Badge>
-                                {/* A question generated against the syllabus
-                                    has no past paper to name; it's identified
-                                    by its chapter instead. */}
-                                {question.paper ? (
+                                {/* Only a past-paper question has anything to
+                                    say here. A syllabus-generated one's chapter
+                                    *is* its topic, and the topic badge on the
+                                    left already says it — printing it again on
+                                    the right just showed the same words twice. */}
+                                {question.paper && (
                                     <span className="text-sm text-gray-500">
                                         {question.paper.name} (
                                         {question.paperVariant?.year})
                                     </span>
-                                ) : (
-                                    question.chapter && (
-                                        <span className="text-sm text-gray-500">
-                                            {question.chapterTitle ??
-                                                question.chapter}
-                                        </span>
-                                    )
                                 )}
                             </div>
                         </div>

--- a/src/components/questionBank/QuestionBank.tsx
+++ b/src/components/questionBank/QuestionBank.tsx
@@ -152,17 +152,23 @@ export function QuestionBank({ subjectId }: Props) {
                         variant="inverted"
                         maxCount={3}
                     />
-                    <MultiSelect
-                        value={papers}
-                        options={paperOptions}
-                        onValueChange={(e) => {
-                            setFilterSearchParams({ page: 1, papers: e })
-                        }}
-                        defaultValue={papers}
-                        placeholder="Select paper"
-                        variant="inverted"
-                        maxCount={2}
-                    />
+                    {/* Hidden for a subject with no past papers — SPM
+                        Chemistry's questions are generated against the
+                        syllabus, so a paper filter there offers nothing to
+                        pick and, if picked, would match nothing. */}
+                    {paperOptions.length > 0 && (
+                        <MultiSelect
+                            value={papers}
+                            options={paperOptions}
+                            onValueChange={(e) => {
+                                setFilterSearchParams({ page: 1, papers: e })
+                            }}
+                            defaultValue={papers}
+                            placeholder="Select paper"
+                            variant="inverted"
+                            maxCount={2}
+                        />
+                    )}
                 </div>
                 <div className="w-full space-y-2 flex flex-col grow">
                     <style>{`

--- a/src/components/questionManager/subject/PublishSubjectCard.tsx
+++ b/src/components/questionManager/subject/PublishSubjectCard.tsx
@@ -1,0 +1,75 @@
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { Badge } from '@/components/ui/badge.tsx'
+import useUpdateSubjectMutation from '@/hooks/useUpdateSubjectMutation.ts'
+import { toast } from 'sonner'
+
+/**
+ * Whether students are offered this subject.
+ *
+ * The catalogue is served from the database now, so this toggle is the only
+ * thing standing between a subject existing and students being sent to it —
+ * which is why an unpublished subject is the default and why the state is
+ * spelled out here rather than implied by a switch with no label.
+ */
+export function PublishSubjectCard({
+    subjectId,
+    subjectName,
+    isPublished,
+}: {
+    subjectId: string
+    subjectName: string
+    isPublished: boolean
+}) {
+    const { mutateAsync, isPending } = useUpdateSubjectMutation({ subjectId })
+
+    async function toggle() {
+        try {
+            await mutateAsync(!isPublished)
+            toast.success(
+                isPublished
+                    ? `${subjectName} is no longer offered to students.`
+                    : `${subjectName} is now live on /subjects.`
+            )
+        } catch {
+            toast.error('Could not update the subject.')
+        }
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                    Student visibility
+                    <Badge variant={isPublished ? 'default' : 'secondary'}>
+                        {isPublished ? 'Live' : 'Not published'}
+                    </Badge>
+                </CardTitle>
+                <CardDescription>
+                    {isPublished
+                        ? 'Students see this subject on /subjects and can practise its questions.'
+                        : 'Students cannot see this subject. Publish it once it has questions worth practising.'}
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                <Button
+                    variant={isPublished ? 'outline' : 'default'}
+                    onClick={toggle}
+                    disabled={isPending}
+                >
+                    {isPending
+                        ? 'Saving…'
+                        : isPublished
+                          ? 'Unpublish'
+                          : 'Publish to students'}
+                </Button>
+            </CardContent>
+        </Card>
+    )
+}

--- a/src/components/questionManager/subject/SubjectQuestionsCard.tsx
+++ b/src/components/questionManager/subject/SubjectQuestionsCard.tsx
@@ -1,0 +1,146 @@
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card.tsx'
+import { Badge } from '@/components/ui/badge.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { ClipLoader } from 'react-spinners'
+import useGetPaginatedQuestionsBySubjectQuery from '@/hooks/useGetPaginatedQuestionsBySubjectQuery.ts'
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+
+/**
+ * Every question in a subject, however it was created.
+ *
+ * Bulk-imported questions belong to no paper instance by design, so the
+ * paper-instance page — which filters by exactly that — could never list them.
+ * A batch of 40 imported cleanly into the database and then appeared nowhere in
+ * the admin UI at all. This is the screen that was missing.
+ */
+export function SubjectQuestionsCard({ subjectId }: { subjectId: string }) {
+    const [page, setPage] = useState(1)
+    const { data, isLoading } = useGetPaginatedQuestionsBySubjectQuery({
+        subjectId,
+        page,
+        size: 20,
+        // Unfiltered: this card exists to show everything in the subject,
+        // including the imported questions that belong to no paper instance
+        // and so appear on no other admin screen.
+        topics: [],
+        difficulty: [],
+        papers: [],
+    })
+
+    const total = data?.total ?? 0
+    const items = data?.items ?? []
+    const lastPage = Math.max(1, Math.ceil(total / 20))
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                    Questions
+                    {isLoading ? (
+                        <ClipLoader size={15} />
+                    ) : (
+                        <Badge variant="secondary">{total}</Badge>
+                    )}
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                {!isLoading && total === 0 && (
+                    <p className="text-sm text-muted-foreground">
+                        No questions yet. Add them one at a time from a paper
+                        instance, or use Bulk import above.
+                    </p>
+                )}
+
+                <div className="space-y-2">
+                    {items.map((question) => (
+                        <div
+                            key={question.id}
+                            className="flex items-start justify-between gap-4 rounded-md border p-3"
+                        >
+                            <div className="min-w-0">
+                                <p className="truncate text-sm">
+                                    {/* A text question shows its stem; a
+                                        converted past-paper one has no stem to
+                                        show, so it's identified by its position
+                                        in the paper. */}
+                                    {question.stem ??
+                                        `${question.paper?.name ?? 'Question'} Q${question.number ?? '?'}`}
+                                </p>
+                                <div className="mt-1 flex flex-wrap gap-1">
+                                    {question.chapterTitle && (
+                                        <Badge variant="outline">
+                                            {question.chapterTitle}
+                                        </Badge>
+                                    )}
+                                    {question.topicCode && (
+                                        <Badge variant="outline">
+                                            {question.topicCode}
+                                        </Badge>
+                                    )}
+                                    <Badge variant="outline">
+                                        {question.difficulty}
+                                    </Badge>
+                                    {question.archetype && (
+                                        <Badge variant="outline">
+                                            {question.archetype}
+                                        </Badge>
+                                    )}
+                                    {question.publishStatus && (
+                                        <Badge
+                                            variant={
+                                                question.publishStatus ===
+                                                'published'
+                                                    ? 'default'
+                                                    : 'secondary'
+                                            }
+                                        >
+                                            {question.publishStatus}
+                                        </Badge>
+                                    )}
+                                </div>
+                            </div>
+                            <Link
+                                to={`/questions/${subjectId}`}
+                                className="shrink-0"
+                            >
+                                <Button variant="ghost" size="sm">
+                                    View in bank
+                                </Button>
+                            </Link>
+                        </div>
+                    ))}
+                </div>
+
+                {total > 20 && (
+                    <div className="mt-4 flex items-center justify-between">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={page === 1}
+                            onClick={() => setPage((p) => p - 1)}
+                        >
+                            Previous
+                        </Button>
+                        <span className="text-sm text-muted-foreground">
+                            Page {page} of {lastPage}
+                        </span>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={page >= lastPage}
+                            onClick={() => setPage((p) => p + 1)}
+                        >
+                            Next
+                        </Button>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    )
+}

--- a/src/hooks/useDeletePaperInstanceMutation.ts
+++ b/src/hooks/useDeletePaperInstanceMutation.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { deletePaperPapersInstanceInstanceIdDelete } from '@/client'
+import { deletePaperInstancePapersInstanceInstanceIdDelete } from '@/client'
 import { getAuthHeaders } from '@/lib/authHeaders.ts'
 
 type Props = {
@@ -10,7 +10,7 @@ export default function useDeletePaperInstanceMutation({ subjectId }: Props) {
 
     return useMutation({
         mutationFn: async (paperInstanceId: string) =>
-            await deletePaperPapersInstanceInstanceIdDelete({
+            await deletePaperInstancePapersInstanceInstanceIdDelete({
                 headers: getAuthHeaders(),
                 path: {
                     instance_id: paperInstanceId,

--- a/src/hooks/usePublishedSubjectsQuery.ts
+++ b/src/hooks/usePublishedSubjectsQuery.ts
@@ -13,7 +13,15 @@ export default function usePublishedSubjectsQuery() {
         queryKey: ['published-subjects'],
         queryFn: async () => {
             const result = await listPublishedSubjectsSubjectsGet()
-            return result.data ?? []
+            // The generated client resolves { data: undefined, error } instead
+            // of throwing, so `result.data ?? []` would render an empty
+            // catalogue for a failed request — a page saying "no subjects"
+            // when the truth is "couldn't ask". Throwing puts the query in
+            // isError, which the page reports honestly.
+            if (result.error !== undefined || result.data === undefined) {
+                throw new Error('Could not load subjects.')
+            }
+            return result.data
         },
     })
 }

--- a/src/hooks/usePublishedSubjectsQuery.ts
+++ b/src/hooks/usePublishedSubjectsQuery.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+import { listPublishedSubjectsSubjectsGet } from '@/client'
+
+/**
+ * The subjects students are offered.
+ *
+ * Previously a hard-coded array of two uuids in SubjectsPage, which is why a
+ * subject created afterwards was unreachable — nothing linked to it. Reading
+ * it from the API means publishing a subject is what puts it on the site.
+ */
+export default function usePublishedSubjectsQuery() {
+    return useQuery({
+        queryKey: ['published-subjects'],
+        queryFn: async () => {
+            const result = await listPublishedSubjectsSubjectsGet()
+            return result.data ?? []
+        },
+    })
+}

--- a/src/hooks/useUpdateSubjectMutation.ts
+++ b/src/hooks/useUpdateSubjectMutation.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { updateSubjectSubjectsSubjectIdPatch } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
+
+/**
+ * Publish or unpublish a subject — what puts it on, or takes it off, the
+ * student-facing catalogue.
+ */
+export default function useUpdateSubjectMutation({
+    subjectId,
+}: {
+    subjectId: string
+}) {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: async (isPublished: boolean) => {
+            const result = await updateSubjectSubjectsSubjectIdPatch({
+                path: { subject_id: subjectId },
+                body: { isPublished },
+                headers: getAuthHeaders(),
+            })
+            // The generated client resolves { data: undefined, error } rather
+            // than throwing, so returning `.data` blindly would show the toggle
+            // flipped for a change the server rejected.
+            if (result.error !== undefined) {
+                throw new Error('Could not update the subject.')
+            }
+            return result.data
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['subject'] })
+            queryClient.invalidateQueries({ queryKey: ['published-subjects'] })
+        },
+    })
+}

--- a/src/pages/Admin/SubjectPage.tsx
+++ b/src/pages/Admin/SubjectPage.tsx
@@ -16,6 +16,8 @@ import { TopicsTable } from '@/components/questionManager/subject/TopicsTable.ts
 import { PapersTable } from '@/components/questionManager/subject/PapersTable.tsx'
 import { BreadCrumbs } from '@/components/questionManager/BreadCrumbs.tsx'
 import { SpmBulkImportDialog } from '@/components/questionManager/SpmBulkImportDialog.tsx'
+import { SubjectQuestionsCard } from '@/components/questionManager/subject/SubjectQuestionsCard.tsx'
+import { PublishSubjectCard } from '@/components/questionManager/subject/PublishSubjectCard.tsx'
 import { Button } from '@/components/ui/button.tsx'
 import { useState } from 'react'
 
@@ -65,6 +67,13 @@ export function SubjectPage() {
                     open={importOpen}
                     onOpenChange={setImportOpen}
                 />
+                <div className="mb-4">
+                    <PublishSubjectCard
+                        subjectId={subjectId ?? ''}
+                        subjectName={data?.name ?? ''}
+                        isPublished={data?.isPublished ?? false}
+                    />
+                </div>
                 <div className="grid grid-cols-2 gap-4">
                     <TopicsTable
                         isLoading={isLoading}
@@ -98,6 +107,12 @@ export function SubjectPage() {
                             />
                         </CardFooter>
                     </Card>
+                </div>
+                {/* Every question in the subject, including the bulk-imported
+                    ones that belong to no paper instance and so appear on no
+                    other admin screen. */}
+                <div className="mt-4">
+                    <SubjectQuestionsCard subjectId={subjectId ?? ''} />
                 </div>
             </div>
         </AdminLayout>

--- a/src/pages/SubjectsPage.test.tsx
+++ b/src/pages/SubjectsPage.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import SubjectsPage from './SubjectsPage'
+
+const mockQuery = vi.fn()
+vi.mock('@/hooks/usePublishedSubjectsQuery.ts', () => ({
+    default: () => mockQuery(),
+}))
+
+function renderGrid() {
+    render(
+        <MemoryRouter>
+            <SubjectsPage embedded />
+        </MemoryRouter>
+    )
+}
+
+describe('SubjectsPage', () => {
+    it('lists whatever the API returns, not a hard-coded set', () => {
+        // The bug this replaces: the list was two uuids in a TS array, so a
+        // subject created afterwards had nothing linking to it.
+        mockQuery.mockReturnValue({
+            data: [
+                { id: 'a', name: 'SPM Chemistry', code: 'CHEM', topicCount: 1, questionCount: 40 },
+                { id: 'b', name: 'SPM Physics', code: 'PHY', topicCount: 3, questionCount: 90 },
+            ],
+            isLoading: false,
+            isError: false,
+        })
+        renderGrid()
+
+        expect(screen.getByText('SPM Chemistry')).toBeInTheDocument()
+        expect(screen.getByText('SPM Physics')).toBeInTheDocument()
+        expect(screen.getByText('40 questions')).toBeInTheDocument()
+    })
+
+    it('links each subject to its own bank', () => {
+        mockQuery.mockReturnValue({
+            data: [{ id: 'chem-id', name: 'SPM Chemistry', code: 'CHEM', topicCount: 1, questionCount: 40 }],
+            isLoading: false,
+            isError: false,
+        })
+        renderGrid()
+
+        expect(screen.getByRole('link')).toHaveAttribute(
+            'href',
+            '/questions/chem-id'
+        )
+    })
+
+    it('renders a subject it has no styling for rather than dropping it', () => {
+        // Presentation is keyed by name; an unknown subject must still appear,
+        // since "not in the lookup" is exactly how the old bug hid things.
+        mockQuery.mockReturnValue({
+            data: [{ id: 'x', name: 'SPM Geography', code: 'GEO', topicCount: 2, questionCount: 7 }],
+            isLoading: false,
+            isError: false,
+        })
+        renderGrid()
+
+        expect(screen.getByText('SPM Geography')).toBeInTheDocument()
+        expect(screen.getByText('Practise by topic and difficulty')).toBeInTheDocument()
+    })
+
+    it('says so when the subjects cannot be loaded', () => {
+        mockQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true })
+        renderGrid()
+
+        expect(screen.getByText(/Couldn't load subjects/)).toBeInTheDocument()
+    })
+})

--- a/src/pages/SubjectsPage.tsx
+++ b/src/pages/SubjectsPage.tsx
@@ -8,348 +8,111 @@ import {
     CardTitle,
 } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { ArrowRight, Calculator, TrendingUp } from 'lucide-react'
+import {
+    ArrowRight,
+    Atom,
+    BookOpen,
+    Calculator,
+    FlaskConical,
+    Leaf,
+    TrendingUp,
+} from 'lucide-react'
 import type { ElementType } from 'react'
 import { LandingLayout } from '@/components/layout/landing/LandingLayout.tsx'
-import useGetTopicsBySubjectQuery from '@/hooks/useGetTopicsBySubjectQuery.ts'
+import usePublishedSubjectsQuery from '@/hooks/usePublishedSubjectsQuery.ts'
+import type { PublishedSubject } from '@/client'
 
-interface Topic {
-    id: string
-    title: string
-    description: string
+type Presentation = {
     icon: ElementType
-    color: string
-    questions: number
-}
-
-interface Subject {
-    id: string
-    name: string
-    description: string
-    icon: ElementType
-    color: string
     gradient: string
-    topics: Topic[]
-    url: string
+    description: string
 }
 
-export const subjectsPage: Subject[] = [
-    {
-        id: '8d4a1938-789f-4c57-96b2-1c079941a59e',
-        url: '/questions/8d4a1938-789f-4c57-96b2-1c079941a59e',
-        name: 'Mathematics',
-        description: 'Master fundamental mathematics concepts for SPM',
+/**
+ * How a subject looks on its card.
+ *
+ * Presentation is a design decision, not data — there is no sensible column
+ * for "which lucide icon". Keyed by subject name, with a fallback, so a
+ * subject created in the admin appears immediately with a reasonable default
+ * rather than not appearing at all. That was the previous failure: the whole
+ * list lived here, so a subject nobody had hand-written was invisible.
+ */
+const PRESENTATION: Record<string, Presentation> = {
+    'Modern Mathematics': {
         icon: Calculator,
-        color: 'blue',
         gradient: 'from-blue-500 to-cyan-500',
-        topics: [
-            {
-                id: 'algebra',
-                title: 'Algebra',
-                description:
-                    'Master algebraic expressions, factorization, and expansions',
-                icon: Calculator,
-                color: 'bg-blue-100 text-blue-600',
-                questions: 250,
-            },
-            {
-                id: 'functions',
-                title: 'Functions',
-                description:
-                    'Understand function concepts, composite and inverse functions',
-                icon: TrendingUp,
-                color: 'bg-purple-100 text-purple-600',
-                questions: 180,
-            },
-            {
-                id: 'quadratic',
-                title: 'Quadratic Equations',
-                description:
-                    'Solve quadratic equations, inequalities, and graph quadratic functions',
-                icon: TrendingUp,
-                color: 'bg-green-100 text-green-600',
-                questions: 200,
-            },
-            {
-                id: 'simultaneous',
-                title: 'Simultaneous Equations',
-                description:
-                    'Learn to solve two or three linear equations simultaneously',
-                icon: Calculator,
-                color: 'bg-orange-100 text-orange-600',
-                questions: 150,
-            },
-            {
-                id: 'indices',
-                title: 'Indices & Logarithms',
-                description:
-                    'Master laws of indices and logarithmic operations',
-                icon: TrendingUp,
-                color: 'bg-yellow-100 text-yellow-600',
-                questions: 120,
-            },
-            {
-                id: 'coordinate',
-                title: 'Coordinate Geometry',
-                description:
-                    'Study points, lines, and geometric shapes on coordinate planes',
-                icon: Calculator,
-                color: 'bg-red-100 text-red-600',
-                questions: 170,
-            },
-            {
-                id: 'statistics',
-                title: 'Statistics',
-                description:
-                    'Analyze data with mean, median, mode, and standard deviation',
-                icon: TrendingUp,
-                color: 'bg-indigo-100 text-indigo-600',
-                questions: 160,
-            },
-            {
-                id: 'probability',
-                title: 'Probability',
-                description:
-                    'Calculate probabilities and understand probability distributions',
-                icon: Calculator,
-                color: 'bg-pink-100 text-pink-600',
-                questions: 140,
-            },
-        ],
+        description: 'Master fundamental mathematics concepts for SPM',
     },
-    {
-        url: '/questions/00246712-44e0-415e-aa87-d0e8c70e94d9',
-        id: '00246712-44e0-415e-aa87-d0e8c70e94d9',
-        name: 'Add Math',
-        description: 'Advanced mathematical concepts and techniques',
+    'Additional Mathematics': {
         icon: TrendingUp,
-        color: 'purple',
         gradient: 'from-purple-500 to-pink-500',
-        topics: [
-            {
-                id: 'functions',
-                title: 'Functions',
-                description:
-                    'Advanced function concepts including absolute value and composite functions',
-                icon: TrendingUp,
-                color: 'bg-purple-100 text-purple-600',
-                questions: 180,
-            },
-            {
-                id: 'quadratic-equations',
-                title: 'Quadratic Equations',
-                description:
-                    'Advanced quadratic equations and their applications',
-                icon: Calculator,
-                color: 'bg-pink-100 text-pink-600',
-                questions: 200,
-            },
-            {
-                id: 'indices-logarithms',
-                title: 'Indices & Logarithms',
-                description: 'Complex indices and logarithmic equations',
-                icon: TrendingUp,
-                color: 'bg-violet-100 text-violet-600',
-                questions: 150,
-            },
-            {
-                id: 'coordinate-geometry',
-                title: 'Coordinate Geometry',
-                description: 'Advanced topics in analytical geometry',
-                icon: Calculator,
-                color: 'bg-fuchsia-100 text-fuchsia-600',
-                questions: 170,
-            },
-            {
-                id: 'differentiation',
-                title: 'Differentiation',
-                description: 'Learn derivatives and their applications',
-                icon: TrendingUp,
-                color: 'bg-purple-100 text-purple-600',
-                questions: 220,
-            },
-            {
-                id: 'integration',
-                title: 'Integration',
-                description: 'Master integration techniques and applications',
-                icon: Calculator,
-                color: 'bg-pink-100 text-pink-600',
-                questions: 200,
-            },
-        ],
+        description: 'Advanced mathematics for SPM Additional Mathematics',
     },
-    // {
-    //     id: 'chemistry',
-    //     name: 'Chemistry',
-    //     description: 'Explore the composition and properties of matter',
-    //     icon: FlaskConical,
-    //     color: 'green',
-    //     gradient: 'from-green-500 to-emerald-500',
-    //     topics: [
-    //         {
-    //             id: 'atomic-structure',
-    //             title: 'Atomic Structure',
-    //             description:
-    //                 'Understanding atoms, protons, neutrons, and electrons',
-    //             icon: Atom,
-    //             color: 'bg-green-100 text-green-600',
-    //             questions: 180,
-    //         },
-    //         {
-    //             id: 'periodic-table',
-    //             title: 'Periodic Table',
-    //             description: 'Elements, groups, and periodic trends',
-    //             icon: FlaskConical,
-    //             color: 'bg-emerald-100 text-emerald-600',
-    //             questions: 160,
-    //         },
-    //         {
-    //             id: 'chemical-bonds',
-    //             title: 'Chemical Bonds',
-    //             description: 'Ionic, covalent, and metallic bonding',
-    //             icon: Atom,
-    //             color: 'bg-teal-100 text-teal-600',
-    //             questions: 190,
-    //         },
-    //         {
-    //             id: 'acids-bases',
-    //             title: 'Acids & Bases',
-    //             description: 'pH, neutralization, and salt formation',
-    //             icon: FlaskConical,
-    //             color: 'bg-lime-100 text-lime-600',
-    //             questions: 150,
-    //         },
-    //         {
-    //             id: 'electrochemistry',
-    //             title: 'Electrochemistry',
-    //             description: 'Electrolysis and electrochemical cells',
-    //             icon: Atom,
-    //             color: 'bg-green-100 text-green-600',
-    //             questions: 140,
-    //         },
-    //     ],
-    // },
-    // {
-    //     id: 'physics',
-    //     name: 'Physics',
-    //     description: 'Understand the fundamental laws of nature',
-    //     icon: Atom,
-    //     color: 'orange',
-    //     gradient: 'from-orange-500 to-red-500',
-    //     topics: [
-    //         {
-    //             id: 'mechanics',
-    //             title: 'Mechanics',
-    //             description: 'Motion, forces, work, energy, and power',
-    //             icon: Atom,
-    //             color: 'bg-orange-100 text-orange-600',
-    //             questions: 200,
-    //         },
-    //         {
-    //             id: 'waves',
-    //             title: 'Waves',
-    //             description: 'Wave properties, sound, and light',
-    //             icon: Atom,
-    //             color: 'bg-red-100 text-red-600',
-    //             questions: 180,
-    //         },
-    //         {
-    //             id: 'electricity',
-    //             title: 'Electricity',
-    //             description: 'Current, voltage, resistance, and circuits',
-    //             icon: Atom,
-    //             color: 'bg-amber-100 text-amber-600',
-    //             questions: 190,
-    //         },
-    //         {
-    //             id: 'electromagnetism',
-    //             title: 'Electromagnetism',
-    //             description: 'Magnetic fields and electromagnetic induction',
-    //             icon: Atom,
-    //             color: 'bg-orange-100 text-orange-600',
-    //             questions: 160,
-    //         },
-    //         {
-    //             id: 'radioactivity',
-    //             title: 'Radioactivity',
-    //             description: 'Nuclear physics and radioactive decay',
-    //             icon: Atom,
-    //             color: 'bg-red-100 text-red-600',
-    //             questions: 140,
-    //         },
-    //     ],
-    // },
-    // {
-    //     id: 'biology',
-    //     name: 'Biology',
-    //     description: 'Study living organisms and life processes',
-    //     icon: Dna,
-    //     color: 'teal',
-    //     gradient: 'from-teal-500 to-cyan-500',
-    //     topics: [
-    //         {
-    //             id: 'cell-structure',
-    //             title: 'Cell Structure',
-    //             description: 'Cell organelles and their functions',
-    //             icon: Dna,
-    //             color: 'bg-teal-100 text-teal-600',
-    //             questions: 170,
-    //         },
-    //         {
-    //             id: 'nutrition',
-    //             title: 'Nutrition',
-    //             description: 'Food, nutrients, and digestive system',
-    //             icon: Dna,
-    //             color: 'bg-cyan-100 text-cyan-600',
-    //             questions: 160,
-    //         },
-    //         {
-    //             id: 'respiration',
-    //             title: 'Respiration',
-    //             description: 'Cellular respiration and gas exchange',
-    //             icon: Dna,
-    //             color: 'bg-teal-100 text-teal-600',
-    //             questions: 150,
-    //         },
-    //         {
-    //             id: 'reproduction',
-    //             title: 'Reproduction',
-    //             description: 'Sexual and asexual reproduction',
-    //             icon: Dna,
-    //             color: 'bg-cyan-100 text-cyan-600',
-    //             questions: 140,
-    //         },
-    //         {
-    //             id: 'genetics',
-    //             title: 'Genetics',
-    //             description: 'DNA, genes, and inheritance',
-    //             icon: Dna,
-    //             color: 'bg-teal-100 text-teal-600',
-    //             questions: 180,
-    //         },
-    //         {
-    //             id: 'ecology',
-    //             title: 'Ecology',
-    //             description:
-    //                 'Ecosystems, food chains, and environmental conservation',
-    //             icon: Dna,
-    //             color: 'bg-cyan-100 text-cyan-600',
-    //             questions: 160,
-    //         },
-    //     ],
-    // },
-]
+    'SPM Chemistry': {
+        icon: FlaskConical,
+        gradient: 'from-emerald-500 to-teal-500',
+        description: 'Practise SPM Chemistry chapter by chapter',
+    },
+    'SPM Physics': {
+        icon: Atom,
+        gradient: 'from-orange-500 to-amber-500',
+        description: 'Practise SPM Physics chapter by chapter',
+    },
+    'SPM Biology': {
+        icon: Leaf,
+        gradient: 'from-lime-500 to-green-500',
+        description: 'Practise SPM Biology chapter by chapter',
+    },
+}
 
-function TopicCountBadge({ subjectId }: { subjectId: string }) {
-    const { data: topics, isLoading } = useGetTopicsBySubjectQuery(subjectId)
+const DEFAULT_PRESENTATION: Presentation = {
+    icon: BookOpen,
+    gradient: 'from-slate-500 to-slate-600',
+    description: 'Practise by topic and difficulty',
+}
+
+function presentationFor(name: string): Presentation {
+    return PRESENTATION[name] ?? DEFAULT_PRESENTATION
+}
+
+function SubjectCard({ subject }: { subject: PublishedSubject }) {
+    const { icon: Icon, gradient, description } = presentationFor(subject.name)
+
     return (
-        <Badge variant="secondary">
-            {isLoading ? '...' : (topics?.length ?? 0)} topics
-        </Badge>
+        <Link to={`/questions/${subject.id}`}>
+            <Card className="h-full cursor-pointer transition-all hover:shadow-xl hover:scale-105 group">
+                <CardHeader>
+                    <div
+                        className={`h-16 w-16 rounded-xl bg-gradient-to-br ${gradient} flex items-center justify-center mb-4 group-hover:scale-110 transition-transform`}
+                    >
+                        <Icon className="h-8 w-8 text-white" />
+                    </div>
+                    <CardTitle className="text-2xl">{subject.name}</CardTitle>
+                    <CardDescription className="text-base">
+                        {description}
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <div className="flex items-center justify-between">
+                        <div className="flex gap-2">
+                            <Badge variant="secondary">
+                                {subject.topicCount} topics
+                            </Badge>
+                            <Badge variant="secondary">
+                                {subject.questionCount} questions
+                            </Badge>
+                        </div>
+                        <ArrowRight className="h-5 w-5 text-slate-400 group-hover:text-blue-600 group-hover:translate-x-1 transition-all" />
+                    </div>
+                </CardContent>
+            </Card>
+        </Link>
     )
 }
 
 function SubjectsGrid() {
+    const { data: subjects, isLoading, isError } = usePublishedSubjectsQuery()
+
     return (
         <div className="container mx-auto px-4 py-12">
             <div className="max-w-6xl mx-auto">
@@ -358,43 +121,38 @@ function SubjectsGrid() {
                         Choose Your Subject
                     </h1>
                     <p className="text-lg text-slate-600 max-w-2xl mx-auto">
-                        Select a subject to start practicing. Each subject
-                        has comprehensive topics aligned with the SPM
-                        syllabus.
+                        Select a subject to start practicing. Each subject has
+                        comprehensive topics aligned with the SPM syllabus.
                     </p>
                 </div>
 
-                <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-                    {subjectsPage.map((subject) => {
-                        const Icon = subject.icon
+                {isLoading && (
+                    <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {[0, 1, 2].map((i) => (
+                            <Card key={i} className="h-56 animate-pulse">
+                                <CardHeader>
+                                    <div className="h-16 w-16 rounded-xl bg-slate-200 mb-4" />
+                                    <div className="h-6 w-40 bg-slate-200 rounded" />
+                                </CardHeader>
+                            </Card>
+                        ))}
+                    </div>
+                )}
 
-                        return (
-                            <Link key={subject.id} to={subject.url}>
-                                <Card className="h-full cursor-pointer transition-all hover:shadow-xl hover:scale-105 group">
-                                    <CardHeader>
-                                        <div
-                                            className={`h-16 w-16 rounded-xl bg-gradient-to-br ${subject.gradient} flex items-center justify-center mb-4 group-hover:scale-110 transition-transform`}
-                                        >
-                                            <Icon className="h-8 w-8 text-white" />
-                                        </div>
-                                        <CardTitle className="text-2xl">
-                                            {subject.name}
-                                        </CardTitle>
-                                        <CardDescription className="text-base">
-                                            {subject.description}
-                                        </CardDescription>
-                                    </CardHeader>
-                                    <CardContent>
-                                        <div className="flex items-center justify-between">
-                                            <TopicCountBadge subjectId={subject.id} />
-                                            <ArrowRight className="h-5 w-5 text-slate-400 group-hover:text-blue-600 group-hover:translate-x-1 transition-all" />
-                                        </div>
-                                    </CardContent>
-                                </Card>
-                            </Link>
-                        )
-                    })}
-                </div>
+                {isError && (
+                    <p className="text-center text-slate-600">
+                        Couldn't load subjects just now. Please refresh to try
+                        again.
+                    </p>
+                )}
+
+                {!isLoading && !isError && (
+                    <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {(subjects ?? []).map((subject) => (
+                            <SubjectCard key={subject.id} subject={subject} />
+                        ))}
+                    </div>
+                )}
             </div>
         </div>
     )
@@ -406,7 +164,7 @@ export default function SubjectsPage({ embedded }: { embedded?: boolean }) {
         <LandingLayout>
             <Seo
                 title="SPM Practice by Subject | JomExam"
-                description="Practise SPM Mathematics and Additional Mathematics by topic and difficulty — real exam-style questions for Malaysian Form 4–5 students, with more STEM subjects on the way."
+                description="Practise SPM Mathematics, Additional Mathematics and Chemistry by topic and difficulty — real exam-style questions for Malaysian Form 4–5 students, with more STEM subjects on the way."
                 path="/subjects"
             />
             <SubjectsGrid />


### PR DESCRIPTION
> Depends on [math-be#38](https://github.com/ClintonWeeYuan/math-be/pull/38). Merge and deploy that first, or `/subjects` renders its error state — prod currently answers `405` to `GET /subjects`, since only `POST` exists there.

Answers "where are the questions?". The 40 imported Chemistry questions were in the database and served correctly by the API the whole time — nothing in the UI linked to them.

## 1. `/subjects` is data-driven

The list was a hard-coded array of two subject uuids in `SubjectsPage.tsx`. SPM Chemistry, created later, was reachable only by typing its uuid into the URL.

Now read from `GET /subjects`, with real topic and question counts on each card. Publishing a subject is what puts it on the site.

Presentation — icon, gradient, blurb — stays in the frontend keyed by subject name, because there's no sensible column for "which lucide icon". Crucially it **falls back to a default** rather than skipping: "not in the lookup" is exactly how the old bug hid things, and a test pins that an unknown subject still renders.

## 2. Admin can see a subject's questions

A bulk-imported question belongs to no paper instance by design, so the paper-instance page — which filters by exactly that — could never list it. A batch of 40 imported cleanly and then appeared **nowhere in the admin UI at all**.

`SubjectQuestionsCard` on the subject page lists everything in the subject with chapter, topic code, difficulty, archetype and draft/published state. Paginated, reusing the existing `useGetPaginatedQuestionsBySubjectQuery` rather than adding a near-duplicate hook.

Plus `PublishSubjectCard` — the publish toggle, spelled out rather than an unlabelled switch, since it's now the only thing between a subject existing and students being sent to it.

## 3. Bank fixes

- **Paper filter hidden** when a subject has no papers. On SPM Chemistry it offered nothing to pick and would have matched nothing if picked.
- **Topic no longer printed twice.** The right-hand slot used to show `P1 (2019)`; for a paperless question it fell back to the chapter, which is the same words as the topic badge on the left. It now shows nothing unless there's a real paper.

## Two things caught while verifying

**The subjects hook swallowed errors.** I first wrote `result.data ?? []`, which renders an empty catalogue for a failed request — a page saying "no subjects" when the truth is "couldn't ask". Caught by pointing the app at a backend without the endpoint: it silently showed nothing. It now throws so the page reports the failure. Same false-success trap as #37.

**`useDeletePaperInstanceMutation` was broken by be#35.** That PR renamed `delete_paper` → `delete_paper_instance` (two functions shared a name), which changed the generated operation name. The hook still referenced the old one — latent since be#35 merged, surfaced by regenerating the client. Deleting a paper instance from the admin would have failed at runtime.

## Verified

Ran the backend locally against the prod database and drove the real UI:

- `/subjects` renders all three subjects with correct counts — Additional Mathematics 20/560, Modern Mathematics 49/513, **SPM Chemistry 1/40**
- the Chemistry bank shows no paper filter and one topic label per card

`pnpm build` clean, `60 files / 303 tests` passing (4 new).