### PR TITLE
fix: hide empty past-paper sections, and show how many topics there are

### DIFF
--- a/src/components/questionManager/subject/TopicsTable.test.tsx
+++ b/src/components/questionManager/subject/TopicsTable.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TopicsTable } from './TopicsTable'
+
+function topic(id: string, name: string, sortOrder: number) {
+    return { id, name, sortOrder, level: { id: 'l4', name: 'Form 4' } }
+}
+
+function renderTable(topics: unknown[]) {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    render(
+        <QueryClientProvider client={client}>
+            <MemoryRouter>
+                <TopicsTable
+                    isLoading={false}
+                    topics={topics as never}
+                    subjectId="s1"
+                    levels={[]}
+                />
+            </MemoryRouter>
+        </QueryClientProvider>
+    )
+}
+
+describe('TopicsTable', () => {
+    it('states how many topics there are', () => {
+        // The box scrolls after about four rows with nothing to say so, and
+        // seven imported chapters read as four missing ones.
+        renderTable(
+            Array.from({ length: 7 }, (_, i) => topic(`t${i}`, `C0${i + 1}`, i + 1))
+        )
+
+        expect(screen.getByText('7 topics for this subject')).toBeInTheDocument()
+    })
+
+    it('renders every topic, however many there are', () => {
+        renderTable(
+            Array.from({ length: 7 }, (_, i) => topic(`t${i}`, `Chapter ${i + 1}`, i + 1))
+        )
+
+        for (let i = 1; i <= 7; i++) {
+            expect(screen.getByText(`Chapter ${i}`)).toBeInTheDocument()
+        }
+    })
+
+    it('says so when there are none', () => {
+        renderTable([])
+        expect(screen.getByText('No topics yet.')).toBeInTheDocument()
+    })
+})

