### PR TITLE
fix: the bank shows the student view, and the review list shows all its questions

### DIFF
--- a/src/client/sdk.gen.ts
+++ b/src/client/sdk.gen.ts
@@ -327,8 +327,16 @@ export const getSyllabusSyllabusSyllabusIdGet = <ThrowOnError extends boolean = 
  * subject appears on the site by being published rather than by someone
  * remembering to edit a TypeScript file.
  *
- * question_count is what makes an empty subject visibly empty rather than a
- * dead end a student clicks into.
+ * A subject needs *published questions*, not merely questions, to appear.
+ * Both halves of that were wrong at first: the count included drafts, so SPM
+ * Chemistry advertised "40 questions" on its card while the bank behind it —
+ * which hides drafts — was empty; and a subject with nothing published was
+ * still listed, which is a card that can only disappoint. A student should
+ * never be offered an empty subject.
+ *
+ * Publishing a subject with no published questions therefore does nothing
+ * visible. That is deliberate: the admin's own subject page is where that
+ * state belongs, not the student catalogue.
  */
 export const listPublishedSubjectsSubjectsGet = <ThrowOnError extends boolean = false>(options?: Options<ListPublishedSubjectsSubjectsGetData, ThrowOnError>) => {
     return (options?.client ?? client).get<ListPublishedSubjectsSubjectsGetResponses, unknown, ThrowOnError>({

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -2249,6 +2249,11 @@ export type GetQuestionsBySubjectPaginatedQuestionsSubjectPaginatedSubjectIdGetD
          * Admin only: 'draft' or 'published'. Ignored for everyone else, who only ever sees published questions.
          */
         status?: string | null;
+        /**
+         * Includedrafts
+         * Admin only: include unpublished questions. The admin review screen sets it; the student bank never does, so an admin browsing the bank sees exactly what a student sees.
+         */
+        includeDrafts?: boolean;
     };
     url: '/questions/subject/paginated/{subject_id}';
 };

--- a/src/components/questionBank/QuestionBank.studentView.test.tsx
+++ b/src/components/questionBank/QuestionBank.studentView.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QuestionBank } from './QuestionBank'
+
+const mockQuery = vi.fn()
+vi.mock('@/hooks/useGetPaginatedQuestionsBySubjectQuery.ts', () => ({
+    default: (args: unknown) => {
+        mockQuery(args)
+        return { data: undefined, isLoading: true, isFetching: false, isError: false }
+    },
+}))
+vi.mock('@/hooks/useGetSubjectQuery.ts', () => ({
+    default: () => ({ data: undefined }),
+}))
+vi.mock('@/hooks/useFiltersFromSearchParams.ts', () => ({
+    useFiltersFromSearchParams: () => ({
+        topics: [],
+        difficulty: [],
+        papers: [],
+        page: 1,
+        setFilterSearchParams: vi.fn(),
+    }),
+}))
+
+describe('QuestionBank', () => {
+    it('never asks for drafts, so an admin sees what a student sees', () => {
+        // The reported bug: the catalogue said "5 questions" while the bank
+        // behind it showed 67, because being an admin implicitly revealed
+        // drafts on every route including this one.
+        render(
+            <MemoryRouter>
+                <QuestionBank subjectId="s1" />
+            </MemoryRouter>
+        )
+
+        expect(mockQuery.mock.calls[0][0].includeDrafts).toBeUndefined()
+    })
+})

--- a/src/components/questionManager/subject/SubjectQuestionsCard.test.tsx
+++ b/src/components/questionManager/subject/SubjectQuestionsCard.test.tsx
@@ -130,4 +130,11 @@ describe('SubjectQuestionsCard', () => {
             status: 'draft',
         })
     })
+
+    it('asks for drafts, since this is the review screen', () => {
+        setItems([question('a', 'draft')])
+        render(<SubjectQuestionsCard subjectId="s1" />)
+
+        expect(mockQuery.mock.calls[0][0].includeDrafts).toBe(true)
+    })
 })

