### PR TITLE
fix: explain a published subject that has nothing to show

### DIFF
--- a/src/components/questionManager/subject/PublishSubjectCard.test.tsx
+++ b/src/components/questionManager/subject/PublishSubjectCard.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PublishSubjectCard } from './PublishSubjectCard'
+
+const mockMutateAsync = vi.fn()
+const mockQuery = vi.fn()
+vi.mock('@/hooks/useUpdateSubjectMutation.ts', () => ({
+    default: () => ({ mutateAsync: mockMutateAsync, isPending: false }),
+}))
+vi.mock('@/hooks/useGetPaginatedQuestionsBySubjectQuery.ts', () => ({
+    default: (args: unknown) => mockQuery(args),
+}))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+function setPublishedCount(total: number) {
+    mockQuery.mockReturnValue({ data: { total, items: [], page: 1, size: 1 } })
+}
+
+function renderCard(isPublished: boolean) {
+    render(
+        <PublishSubjectCard
+            subjectId="s1"
+            subjectName="SPM Chemistry"
+            isPublished={isPublished}
+        />
+    )
+}
+
+describe('PublishSubjectCard', () => {
+    beforeEach(() => {
+        mockMutateAsync.mockReset()
+        mockQuery.mockReset()
+    })
+
+    it('counts published questions, not drafts', () => {
+        setPublishedCount(40)
+        renderCard(true)
+        expect(mockQuery.mock.calls[0][0].status).toBe('published')
+    })
+
+    it('explains why a published subject with no published questions is invisible', () => {
+        // Publishing it is otherwise a no-op with nothing to show for it, which
+        // reads as a broken toggle.
+        setPublishedCount(0)
+        renderCard(true)
+
+        expect(
+            screen.getByText('Published, but not visible')
+        ).toBeInTheDocument()
+        expect(
+            screen.getByText(/students are never sent to an empty subject/)
+        ).toBeInTheDocument()
+    })
+
+    it('reports the live state once questions are published', () => {
+        setPublishedCount(40)
+        renderCard(true)
+
+        expect(screen.getByText('Live')).toBeInTheDocument()
+        expect(
+            screen.getByText(/40 published question\(s\)/)
+        ).toBeInTheDocument()
+    })
+
+    it('is plainly unpublished when the subject is not published', () => {
+        setPublishedCount(40)
+        renderCard(false)
+
+        expect(screen.getByText('Not published')).toBeInTheDocument()
+        expect(
+            screen.getByRole('button', { name: 'Publish to students' })
+        ).toBeInTheDocument()
+    })
+})

--- a/src/components/questionManager/subject/PublishSubjectCard.tsx
+++ b/src/components/questionManager/subject/PublishSubjectCard.tsx
@@ -8,6 +8,7 @@ import {
 import { Button } from '@/components/ui/button.tsx'
 import { Badge } from '@/components/ui/badge.tsx'
 import useUpdateSubjectMutation from '@/hooks/useUpdateSubjectMutation.ts'
+import useGetPaginatedQuestionsBySubjectQuery from '@/hooks/useGetPaginatedQuestionsBySubjectQuery.ts'
 import { toast } from 'sonner'
 
 /**
@@ -28,6 +29,20 @@ export function PublishSubjectCard({
     isPublished: boolean
 }) {
     const { mutateAsync, isPending } = useUpdateSubjectMutation({ subjectId })
+    // A subject with no *published* questions is left off the catalogue
+    // entirely, so publishing it can be a no-op with nothing to show for it.
+    // Asking here is what stops that looking like a broken toggle.
+    const { data: published } = useGetPaginatedQuestionsBySubjectQuery({
+        subjectId,
+        page: 1,
+        size: 1,
+        topics: [],
+        difficulty: [],
+        papers: [],
+        status: 'published',
+    })
+    const publishedCount = published?.total ?? 0
+    const liveButEmpty = isPublished && publishedCount === 0
 
     async function toggle() {
         try {
@@ -47,14 +62,28 @@ export function PublishSubjectCard({
             <CardHeader>
                 <CardTitle className="flex items-center gap-2">
                     Student visibility
-                    <Badge variant={isPublished ? 'default' : 'secondary'}>
-                        {isPublished ? 'Live' : 'Not published'}
+                    <Badge
+                        variant={
+                            liveButEmpty
+                                ? 'secondary'
+                                : isPublished
+                                  ? 'default'
+                                  : 'secondary'
+                        }
+                    >
+                        {liveButEmpty
+                            ? 'Published, but not visible'
+                            : isPublished
+                              ? 'Live'
+                              : 'Not published'}
                     </Badge>
                 </CardTitle>
                 <CardDescription>
-                    {isPublished
-                        ? 'Students see this subject on /subjects and can practise its questions.'
-                        : 'Students cannot see this subject. Publish it once it has questions worth practising.'}
+                    {liveButEmpty
+                        ? 'This subject is published but has no published questions, so it stays off /subjects — students are never sent to an empty subject. Publish some questions below and it appears.'
+                        : isPublished
+                          ? `Students see this subject on /subjects and can practise its ${publishedCount} published question(s).`
+                          : 'Students cannot see this subject. Publish it once it has questions worth practising.'}
                 </CardDescription>
             </CardHeader>
             <CardContent>


### PR DESCRIPTION
Pairs with [math-be#40](https://github.com/ClintonWeeYuan/math-be/pull/40), which leaves a subject off the student catalogue until it has published questions.

## Why

With #40, publishing a subject that has no published questions **does nothing visible** — which is correct for students, and reads as a broken toggle for the admin who just clicked it.

## What

The publish card asks how many *published* questions the subject has, and says which of the three states it's in:

| State | Card |
|---|---|
| Not published | *"Students cannot see this subject."* |
| Published, no published questions | **"Published, but not visible"** — *"…so it stays off /subjects — students are never sent to an empty subject. Publish some questions below and it appears."* |
| Published, with questions | **"Live"** — *"…and can practise its 40 published question(s)."* |

The middle state is the one that didn't exist before and is exactly what SPM Chemistry is in right now: subject published, all 40 questions still drafts.

It reads the count from the same paginated endpoint with `status: 'published'` and `size: 1` — the admin sees drafts by default, so an unfiltered count would report 40 and contradict the catalogue it's explaining.

`pnpm build` clean, `62 files / 313 tests` passing (4 new).