--- a/src/components/questionManager/subject/TopicsTable.tsx
+++ b/src/components/questionManager/subject/TopicsTable.tsx
@@ -19,6 +19,7 @@ import {
 import { CreateTopicDialog } from '@/components/questionManager/subject/CreateTopicDialog.tsx'
 import { DeleteTopicDialog } from '@/components/questionManager/subject/DeleteTopicDialog.tsx'
 import { UpdateTopicDialog } from '@/components/questionManager/subject/UpdateTopicDialog.tsx'
+import { Badge } from '@/components/ui/badge.tsx'
 import type { BaseLevel, BaseTopic } from '@/client'
 
 type Props = {
@@ -38,7 +39,14 @@ export function TopicsTable({ isLoading, topics, subjectId, levels }: Props) {
             ) : (
                 <>
                     <CardHeader>
-                        <CardTitle>Topics</CardTitle>
+                        <CardTitle className="flex items-center gap-2">
+                            Topics
+                            {/* The count is what tells you the list is
+                                complete. This box scrolls after about four
+                                rows with nothing to say so, and seven imported
+                                chapters read as four missing ones. */}
+                            <Badge variant="secondary">{topics.length}</Badge>
+                        </CardTitle>
                         <CardDescription>
                             The topics for this subject
                         </CardDescription>
@@ -46,7 +54,9 @@ export function TopicsTable({ isLoading, topics, subjectId, levels }: Props) {
                     <CardContent className="max-h-[300px] overflow-y-auto">
                         <Table>
                             <TableCaption>
-                                A list of topics for this subject
+                                {topics.length === 0
+                                    ? 'No topics yet.'
+                                    : `${topics.length} topic${topics.length === 1 ? '' : 's'} for this subject`}
                             </TableCaption>
                             <TableHeader>
                                 <TableRow>

--- a/src/pages/Admin/SubjectPage.test.tsx
+++ b/src/pages/Admin/SubjectPage.test.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { SubjectPage } from './SubjectPage'
+
+const mockSubject = vi.fn()
+const mockInstances = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual<object>('react-router-dom')
+    return { ...actual, useParams: () => ({ subjectId: 's1', syllabusId: 'sy1' }) }
+})
+vi.mock('@/hooks/useGetSubjectQuery.ts', () => ({
+    default: () => mockSubject(),
+}))
+vi.mock('@/hooks/useGetSyllabusQuery.ts', () => ({
+    default: () => ({ data: { name: 'SPM', levels: [], paperVariants: [] } }),
+}))
+vi.mock('@/hooks/useGetPaperInstancesBySubjectQuery.ts', () => ({
+    default: () => mockInstances(),
+}))
+vi.mock('@/components/questionManager/subject/SubjectQuestionsCard.tsx', () => ({
+    SubjectQuestionsCard: () => <div>questions card</div>,
+}))
+vi.mock('@/components/questionManager/subject/PublishSubjectCard.tsx', () => ({
+    PublishSubjectCard: () => <div>publish card</div>,
+}))
+vi.mock('@/components/layout/AdminLayout.tsx', () => ({
+    AdminLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+function renderPage() {
+    render(
+        <MemoryRouter>
+            <SubjectPage />
+        </MemoryRouter>
+    )
+}
+
+describe('SubjectPage past-paper sections', () => {
+    beforeEach(() => {
+        mockSubject.mockReset()
+        mockInstances.mockReset()
+    })
+
+    it('hides them for a subject built from imported chapters', () => {
+        // SPM Chemistry: topics and questions, but no papers — two permanently
+        // empty tables are noise.
+        mockSubject.mockReturnValue({
+            data: { id: 's1', name: 'SPM Chemistry', topics: [], papers: [] },
+            isLoading: false,
+        })
+        mockInstances.mockReturnValue({ data: [] })
+        renderPage()
+
+        expect(screen.queryByText('Paper Instances')).not.toBeInTheDocument()
+        expect(screen.getByText(/No past papers/)).toBeInTheDocument()
+    })
+
+    it('still lets you set them up, so nothing is unreachable', async () => {
+        mockSubject.mockReturnValue({
+            data: { id: 's1', name: 'SPM Chemistry', topics: [], papers: [] },
+            isLoading: false,
+        })
+        mockInstances.mockReturnValue({ data: [] })
+        renderPage()
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Set up past papers' })
+        )
+
+        expect(screen.getByText('Paper Instances')).toBeInTheDocument()
+    })
+
+    it('shows them for a subject that has papers', () => {
+        mockSubject.mockReturnValue({
+            data: {
+                id: 's1',
+                name: 'Additional Mathematics',
+                topics: [],
+                papers: [{ id: 'p1', name: 'P1' }],
+            },
+            isLoading: false,
+        })
+        mockInstances.mockReturnValue({ data: [] })
+        renderPage()
+
+        expect(screen.getByText('Paper Instances')).toBeInTheDocument()
+        expect(screen.queryByText(/No past papers/)).not.toBeInTheDocument()
+    })
+
+    it('shows them when instances exist but papers have not loaded', () => {
+        // Mid-setup is still "uses past papers" — hiding the section here
+        // would strand the instances that already exist.
+        mockSubject.mockReturnValue({
+            data: { id: 's1', name: 'X', topics: [], papers: [] },
+            isLoading: false,
+        })
+        mockInstances.mockReturnValue({ data: [{ id: 'pi1' }] })
+        renderPage()
+
+        expect(screen.getByText('Paper Instances')).toBeInTheDocument()
+    })
+})

--- a/src/pages/Admin/SubjectPage.test.tsx
+++ b/src/pages/Admin/SubjectPage.test.tsx
@@ -105,7 +105,15 @@ describe('SubjectPage past-paper sections', () => {
             data: { id: 's1', name: 'X', topics: [], papers: [] },
             isLoading: false,
         })
-        mockInstances.mockReturnValue({ data: [{ id: 'pi1' }] })
+        mockInstances.mockReturnValue({
+            data: [
+                {
+                    id: 'pi1',
+                    paper: { id: 'p1', name: 'P1' },
+                    variant: { id: 'v1', name: 'Nov', year: 2019 },
+                },
+            ],
+        })
         renderPage()
 
         expect(screen.getByText('Paper Instances')).toBeInTheDocument()

--- a/src/pages/Admin/SubjectPage.test.tsx
+++ b/src/pages/Admin/SubjectPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { SubjectPage } from './SubjectPage'
 
 const mockSubject = vi.fn()
@@ -31,10 +32,17 @@ vi.mock('@/components/layout/AdminLayout.tsx', () => ({
 }))
 
 function renderPage() {
+    // The page mounts dialogs that own mutations, so it needs a real client
+    // even though every data hook here is mocked.
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
     render(
-        <MemoryRouter>
-            <SubjectPage />
-        </MemoryRouter>
+        <QueryClientProvider client={client}>
+            <MemoryRouter>
+                <SubjectPage />
+            </MemoryRouter>
+        </QueryClientProvider>
     )
 }
 

--- a/src/pages/Admin/SubjectPage.tsx
+++ b/src/pages/Admin/SubjectPage.tsx
@@ -24,6 +24,7 @@ import { useState } from 'react'
 export function SubjectPage() {
     const { subjectId, syllabusId } = useParams()
     const [importOpen, setImportOpen] = useState(false)
+    const [showPapers, setShowPapers] = useState(false)
 
     const { data: syllabus } = useGetSyllabusQuery({
         syllabusId: syllabusId ?? '',
@@ -36,6 +37,12 @@ export function SubjectPage() {
     const { data: paperInstances } = useGetPaperInstancesBySubjectQuery({
         subjectId: subjectId ?? '',
     })
+
+    // Either one being non-empty means this subject does use past papers, so
+    // both sections stay — a subject with papers but no instances yet is
+    // mid-setup, not unused.
+    const hasPastPapers =
+        (data?.papers?.length ?? 0) > 0 || (paperInstances?.length ?? 0) > 0
 
     return (
         <AdminLayout>
@@ -74,40 +81,77 @@ export function SubjectPage() {
                         isPublished={data?.isPublished ?? false}
                     />
                 </div>
-                <div className="grid grid-cols-2 gap-4">
-                    <TopicsTable
-                        isLoading={isLoading}
-                        topics={data?.topics ?? []}
-                        subjectId={data?.id ?? ''}
-                        levels={syllabus?.levels ?? []}
-                    />
-                    <PapersTable
-                        isLoading={isLoading}
-                        papers={data?.papers ?? []}
-                        subjectId={subjectId ?? ''}
-                    />
-                </div>
-                <div className="mt-4">
-                    <Card>
-                        <CardHeader>
-                            <CardTitle>Paper Instances</CardTitle>
-                            <CardContent>
-                                <PaperInstanceTable
-                                    paperInstances={paperInstances ?? []}
-                                    subjectId={subjectId ?? ''}
-                                />
-                            </CardContent>
-                        </CardHeader>
-                        <CardFooter>
-                            <CreatePaperInstanceDialog
+                {/* Papers and paper instances are about scanned past papers.
+                    A subject whose questions are generated chapter by chapter
+                    has none and never will, so two permanently empty tables
+                    are just noise on the page — hidden until they hold
+                    something, or until someone asks for them. Never removed:
+                    hiding them outright would take away the only way to set
+                    past papers up in the first place. */}
+                {hasPastPapers || showPapers ? (
+                    <>
+                        <div className="grid grid-cols-2 gap-4">
+                            <TopicsTable
+                                isLoading={isLoading}
+                                topics={data?.topics ?? []}
+                                subjectId={data?.id ?? ''}
+                                levels={syllabus?.levels ?? []}
+                            />
+                            <PapersTable
+                                isLoading={isLoading}
                                 papers={data?.papers ?? []}
-                                paperVariants={syllabus?.paperVariants ?? []}
-                                existingPaperInstances={paperInstances ?? []}
                                 subjectId={subjectId ?? ''}
                             />
-                        </CardFooter>
-                    </Card>
-                </div>
+                        </div>
+                        <div className="mt-4">
+                            <Card>
+                                <CardHeader>
+                                    <CardTitle>Paper Instances</CardTitle>
+                                    <CardContent>
+                                        <PaperInstanceTable
+                                            paperInstances={paperInstances ?? []}
+                                            subjectId={subjectId ?? ''}
+                                        />
+                                    </CardContent>
+                                </CardHeader>
+                                <CardFooter>
+                                    <CreatePaperInstanceDialog
+                                        papers={data?.papers ?? []}
+                                        paperVariants={
+                                            syllabus?.paperVariants ?? []
+                                        }
+                                        existingPaperInstances={
+                                            paperInstances ?? []
+                                        }
+                                        subjectId={subjectId ?? ''}
+                                    />
+                                </CardFooter>
+                            </Card>
+                        </div>
+                    </>
+                ) : (
+                    <>
+                        <TopicsTable
+                            isLoading={isLoading}
+                            topics={data?.topics ?? []}
+                            subjectId={data?.id ?? ''}
+                            levels={syllabus?.levels ?? []}
+                        />
+                        <div className="mt-4 flex items-center justify-between rounded-md border border-dashed p-3">
+                            <p className="text-sm text-muted-foreground">
+                                No past papers. Questions imported chapter by
+                                chapter don't need them.
+                            </p>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setShowPapers(true)}
+                            >
+                                Set up past papers
+                            </Button>
+                        </div>
+                    </>
+                )}
                 {/* Every question in the subject, including the bulk-imported
                     ones that belong to no paper instance and so appear on no
                     other admin screen. */}


### PR DESCRIPTION
Two reports about the admin subject page misrepresenting what's on it. Pairs with [math-be#44](https://github.com/ClintonWeeYuan/math-be/pull/44), which returns topics in syllabus order.

## 1. Past-paper sections on a subject that has none

Papers and Paper Instances are about **scanned past papers**. A subject whose questions are generated chapter by chapter — SPM Chemistry — has none and never will, so the page carried two permanently empty tables. That's the blank area under Student visibility.

They now collapse to one line:

> No past papers. Questions imported chapter by chapter don't need them.  **[Set up past papers]**

Topics goes full width instead of sharing a two-column grid with an empty table.

**Nothing becomes unreachable** — hiding them outright would remove the only way to set past papers up, so the button brings both back. The condition is `papers > 0 **or** instances > 0`: a subject with papers but no instances yet is mid-setup, not unused.

## 2. "I've published 6 topics but only 4 appear"

All seven were there and the API returned all seven. The card has `max-h-[300px] overflow-y-auto`, which fits about four rows **with nothing indicating more below**.

The card now states its count — a badge in the header and `"7 topics for this subject"` as the caption. That's what answers *"is this list complete?"* without the reader having to discover a scrollbar.

Deliberately not `"scroll for the rest"`: that would be a lie for a subject with two topics. The count is true either way.

The scroll itself stays — Modern Mathematics has 49 topics and a card that grows to fit them would push everything else off the page.

## Tests

Seven new: four for the paper sections (hidden, revealable, shown with papers, shown with instances) and three for the topics card (states the count, renders all seven, says so when empty).

`pnpm build` clean, `67 files / 333 tests` passing.

I did **not** view either in a browser — admin pages need a login I won't perform — so both are verified through the rendered DOM. Worth a glance once deployed.