### PR TITLE
feat: edit and delete questions from the subject page

### DIFF
--- a/src/client/sdk.gen.ts
+++ b/src/client/sdk.gen.ts
@@ -171,9 +171,16 @@ export const getQuestionQuestionsQuestionIdGet = <ThrowOnError extends boolean =
 
 /**
  * Update Question
- * Update an existing question's details.
+ * Update a question. Only the fields present in the body are touched.
  *
- * Only the fields provided in the request body will be updated.
+ * Handles both kinds: a converted past-paper question, where this edits
+ * topics/number/difficulty/marks, and one authored as text, where it also
+ * edits the stem, the options and the answer.
+ *
+ * Genuinely partial now. It previously did `del update_data["topics"]`
+ * unconditionally, so any request that omitted topics raised KeyError and
+ * 500'd — it only ever worked because the one dialog calling it happened to
+ * send every field.
  */
 export const updateQuestionQuestionsQuestionIdPatch = <ThrowOnError extends boolean = false>(options: Options<UpdateQuestionQuestionsQuestionIdPatchData, ThrowOnError>) => {
     return (options.client ?? client).patch<UpdateQuestionQuestionsQuestionIdPatchResponses, UpdateQuestionQuestionsQuestionIdPatchErrors, ThrowOnError>({
@@ -327,8 +334,16 @@ export const getSyllabusSyllabusSyllabusIdGet = <ThrowOnError extends boolean = 
  * subject appears on the site by being published rather than by someone
  * remembering to edit a TypeScript file.
  *
- * question_count is what makes an empty subject visibly empty rather than a
- * dead end a student clicks into.
+ * A subject needs *published questions*, not merely questions, to appear.
+ * Both halves of that were wrong at first: the count included drafts, so SPM
+ * Chemistry advertised "40 questions" on its card while the bank behind it —
+ * which hides drafts — was empty; and a subject with nothing published was
+ * still listed, which is a card that can only disappoint. A student should
+ * never be offered an empty subject.
+ *
+ * Publishing a subject with no published questions therefore does nothing
+ * visible. That is deliberate: the admin's own subject page is where that
+ * state belongs, not the student catalogue.
  */
 export const listPublishedSubjectsSubjectsGet = <ThrowOnError extends boolean = false>(options?: Options<ListPublishedSubjectsSubjectsGetData, ThrowOnError>) => {
     return (options?.client ?? client).get<ListPublishedSubjectsSubjectsGetResponses, unknown, ThrowOnError>({

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -1608,6 +1608,10 @@ export type SpmBulkImportResponse = {
      * Unknowntopiccodes
      */
     unknownTopicCodes: Array<string>;
+    /**
+     * Editedsourcerefs
+     */
+    editedSourceRefs?: Array<string>;
 };
 
 /**

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -1085,6 +1085,29 @@ export type DiagnosticSetResponse = {
 };
 
 /**
+ * EditOptionBody
+ * One answer option as the editor sends it.
+ *
+ * is_correct is deliberately absent: the answer is stated once, by
+ * correct_option on the question, and derived from it here. Two places to say
+ * which option is right is two places to disagree.
+ */
+export type EditOptionBody = {
+    /**
+     * Label
+     */
+    label: string;
+    /**
+     * Text
+     */
+    text: string;
+    /**
+     * Misconception
+     */
+    misconception?: string | null;
+};
+
+/**
  * HTTPValidationError
  */
 export type HttpValidationError = {
@@ -1896,6 +1919,30 @@ export type UpdateQuestionBody = {
      * Marks
      */
     marks?: number | null;
+    /**
+     * Stem
+     */
+    stem?: string | null;
+    /**
+     * Correctoption
+     */
+    correctOption?: string | null;
+    /**
+     * Chapter
+     */
+    chapter?: string | null;
+    /**
+     * Topiccode
+     */
+    topicCode?: string | null;
+    /**
+     * Archetype
+     */
+    archetype?: string | null;
+    /**
+     * Options
+     */
+    options?: Array<EditOptionBody> | null;
 };
 
 /**
@@ -2392,7 +2439,7 @@ export type UpdateQuestionQuestionsQuestionIdPatchData = {
     body: UpdateQuestionBody;
     path: {
         /**
-         * Question Id
+         * The ID of the question to update.
          */
         question_id: string;
     };

--- a/src/components/questionManager/SpmBulkImportDialog.tsx
+++ b/src/components/questionManager/SpmBulkImportDialog.tsx
@@ -151,6 +151,16 @@ export function SpmBulkImportDialog({
                             </p>
                         )}
 
+                        {report.editedSourceRefs.length > 0 && (
+                            <p className="mt-2 text-amber-700">
+                                {report.editedSourceRefs.length} question(s)
+                                have been edited by hand since they were
+                                imported. Importing replaces them with what's
+                                in this file:{' '}
+                                {report.editedSourceRefs.join(', ')}
+                            </p>
+                        )}
+
                         {hasProblems ? (
                             <>
                                 <p className="mt-3 font-medium text-red-600">

--- a/src/components/questionManager/SpmBulkImportDialog.tsx
+++ b/src/components/questionManager/SpmBulkImportDialog.tsx
@@ -151,13 +151,13 @@ export function SpmBulkImportDialog({
                             </p>
                         )}
 
-                        {report.editedSourceRefs.length > 0 && (
+                        {(report.editedSourceRefs?.length ?? 0) > 0 && (
                             <p className="mt-2 text-amber-700">
-                                {report.editedSourceRefs.length} question(s)
+                                {report.editedSourceRefs?.length} question(s)
                                 have been edited by hand since they were
                                 imported. Importing replaces them with what's
                                 in this file:{' '}
-                                {report.editedSourceRefs.join(', ')}
+                                {report.editedSourceRefs?.join(', ')}
                             </p>
                         )}
 

--- a/src/components/questionManager/subject/DeleteQuestionByIdDialog.tsx
+++ b/src/components/questionManager/subject/DeleteQuestionByIdDialog.tsx
@@ -1,0 +1,79 @@
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import type { QuestionResponse } from '@/client'
+import useDeleteQuestionByIdMutation from '@/hooks/useDeleteQuestionByIdMutation.ts'
+import { toast } from 'sonner'
+
+/**
+ * Deleting a question is permanent and takes its options and topic links with
+ * it, so the question is named back before it goes — a row of identical
+ * buttons in a list of 58 is exactly where a stray click happens.
+ */
+export function DeleteQuestionByIdDialog({
+    question,
+    open,
+    onOpenChange,
+}: {
+    question: QuestionResponse
+    open: boolean
+    onOpenChange: (open: boolean) => void
+}) {
+    const { mutateAsync, isPending } = useDeleteQuestionByIdMutation()
+
+    async function confirm() {
+        try {
+            await mutateAsync(question.id)
+            toast.success('Question deleted.')
+            onOpenChange(false)
+        } catch {
+            toast.error('Could not delete the question.')
+        }
+    }
+
+    const label =
+        question.stem ??
+        `${question.paper?.name ?? 'Question'} Q${question.number ?? '?'}`
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Delete this question?</DialogTitle>
+                    <DialogDescription>
+                        This removes the question and its answer options for
+                        good. If it came from a chapter file, re-importing that
+                        file will bring it back.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <blockquote className="border-l-2 pl-3 text-sm text-muted-foreground">
+                    {label}
+                </blockquote>
+
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                        disabled={isPending}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        variant="destructive"
+                        onClick={confirm}
+                        disabled={isPending}
+                    >
+                        {isPending ? 'Deleting…' : 'Delete'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/components/questionManager/subject/EditQuestionDialog.test.tsx
+++ b/src/components/questionManager/subject/EditQuestionDialog.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { EditQuestionDialog } from './EditQuestionDialog'
+
+const mockMutateAsync = vi.fn()
+const mockOptions = vi.fn()
+vi.mock('@/hooks/useEditQuestionMutation.ts', () => ({
+    default: () => ({ mutateAsync: mockMutateAsync, isPending: false }),
+}))
+vi.mock('@/hooks/questionOptions/useGetQuestionOptionsQuery.ts', () => ({
+    default: () => mockOptions(),
+}))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+const QUESTION = {
+    id: 'q1',
+    stem: 'What is an acid?',
+    difficulty: 'easy',
+    chapter: 'C06',
+    topicCode: '6.1.1',
+    archetype: 'Recall / concept',
+    correctOption: 'A',
+    topics: [],
+    createdAt: '2026-08-04T00:00:00Z',
+    marks: null,
+    type: 'multiple_choice',
+} as never
+
+function setOptions(rows: unknown[]) {
+    mockOptions.mockReturnValue({ data: rows })
+}
+
+function renderDialog() {
+    render(
+        <EditQuestionDialog question={QUESTION} open onOpenChange={() => {}} />
+    )
+}
+
+const BASE_OPTIONS = [
+    { id: 'o1', label: 'A', value: 'A proton donor', position: 0, isCorrect: true, misconception: null },
+    { id: 'o2', label: 'B', value: 'A proton acceptor', position: 1, isCorrect: false, misconception: 'Confuses base' },
+]
+
+describe('EditQuestionDialog', () => {
+    beforeEach(() => {
+        mockMutateAsync.mockReset()
+        mockMutateAsync.mockResolvedValue({})
+        mockOptions.mockReset()
+        setOptions(BASE_OPTIONS)
+    })
+
+    it('seeds from the question and its existing options', () => {
+        renderDialog()
+        expect(screen.getByLabelText('Question')).toHaveValue('What is an acid?')
+        expect(screen.getByLabelText('Option 1 text')).toHaveValue('A proton donor')
+        expect(screen.getByLabelText('Option 2 misconception')).toHaveValue('Confuses base')
+    })
+
+    it('saves the stem, classification, options and answer together', async () => {
+        renderDialog()
+        const stem = screen.getByLabelText('Question')
+        await userEvent.clear(stem)
+        await userEvent.type(stem, 'Corrected stem')
+        await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+        const body = mockMutateAsync.mock.calls[0][0]
+        expect(body.stem).toBe('Corrected stem')
+        expect(body.chapter).toBe('C06')
+        expect(body.correctOption).toBe('A')
+        expect(body.options).toEqual([
+            { label: 'A', text: 'A proton donor', misconception: null },
+            { label: 'B', text: 'A proton acceptor', misconception: 'Confuses base' },
+        ])
+    })
+
+    it('sends null rather than an empty misconception', async () => {
+        // The radar narrates these; an empty string would render as a blank
+        // explanation rather than none.
+        setOptions([{ ...BASE_OPTIONS[0], misconception: '' }])
+        renderDialog()
+        await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+        expect(mockMutateAsync.mock.calls[0][0].options[0].misconception).toBeNull()
+    })
+
+    it('never sends isCorrect — the answer is stated once', async () => {
+        renderDialog()
+        await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+        const body = mockMutateAsync.mock.calls[0][0]
+        expect(body.options.every((o: object) => !('isCorrect' in o))).toBe(true)
+    })
+
+    it('changes which option is correct', async () => {
+        renderDialog()
+        await userEvent.click(screen.getAllByRole('radio')[1])
+        await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+        expect(mockMutateAsync.mock.calls[0][0].correctOption).toBe('B')
+    })
+
+    it('cannot be saved with an empty question', async () => {
+        renderDialog()
+        await userEvent.clear(screen.getByLabelText('Question'))
+        expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    })
+
+    it('cannot be saved when the answer is not one of the options', async () => {
+        renderDialog()
+        const label = screen.getByLabelText('Option 1 label')
+        await userEvent.clear(label)
+        await userEvent.type(label, 'Z')
+
+        expect(screen.getByText('Choose which option is correct.')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    })
+})

--- a/src/components/questionManager/subject/EditQuestionDialog.tsx
+++ b/src/components/questionManager/subject/EditQuestionDialog.tsx
@@ -1,0 +1,271 @@
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { Input } from '@/components/ui/input.tsx'
+import { Label } from '@/components/ui/label.tsx'
+import { Textarea } from '@/components/ui/textarea.tsx'
+import { useEffect, useState } from 'react'
+import type { QuestionResponse } from '@/client'
+import useEditQuestionMutation from '@/hooks/useEditQuestionMutation.ts'
+import useGetQuestionOptionQuery from '@/hooks/questionOptions/useGetQuestionOptionsQuery.ts'
+import { LatexText } from '@/components/diagnostic/LatexText.tsx'
+import { toast } from 'sonner'
+
+type DraftOption = {
+    label: string
+    text: string
+    misconception: string
+}
+
+const DIFFICULTIES = ['easy', 'medium', 'hard']
+
+/**
+ * Edit an imported question in place.
+ *
+ * The chapter JSON file it came from stays the better place for wholesale
+ * rewrites — re-importing updates in place and keeps the file authoritative —
+ * so this is for the one-off correction you don't want to regenerate a file
+ * for. Saving stamps the question as hand-edited, and the import's dry run
+ * warns before a later re-import overwrites it.
+ */
+export function EditQuestionDialog({
+    question,
+    open,
+    onOpenChange,
+}: {
+    question: QuestionResponse
+    open: boolean
+    onOpenChange: (open: boolean) => void
+}) {
+    const { data: existingOptions } = useGetQuestionOptionQuery({
+        questionId: question.id,
+    })
+    const { mutateAsync, isPending } = useEditQuestionMutation({
+        questionId: question.id,
+    })
+
+    const [stem, setStem] = useState(question.stem ?? '')
+    const [difficulty, setDifficulty] = useState(question.difficulty)
+    const [chapter, setChapter] = useState(question.chapter ?? '')
+    const [topicCode, setTopicCode] = useState(question.topicCode ?? '')
+    const [archetype, setArchetype] = useState(question.archetype ?? '')
+    const [correctOption, setCorrectOption] = useState(
+        question.correctOption ?? ''
+    )
+    const [options, setOptions] = useState<DraftOption[]>([])
+
+    // Options arrive from their own request, so the draft can only be seeded
+    // once they land — and re-seeded if the dialog is reopened on a question
+    // whose options have since changed.
+    useEffect(() => {
+        if (!existingOptions) return
+        setOptions(
+            [...existingOptions]
+                .sort((a, b) => a.position - b.position)
+                .map((option, index) => ({
+                    label: option.label ?? String.fromCharCode(65 + index),
+                    text: option.value,
+                    misconception: option.misconception ?? '',
+                }))
+        )
+    }, [existingOptions])
+
+    function updateOption(index: number, patch: Partial<DraftOption>) {
+        setOptions((current) =>
+            current.map((option, i) =>
+                i === index ? { ...option, ...patch } : option
+            )
+        )
+    }
+
+    const labels = options.map((o) => o.label)
+    const answerIsAnOption = labels.includes(correctOption)
+    const canSave =
+        stem.trim().length > 0 &&
+        options.length > 0 &&
+        options.every((o) => o.label.trim() && o.text.trim()) &&
+        answerIsAnOption
+
+    async function save() {
+        try {
+            await mutateAsync({
+                stem: stem.trim(),
+                difficulty,
+                chapter: chapter.trim() || null,
+                topicCode: topicCode.trim() || null,
+                archetype: archetype.trim() || null,
+                correctOption,
+                options: options.map((o) => ({
+                    label: o.label.trim(),
+                    text: o.text.trim(),
+                    // Empty means "no misconception recorded", not an empty
+                    // string — the radar reads these and would narrate a blank.
+                    misconception: o.misconception.trim() || null,
+                })),
+            })
+            toast.success('Question saved.')
+            onOpenChange(false)
+        } catch {
+            toast.error('Could not save the question.')
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-h-[85vh] max-w-3xl overflow-y-auto">
+                <DialogHeader>
+                    <DialogTitle>Edit question</DialogTitle>
+                    <DialogDescription>
+                        Saving marks this question as edited by hand. Importing
+                        its chapter file again will overwrite it — the import
+                        warns you first.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="grid gap-4">
+                    <div className="grid gap-2">
+                        <Label htmlFor="stem">Question</Label>
+                        <Textarea
+                            id="stem"
+                            rows={4}
+                            value={stem}
+                            onChange={(e) => setStem(e.target.value)}
+                        />
+                        {stem.trim() && (
+                            <div className="rounded-md border bg-muted/40 p-3 text-sm">
+                                {/* Rendered as the student sees it, so LaTeX
+                                    that doesn't parse is obvious before saving
+                                    rather than after publishing. */}
+                                <LatexText text={stem} />
+                            </div>
+                        )}
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                        <div className="grid gap-2">
+                            <Label htmlFor="difficulty">Difficulty</Label>
+                            <select
+                                id="difficulty"
+                                className="h-9 rounded-md border px-2 text-sm"
+                                value={difficulty}
+                                onChange={(e) => setDifficulty(e.target.value)}
+                            >
+                                {DIFFICULTIES.map((value) => (
+                                    <option key={value} value={value}>
+                                        {value}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="chapter">Chapter</Label>
+                            <Input
+                                id="chapter"
+                                value={chapter}
+                                onChange={(e) => setChapter(e.target.value)}
+                                placeholder="C02"
+                            />
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="topicCode">Topic code</Label>
+                            <Input
+                                id="topicCode"
+                                value={topicCode}
+                                onChange={(e) => setTopicCode(e.target.value)}
+                                placeholder="2.1.1"
+                            />
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="archetype">Archetype</Label>
+                            <Input
+                                id="archetype"
+                                value={archetype}
+                                onChange={(e) => setArchetype(e.target.value)}
+                                placeholder="Recall / concept"
+                            />
+                        </div>
+                    </div>
+
+                    <div className="grid gap-2">
+                        <Label>Options</Label>
+                        {options.map((option, index) => (
+                            <div
+                                key={index}
+                                className="grid gap-2 rounded-md border p-3"
+                            >
+                                <div className="flex items-center gap-2">
+                                    <Input
+                                        aria-label={`Option ${index + 1} label`}
+                                        className="w-16"
+                                        value={option.label}
+                                        onChange={(e) =>
+                                            updateOption(index, {
+                                                label: e.target.value,
+                                            })
+                                        }
+                                    />
+                                    <Input
+                                        aria-label={`Option ${index + 1} text`}
+                                        value={option.text}
+                                        onChange={(e) =>
+                                            updateOption(index, {
+                                                text: e.target.value,
+                                            })
+                                        }
+                                    />
+                                    <label className="flex shrink-0 items-center gap-1 text-sm">
+                                        <input
+                                            type="radio"
+                                            name="correct-option"
+                                            checked={
+                                                correctOption === option.label
+                                            }
+                                            onChange={() =>
+                                                setCorrectOption(option.label)
+                                            }
+                                        />
+                                        Correct
+                                    </label>
+                                </div>
+                                <Input
+                                    aria-label={`Option ${index + 1} misconception`}
+                                    placeholder="Why a student might pick this (optional)"
+                                    value={option.misconception}
+                                    onChange={(e) =>
+                                        updateOption(index, {
+                                            misconception: e.target.value,
+                                        })
+                                    }
+                                />
+                            </div>
+                        ))}
+                        {!answerIsAnOption && options.length > 0 && (
+                            <p className="text-sm text-red-600">
+                                Choose which option is correct.
+                            </p>
+                        )}
+                    </div>
+                </div>
+
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                        disabled={isPending}
+                    >
+                        Cancel
+                    </Button>
+                    <Button onClick={save} disabled={!canSave || isPending}>
+                        {isPending ? 'Saving…' : 'Save'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/components/questionManager/subject/SubjectQuestionsCard.tsx
+++ b/src/components/questionManager/subject/SubjectQuestionsCard.tsx
@@ -12,6 +12,9 @@ import useGetPaginatedQuestionsBySubjectQuery from '@/hooks/useGetPaginatedQuest
 import useBulkSetQuestionStatusMutation from '@/hooks/useBulkSetQuestionStatusMutation.ts'
 import { useState } from 'react'
 import { toast } from 'sonner'
+import type { QuestionResponse } from '@/client'
+import { EditQuestionDialog } from '@/components/questionManager/subject/EditQuestionDialog.tsx'
+import { DeleteQuestionByIdDialog } from '@/components/questionManager/subject/DeleteQuestionByIdDialog.tsx'
 
 type StatusFilter = 'all' | 'draft' | 'published'
 
@@ -39,6 +42,11 @@ export function SubjectQuestionsCard({ subjectId }: { subjectId: string }) {
         status: filter === 'all' ? undefined : filter,
     })
     const { mutateAsync, isPending } = useBulkSetQuestionStatusMutation()
+    // One dialog each, holding the question being acted on, rather than a
+    // dialog per row: 20 mounted dialogs per page would each fetch their own
+    // options.
+    const [editing, setEditing] = useState<QuestionResponse | null>(null)
+    const [deleting, setDeleting] = useState<QuestionResponse | null>(null)
 
     const total = data?.total ?? 0
     const items = data?.items ?? []
@@ -189,20 +197,36 @@ export function SubjectQuestionsCard({ subjectId }: { subjectId: string }) {
                                         </Badge>
                                     </div>
                                 </div>
-                                <Button
-                                    variant={isDraft ? 'default' : 'ghost'}
-                                    size="sm"
-                                    className="shrink-0"
-                                    disabled={isPending}
-                                    onClick={() =>
-                                        setStatus(
-                                            [question.id],
-                                            isDraft ? 'published' : 'draft'
-                                        )
-                                    }
-                                >
-                                    {isDraft ? 'Publish' : 'Unpublish'}
-                                </Button>
+                                <div className="flex shrink-0 gap-1">
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => setEditing(question)}
+                                    >
+                                        Edit
+                                    </Button>
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        className="text-red-600 hover:text-red-700"
+                                        onClick={() => setDeleting(question)}
+                                    >
+                                        Delete
+                                    </Button>
+                                    <Button
+                                        variant={isDraft ? 'default' : 'ghost'}
+                                        size="sm"
+                                        disabled={isPending}
+                                        onClick={() =>
+                                            setStatus(
+                                                [question.id],
+                                                isDraft ? 'published' : 'draft'
+                                            )
+                                        }
+                                    >
+                                        {isDraft ? 'Publish' : 'Unpublish'}
+                                    </Button>
+                                </div>
                             </div>
                         )
                     })}
@@ -232,6 +256,26 @@ export function SubjectQuestionsCard({ subjectId }: { subjectId: string }) {
                     </div>
                 )}
             </CardContent>
+
+            {/* Keyed by question id so reopening on a different question
+                remounts with that question's own state rather than the
+                previous one's. */}
+            {editing && (
+                <EditQuestionDialog
+                    key={editing.id}
+                    question={editing}
+                    open
+                    onOpenChange={(next) => !next && setEditing(null)}
+                />
+            )}
+            {deleting && (
+                <DeleteQuestionByIdDialog
+                    key={deleting.id}
+                    question={deleting}
+                    open
+                    onOpenChange={(next) => !next && setDeleting(null)}
+                />
+            )}
         </Card>
     )
 }

--- a/src/hooks/useDeleteQuestionByIdMutation.ts
+++ b/src/hooks/useDeleteQuestionByIdMutation.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { deleteQuestionQuestionsQuestionIdDelete } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
+
+/**
+ * Delete a question outright.
+ *
+ * Separate from useDeleteQuestionMutation, which invalidates by paper instance
+ * — a bulk-imported question has none, so that key would never match and the
+ * list would keep showing a question that no longer exists.
+ */
+export default function useDeleteQuestionByIdMutation() {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: async (questionId: string) => {
+            const result = await deleteQuestionQuestionsQuestionIdDelete({
+                path: { question_id: questionId },
+                headers: getAuthHeaders(),
+            })
+            if (result.error !== undefined) {
+                throw new Error('Could not delete the question.')
+            }
+            return result.data
+        },
+        onSuccess: () =>
+            queryClient.invalidateQueries({ queryKey: ['questions'] }),
+    })
+}

--- a/src/hooks/useEditQuestionMutation.ts
+++ b/src/hooks/useEditQuestionMutation.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { updateQuestionQuestionsQuestionIdPatch } from '@/client'
+import type { UpdateQuestionBody } from '@/client'
+import { getAuthHeaders } from '@/lib/authHeaders.ts'
+
+/**
+ * Edit a question's content from the admin.
+ *
+ * Separate from useUpdateQuestionMutation, which is the paper-instance dialog's
+ * narrow version (topics, number, difficulty, marks) and invalidates by paper
+ * instance — a bulk-imported question has none, so that key would never match.
+ */
+export default function useEditQuestionMutation({
+    questionId,
+}: {
+    questionId: string
+}) {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: async (body: UpdateQuestionBody) => {
+            const result = await updateQuestionQuestionsQuestionIdPatch({
+                path: { question_id: questionId },
+                body,
+                headers: getAuthHeaders(),
+            })
+            // The generated client resolves { data: undefined, error } instead
+            // of throwing, so returning `.data` blindly would close the dialog
+            // on an edit the server rejected.
+            if (result.error !== undefined) {
+                throw new Error('Could not save the question.')
+            }
+            return result.data
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['questions'] })
+            queryClient.invalidateQueries({ queryKey: ['options'] })
+        },
+    })
+}


### PR DESCRIPTION
Frontend for "how am I able to delete or edit questions?". Needs [math-be#42](https://github.com/ClintonWeeYuan/math-be/pull/42) merged and deployed first.

## What you get

Each question in the subject list now has **Edit**, **Delete** and **Publish/Unpublish**.

**Edit** — a full editor: question text, difficulty, chapter, topic code, archetype, all options with their misconceptions, and which one is correct.

- The stem renders **as the student will see it** under the textarea, so LaTeX that doesn't parse is obvious before saving rather than after publishing.
- `isCorrect` is never sent. The answer is stated once, by the radio, and derived server-side — two places to say which option is right is two places to disagree.
- An empty misconception saves as `null`, not `""`. The radar narrates these, and a blank string renders as an empty explanation rather than none.
- Save is blocked on an empty question, an empty option, or an answer that isn't one of the options.

**Delete** — a confirmation naming the question, since a row of identical buttons in a list of 58 is exactly where a stray click happens. It says the options go too, and that re-importing the chapter file brings the question back.

## Protecting your JSON files

You chose the full editor, which means the database and your chapter files can now diverge — and re-importing is meant to win. So the import's **Check file** step now warns:

> *N question(s) have been edited by hand since they were imported. Importing replaces them with what's in this file: chem-p1-b1-q4, …*

Reported, never blocking — correcting a file and re-importing is still the normal workflow.

## Two dialogs, not forty

One Edit and one Delete dialog held at the card level with the question being acted on, keyed by id, rather than a pair per row. Twenty mounted editors per page would each fire their own options request.

## Verified against the real database

Not just unit tests — I created a throwaway question in production, edited it through the real endpoint, and deleted it:

```
stem: ZZ probe EDITED | difficulty: hard | archetype: Calculation
correct_option: B | edited_at set: True
   A: new A  correct=False  misconception=why
   B: new B  correct=True   misconception=None
deleted: True | orphaned options: 0
```

Answer correctly moved to B, options replaced, edit stamped, nothing orphaned. Throwaway removed; `probe rows left: 0`.

`pnpm build` clean, `63 files / 321 tests` passing (7 new).