### PR TITLE
fix: surface a failed question fetch instead of an empty list

### DIFF
--- a/src/components/questionBank/QuestionBank.tsx
+++ b/src/components/questionBank/QuestionBank.tsx
@@ -26,7 +26,7 @@ export function QuestionBank({ subjectId }: Props) {
     const { topics, difficulty, papers, page, setFilterSearchParams } =
         useFiltersFromSearchParams()
 
-    const { data, isLoading, isFetching } =
+    const { data, isLoading, isFetching, isError } =
         useGetPaginatedQuestionsBySubjectQuery({
             subjectId,
             page,
@@ -176,7 +176,16 @@ export function QuestionBank({ subjectId }: Props) {
                 .transform-style-3d { transform-style: preserve-3d; }
                 .backface-hidden { backface-visibility: hidden; }
                     `}</style>
-                    {isLoading || isFetching ? (
+                    {isError ? (
+                        // Distinct from an empty bank: "no questions match your
+                        // filters" and "we couldn't ask" look identical to a
+                        // student otherwise, and only one of them is worth
+                        // retrying.
+                        <p className="py-8 text-center text-gray-500">
+                            Couldn't load these questions. Please refresh to try
+                            again.
+                        </p>
+                    ) : isLoading || isFetching ? (
                         <QuestionSkeleton />
                     ) : (
                         <QuestionList

--- a/src/components/questionManager/subject/SubjectQuestionsCard.test.tsx
+++ b/src/components/questionManager/subject/SubjectQuestionsCard.test.tsx
@@ -33,6 +33,7 @@ function setItems(items: unknown[], total = items.length) {
     mockQuery.mockReturnValue({
         data: { total, size: 20, page: 1, items },
         isLoading: false,
+        isError: false,
     })
 }
 
@@ -100,6 +101,22 @@ describe('SubjectQuestionsCard', () => {
         render(<SubjectQuestionsCard subjectId="s1" />)
 
         expect(screen.queryByText(/Publish \d+ draft/)).not.toBeInTheDocument()
+    })
+
+    it('says the request failed rather than showing an empty subject', async () => {
+        // The bug this replaces: a 500 resolved to undefined data, so a subject
+        // holding 40 freshly imported questions rendered "No questions yet".
+        mockQuery.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+        })
+        render(<SubjectQuestionsCard subjectId="s1" />)
+
+        expect(
+            screen.getByText(/Couldn't load these questions/)
+        ).toBeInTheDocument()
+        expect(screen.queryByText(/No questions yet/)).not.toBeInTheDocument()
     })
 
     it('can withdraw a published question', async () => {

--- a/src/components/questionManager/subject/SubjectQuestionsCard.tsx
+++ b/src/components/questionManager/subject/SubjectQuestionsCard.tsx
@@ -29,7 +29,7 @@ const PAGE_SIZE = 20
 export function SubjectQuestionsCard({ subjectId }: { subjectId: string }) {
     const [page, setPage] = useState(1)
     const [filter, setFilter] = useState<StatusFilter>('all')
-    const { data, isLoading } = useGetPaginatedQuestionsBySubjectQuery({
+    const { data, isLoading, isError } = useGetPaginatedQuestionsBySubjectQuery({
         subjectId,
         page,
         size: PAGE_SIZE,
@@ -121,7 +121,14 @@ export function SubjectQuestionsCard({ subjectId }: { subjectId: string }) {
                 </div>
             </CardHeader>
             <CardContent>
-                {!isLoading && total === 0 && (
+                {isError && (
+                    <p className="text-sm text-red-600">
+                        Couldn't load these questions. If you've just signed in,
+                        try refreshing; otherwise the server rejected the
+                        request.
+                    </p>
+                )}
+                {!isLoading && !isError && total === 0 && (
                     <p className="text-sm text-muted-foreground">
                         {filter === 'draft'
                             ? 'Nothing awaiting review.'

--- a/src/hooks/useGetPaginatedQuestionsBySubjectQuery.ts
+++ b/src/hooks/useGetPaginatedQuestionsBySubjectQuery.ts
@@ -34,7 +34,7 @@ export default function useGetPaginatedQuestionsBySubjectQuery({
         queryFn: async () => {
             const token = localStorage.getItem('token') ?? ''
 
-            return (
+            const result =
                 await getQuestionsBySubjectPaginatedQuestionsSubjectPaginatedSubjectIdGet(
                     {
                         path: {
@@ -53,7 +53,15 @@ export default function useGetPaginatedQuestionsBySubjectQuery({
                         },
                     }
                 )
-            ).data
+            // The generated client resolves { data: undefined, error } instead
+            // of throwing, so returning `.data` blindly turned a failed request
+            // into a successful empty page. A 500 on the admin's question list
+            // rendered as "No questions yet" — the most misleading thing it
+            // could have said, right after importing 40 of them.
+            if (result.error !== undefined || result.data === undefined) {
+                throw new Error('Could not load questions.')
+            }
+            return result.data
         },
         queryKey: [
             'questions',


### PR DESCRIPTION
The other half of "can't check questions on the admin". [math-be#41](https://github.com/ClintonWeeYuan/math-be/pull/41) fixes the 500; this makes sure a failure like it can never again be reported as "nothing here".

## Why the symptom was so misleading

`useGetPaginatedQuestionsBySubjectQuery` returned `.data` directly. The generated client resolves `{ data: undefined, error }` rather than throwing, so a **500 became a successful query with undefined data** — `total` fell back to `0`, and the admin card rendered:

> No questions yet. Add them from a paper instance, or use Bulk import above.

Which is the most misleading thing it could have said, immediately after importing 40 questions. The same false-success trap as #37 and #63.

## What changed

The hook throws on error, so `isError` is real. Both consumers now distinguish "nothing here" from "couldn't ask":

- **Admin question list** — *"Couldn't load these questions. If you've just signed in, try refreshing; otherwise the server rejected the request."*
- **Student bank** — *"Couldn't load these questions. Please refresh to try again."*

Worth separating for the student too: "no questions match your filters" and "we couldn't ask" look identical otherwise, and only one of them is worth retrying.

`pnpm build` clean, `62 files / 314 tests` passing, including one asserting the admin card shows the failure rather than "No questions yet".