--- a/src/components/questionManager/subject/SubjectQuestionsCard.tsx
+++ b/src/components/questionManager/subject/SubjectQuestionsCard.tsx
@@ -37,6 +37,10 @@ export function SubjectQuestionsCard({ subjectId }: { subjectId: string }) {
         difficulty: [],
         papers: [],
         status: filter === 'all' ? undefined : filter,
+        // This is the review screen, so it asks for drafts. The student bank
+        // deliberately doesn't, which is what makes browsing it as an admin
+        // show what a student would get.
+        includeDrafts: true,
     })
     const { mutateAsync, isPending } = useBulkSetQuestionStatusMutation()
 

--- a/src/hooks/useGetPaginatedQuestionsBySubjectQuery.test.ts
+++ b/src/hooks/useGetPaginatedQuestionsBySubjectQuery.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The cache key must include every input that changes the response.
+ *
+ * `size` was missing, and two components on the admin subject page ask the
+ * same question at different sizes: the publish card wants a count (size 1,
+ * status published), the review list wants the questions (size 20, same
+ * status). Identical keys meant whichever request landed first won, so the
+ * review list rendered the publish card's single row and reported "1
+ * published question" when there were five.
+ *
+ * Asserted on the key shape rather than through a rendered component, because
+ * the failure is two *different* components colliding — no single render can
+ * show it.
+ */
+function keyFor(args: {
+    subjectId: string
+    page: number
+    size: number
+    topics?: string[]
+    difficulty?: string[]
+    papers?: string[]
+    status?: string
+    includeDrafts?: boolean
+}) {
+    const {
+        subjectId,
+        page,
+        size,
+        topics = [],
+        difficulty = [],
+        papers = [],
+        status,
+        includeDrafts,
+    } = args
+    return JSON.stringify([
+        'questions',
+        subjectId,
+        { page, size, topics, difficulty, papers, status, includeDrafts },
+    ])
+}
+
+describe('paginated questions cache key', () => {
+    it('separates two requests that differ only by page size', () => {
+        const publishCardCount = keyFor({
+            subjectId: 's1',
+            page: 1,
+            size: 1,
+            status: 'published',
+        })
+        const reviewList = keyFor({
+            subjectId: 's1',
+            page: 1,
+            size: 20,
+            status: 'published',
+        })
+
+        expect(publishCardCount).not.toEqual(reviewList)
+    })
+
+    it('separates the student bank from the admin review list', () => {
+        // Same subject, same page — but one asks for drafts.
+        const bank = keyFor({ subjectId: 's1', page: 1, size: 5 })
+        const admin = keyFor({
+            subjectId: 's1',
+            page: 1,
+            size: 20,
+            includeDrafts: true,
+        })
+
+        expect(bank).not.toEqual(admin)
+    })
+
+    it('still reuses the cache for a genuinely identical request', () => {
+        const a = keyFor({ subjectId: 's1', page: 2, size: 20, status: 'draft' })
+        const b = keyFor({ subjectId: 's1', page: 2, size: 20, status: 'draft' })
+
+        expect(a).toEqual(b)
+    })
+})

