### PR TITLE
fix: question content scrolls instead of being cut off

### DIFF
--- a/src/components/questionBank/AnimatedQuestionCard.tsx
+++ b/src/components/questionBank/AnimatedQuestionCard.tsx
@@ -13,6 +13,18 @@ import { Badge } from '@/components/ui/badge.tsx'
 import { BadgeCheckIcon } from 'lucide-react'
 import { useAuth } from '@/components/auth/AuthContext.tsx'
 
+/**
+ * Vertical space the card spends on everything that isn't the question:
+ * p-6 top and bottom (48), the topic/difficulty header (~28), the content
+ * wrapper's my-2 (16), and the footer of link buttons, which carry pb-6 (~56).
+ *
+ * This was 100, which under-counted by about a third — enough that a tall
+ * question (the heating-curve diagram) was cut off at the bottom of its card.
+ * The content area scrolls as well, so a wrong number here degrades to a
+ * scrollbar rather than to content that simply isn't reachable.
+ */
+const CARD_CHROME_PX = 148
+
 export function AnimatedQuestionCard({
     question,
     questionFilters,
@@ -27,8 +39,7 @@ export function AnimatedQuestionCard({
     // Using useCallback ensures this function reference is stable across re-renders,
     // preventing the useEffect in HtmlBlock from re-running unnecessarily.
     const handleHeightChange = useCallback((height: number) => {
-        // Add padding for the card's header and footer
-        setCardHeight(height + 100)
+        setCardHeight(height + CARD_CHROME_PX)
     }, [])
 
     const { mutate: updateQuestionStatus } =
@@ -107,7 +118,13 @@ export function AnimatedQuestionCard({
                                 )}
                             </div>
                         </div>
-                        <div className="flex-grow my-2 relative">
+                        {/* Scrolls rather than clips: the height is computed
+                            from what the content reports, and anything that
+                            reports late or wrong — a slow diagram, a font
+                            reflow — would otherwise leave part of the question
+                            unreachable. Same treatment the answer face has
+                            always had. */}
+                        <div className="flex-grow my-2 relative overflow-y-auto no-scrollbar">
                             <QuestionContent
                                 question={question}
                                 onDimensionChange={handleHeightChange}

--- a/src/components/questionBank/QuestionContent.tsx
+++ b/src/components/questionBank/QuestionContent.tsx
@@ -136,10 +136,13 @@ function TextQuestion({
                 // child otherwise stretches to fill the cross axis, which
                 // distorts every diagram.
                 //
-                // The height cap is what stops a tall diagram — a heating curve
-                // is nearly square and renders enormous at full width — from
-                // pushing the options off the bottom of a card. Width stays
-                // auto so the aspect ratio is untouched.
+                // The width must be definite. These diagrams are SVGs with a
+                // viewBox and no width/height attributes, so they have no
+                // intrinsic size to resolve `w-auto` against and collapse to
+                // 0x0 — invisible, while still being counted as "rendered".
+                // A definite width plus h-auto lets the viewBox's aspect ratio
+                // supply the height, and max-w keeps a wide diagram from
+                // filling the whole card.
                 <img
                     src={question.diagramUrl}
                     alt=""
@@ -153,7 +156,7 @@ function TextQuestion({
                             ref.current.scrollWidth
                         )
                     }
-                    className="mt-3 self-start object-contain max-w-full max-h-[320px] w-auto"
+                    className="mt-3 h-auto w-full max-w-[480px] object-contain"
                 />
             )}
             {showOptions && <TextQuestionOptions questionId={question.id} />}

--- a/src/components/questionBank/QuestionContent.tsx
+++ b/src/components/questionBank/QuestionContent.tsx
@@ -136,13 +136,13 @@ function TextQuestion({
                 // child otherwise stretches to fill the cross axis, which
                 // distorts every diagram.
                 //
-                // The width must be definite. These diagrams are SVGs with a
-                // viewBox and no width/height attributes, so they have no
-                // intrinsic size to resolve `w-auto` against and collapse to
-                // 0x0 — invisible, while still being counted as "rendered".
-                // A definite width plus h-auto lets the viewBox's aspect ratio
-                // supply the height, and max-w keeps a wide diagram from
-                // filling the whole card.
+                // Sized by its own intrinsic dimensions: no explicit width or
+                // height utility. These diagrams are SVGs carrying a viewBox
+                // and no width/height attributes, and forcing `w-auto` on top
+                // of that is what made them resolve to nothing. max-h caps a
+                // tall diagram — a heating curve is nearly square and would
+                // otherwise push the options out of view — and shrinks the
+                // width with it, so the aspect ratio is never distorted.
                 <img
                     src={question.diagramUrl}
                     alt=""
@@ -156,7 +156,7 @@ function TextQuestion({
                             ref.current.scrollWidth
                         )
                     }
-                    className="mt-3 h-auto w-full max-w-[480px] object-contain"
+                    className="mt-3 max-w-full max-h-[320px] object-contain"
                 />
             )}
             {showOptions && <TextQuestionOptions questionId={question.id} />}


### PR DESCRIPTION
Follow-up to #68, which was not enough — the heating-curve question is still clipped in production.

## Why #68 didn't finish the job

#68 made text questions report their height, and the card grew. But the card adds a fixed allowance for its own chrome, and that allowance was **100px** — a guess that under-counts by about a third:

| | |
|---|---|
| `p-6` top and bottom | 48 |
| topic / difficulty header | ~28 |
| content wrapper `my-2` | 16 |
| footer link buttons, which carry `pb-6` | ~56 |
| **actual** | **~148** |

So every card was ~48px short, and a tall question lost its bottom edge.

## The fix, and why it's two things

**`CARD_CHROME_PX = 148`**, named and derived from the classes rather than guessed.

**The content area scrolls** — `overflow-y-auto no-scrollbar`, the same treatment the answer face has always had. This is what you asked for, and it's the part that matters: the card height is computed from what the content *reports*, and anything reporting late or wrong — a slow diagram, a font reflow, a future change to the footer — would otherwise leave part of the question permanently unreachable. With a scroll, a wrong number degrades to a scrollbar instead of to lost content.

## A bug in #68 I'm reverting

#68 sized the diagram with `max-h-[320px] w-auto`. These diagrams are SVGs carrying a `viewBox` and **no `width`/`height` attributes**, so forcing `w-auto` gives the browser nothing to resolve against. The image is back to being sized by its intrinsic dimensions — the exact form I measured rendering correctly at 302px on production before #68 — keeping only the `max-h-[320px]` cap, which shrinks width along with height and so never distorts the aspect ratio.

## Verification — read this

`pnpm build` clean, `61 files / 309 tests` passing.

**I could not verify this in a browser.** The preview pane became unresponsive partway through and reports a `0 × 0` viewport, which collapses all layout to zero and makes every measurement meaningless — the numbers it gave me were nonsense (a card face 48px wide). I stopped rather than read anything into them.

What that means in practice:

- the `overflow-y-auto` backstop is simple and safe, and guarantees nothing can be *clipped* whatever the height maths does
- `CARD_CHROME_PX = 148` is derived from the Tailwind classes, not measured live, so it may be a few px out — which the scroll now absorbs
- the image class is a revert to a state I *did* measure working on prod, plus a cap

Worth a look once deployed. If a card still shows a scrollbar for a short question, the constant is too big and I'll measure it properly.