### PR TITLE
fix: text questions overflow their card

### DIFF
--- a/src/components/questionBank/QuestionContent.tsx
+++ b/src/components/questionBank/QuestionContent.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import type { QuestionResponse } from '@/client'
 import { MemoizedHtmlBlock } from '@/components/questionBank/HtmlBlock.tsx'
 import { LatexText } from '@/components/diagnostic/LatexText.tsx'
@@ -67,20 +68,12 @@ export function QuestionContent({
 }) {
     if (isTextQuestion(question)) {
         return (
-            <div onClick={onClick}>
-                <LatexText text={question.stem ?? ''} />
-                {question.diagramUrl && (
-                    // self-start + object-contain: an <img> that is a direct
-                    // flex child otherwise stretches to fill the cross axis,
-                    // which distorts every diagram.
-                    <img
-                        src={question.diagramUrl}
-                        alt=""
-                        className="mt-3 self-start object-contain max-w-full"
-                    />
-                )}
-                {showOptions && <TextQuestionOptions questionId={question.id} />}
-            </div>
+            <TextQuestion
+                question={question}
+                onDimensionChange={onDimensionChange}
+                onClick={onClick}
+                showOptions={showOptions}
+            />
         )
     }
 
@@ -92,6 +85,79 @@ export function QuestionContent({
             onDimensionChange={onDimensionChange}
             onClick={onClick}
         />
+    )
+}
+
+/**
+ * A text question, reporting its own rendered height.
+ *
+ * The card it sits in is a flip card: both faces are absolutely positioned, so
+ * the card must be given an explicit height, and it takes that height from
+ * whatever the question content reports. Only the iframe ever reported one, so
+ * a text question left the card at its 250px default and the stem, diagram and
+ * options simply overflowed past the bottom — over the pagination beneath it.
+ *
+ * A ResizeObserver rather than a one-off measurement because the height is not
+ * settled at first paint: the options arrive from their own request, KaTeX
+ * re-lays the stem out once it renders, and the diagram has to load before it
+ * takes up space.
+ */
+function TextQuestion({
+    question,
+    onDimensionChange,
+    onClick,
+    showOptions,
+}: {
+    question: QuestionResponse
+    onDimensionChange?: (height: number, width: number) => void
+    onClick: () => void
+    showOptions: boolean
+}) {
+    const ref = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        const element = ref.current
+        if (!element || !onDimensionChange) return
+
+        const report = () =>
+            onDimensionChange(element.scrollHeight, element.scrollWidth)
+
+        report()
+        const observer = new ResizeObserver(report)
+        observer.observe(element)
+        return () => observer.disconnect()
+    }, [onDimensionChange])
+
+    return (
+        <div ref={ref} onClick={onClick}>
+            <LatexText text={question.stem ?? ''} />
+            {question.diagramUrl && (
+                // self-start + object-contain: an <img> that is a direct flex
+                // child otherwise stretches to fill the cross axis, which
+                // distorts every diagram.
+                //
+                // The height cap is what stops a tall diagram — a heating curve
+                // is nearly square and renders enormous at full width — from
+                // pushing the options off the bottom of a card. Width stays
+                // auto so the aspect ratio is untouched.
+                <img
+                    src={question.diagramUrl}
+                    alt=""
+                    // onLoad as well as the observer: an image that has not
+                    // loaded occupies no space, so the height measured before
+                    // it arrives is wrong.
+                    onLoad={() =>
+                        ref.current &&
+                        onDimensionChange?.(
+                            ref.current.scrollHeight,
+                            ref.current.scrollWidth
+                        )
+                    }
+                    className="mt-3 self-start object-contain max-w-full max-h-[320px] w-auto"
+                />
+            )}
+            {showOptions && <TextQuestionOptions questionId={question.id} />}
+        </div>
     )
 }
 


### PR DESCRIPTION
Live bug on `/questions/{spm-chemistry}`. Independent of the review-and-publish PRs; safe to merge on its own.

## The bug

The bank card is a **flip card** — both faces are absolutely positioned, so the card must be told an explicit height. It takes that height from whatever the question content reports via `onDimensionChange`, and **only the iframe ever reported one**. A text question left the card at its `250px` default, so the stem, diagram and options simply ran off the bottom, over the pagination beneath.

Measured on production right now, the five cards on page 1 of SPM Chemistry:

```
declared 250  content 250  ✓
declared 250  content 250  ✓
declared 250  content 250  ✓
declared 250  content 250  ✓
declared 250  content 924  ← 674px overflowing
```

The last one is the heating-curve question. Same page with this branch: **5 cards, 0 overflowing**, every card's declared height equal to its content.

## The fix

Text questions now measure and report their own height.

A `ResizeObserver` rather than a one-off measurement, because the height isn't settled at first paint — the options arrive from their own request, KaTeX re-lays the stem out once it renders, and the diagram has to load before it occupies any space. `onLoad` on the image too, for that last case specifically: an image that hasn't loaded takes up no room, so a height measured before it arrives is wrong.

The diagram also gets `max-h-[320px] w-auto`. A heating curve is nearly square and rendered enormous at full card width, pushing the options out of view even once the card sized correctly. Width stays auto so the aspect ratio is untouched — the same concern as #36.

## Verification

DOM measurement rather than eyeballing a screenshot, since "does the content fit the box" is a numeric question: declared height vs `scrollHeight` for every card, before and after.

`pnpm build` clean, `60 files / 303 tests` passing.