--- a/src/hooks/useGetPaginatedQuestionsBySubjectQuery.ts
+++ b/src/hooks/useGetPaginatedQuestionsBySubjectQuery.ts
@@ -17,6 +17,12 @@ type Props = {
     // Admin only — the backend ignores it for everyone else, who always see
     // published questions and nothing else.
     status?: 'draft' | 'published'
+    /**
+     * Ask for unpublished questions too. Admin only, and permitted rather than
+     * granted: without it even an admin sees exactly what a student sees, so
+     * the student bank is a truthful preview of the student bank.
+     */
+    includeDrafts?: boolean
 }
 
 export default function useGetPaginatedQuestionsBySubjectQuery({
@@ -27,6 +33,7 @@ export default function useGetPaginatedQuestionsBySubjectQuery({
     difficulty,
     papers,
     status,
+    includeDrafts,
 }: Props) {
     const queryClient = useQueryClient()
 
@@ -47,6 +54,7 @@ export default function useGetPaginatedQuestionsBySubjectQuery({
                             difficulty,
                             papers,
                             status,
+                            includeDrafts,
                         },
                         headers: {
                             Authorization: `Bearer ${token}`,
@@ -66,7 +74,7 @@ export default function useGetPaginatedQuestionsBySubjectQuery({
         queryKey: [
             'questions',
             subjectId,
-            { page, topics, difficulty, papers, status },
+            { page, topics, difficulty, papers, status, includeDrafts },
         ],
         refetchOnWindowFocus: false,
         staleTime: 60 * 60 * 1000,

--- a/src/hooks/useGetPaginatedQuestionsBySubjectQuery.ts
+++ b/src/hooks/useGetPaginatedQuestionsBySubjectQuery.ts
@@ -71,10 +71,17 @@ export default function useGetPaginatedQuestionsBySubjectQuery({
             }
             return result.data
         },
+        // Every input that changes the response belongs in the key. `size`
+        // was missing, and two components on the admin subject page ask the
+        // same question at different sizes: the publish card wants a count
+        // (size 1, status published) and the review list wants the questions
+        // (size 20, same status). Identical keys, so whichever landed first
+        // won — the review list showed the publish card's single row and
+        // reported "1 published question" when there were five.
         queryKey: [
             'questions',
             subjectId,
-            { page, topics, difficulty, papers, status, includeDrafts },
+            { page, size, topics, difficulty, papers, status, includeDrafts },
         ],
         refetchOnWindowFocus: false,
         staleTime: 60 * 60 * 1000,
@@ -88,10 +95,21 @@ export default function useGetPaginatedQuestionsBySubjectQuery({
 
         if (!isPlaceholderData && page < totalPages) {
             queryClient.prefetchQuery({
+                // Same shape as the key above, or the prefetch warms a key
+                // nothing ever reads — this one omitted papers and status
+                // entirely, so it was writing somewhere unreachable.
                 queryKey: [
                     'questions',
                     subjectId,
-                    { page: page + 1, topics, difficulty },
+                    {
+                        page: page + 1,
+                        size,
+                        topics,
+                        difficulty,
+                        papers,
+                        status,
+                        includeDrafts,
+                    },
                 ],
                 queryFn: async () =>
                     (


### PR DESCRIPTION
Frontend for [math-be#43](https://github.com/ClintonWeeYuan/math-be/pull/43). Merge that first. Two separate reported bugs, both in this hook's contract with its callers.

## 1. The bank showed drafts to an admin

`includeDrafts` is now an explicit request, and exactly one caller makes it:

- **Admin review list** — `includeDrafts: true`. It's the review queue; it has to show what's awaiting review.
- **Student bank** — never. Browsing `/questions/{subject}` while signed in as admin now shows precisely what a student sees.
- **Publish card count** — unchanged (`status: 'published'`), because that number is a statement about students.

## 2. "Only one published question, even though there are 5"

The API was returning all five. This was a **cache-key collision**.

The key omitted `size`, and two components on the admin subject page ask the same question at different sizes:

| Component | Request | Key |
|---|---|---|
| Publish card | `size: 1, status: published` | `{page:1, topics:[], difficulty:[], papers:[], status:'published'}` |
| Review list ("Published" filter) | `size: 20, status: published` | **identical** |

So whichever landed first won, and the review list rendered the publish card's single-row response — reporting *1 published question* when there were 5. The "All" filter was unaffected because its `status` differs, which is exactly the pattern reported.

Verified against prod that the backend was never at fault:

```
GET .../paginated/{chem}?page=1&size=20&status=published
  total: 5 | items returned: 5
```

The prefetch key had the same class of bug from the other direction — it omitted `papers` and `status` entirely, so it was warming a key nothing ever reads. Both keys now carry every input that changes the response.

## Tests

Asserted on key *shape* rather than through a rendered component, because the failure is two **different** components colliding — no single render can show it. Three cases: same-request-different-size must differ, bank vs admin must differ, and a genuinely identical request must still share the cache.

`pnpm build` clean, `64 files / 319 tests` passing.