### PR TITLE
fix: link subjects by their readable URL

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -82,6 +82,18 @@ function subjectRoutes(subjects) {
         }))
 }
 
+/** The subject catalogue as links a crawler can follow. */
+function subjectsMarkup(subjects) {
+    const listed = (subjects ?? []).filter((s) => s.slug)
+    if (listed.length === 0) return ''
+    return `<ul>${listed
+        .map(
+            (s) =>
+                `<li><a href="/spm/${esc(s.slug)}">${esc(s.name)}</a> — ${esc(String(s.questionCount))} questions across ${esc(String(s.topicCount))} topics</li>`
+        )
+        .join('')}</ul>`
+}
+
 /** Catalogue sets as a readable list a crawler can index. */
 function setsMarkup(sets) {
     if (!sets || sets.length === 0) return ''
@@ -339,6 +351,12 @@ async function main() {
         let body = route.body
         if ('test' in route) {
             body += setsMarkup(await fetchSets(route.test))
+        }
+        // Without these, the subject pages are reachable only from the
+        // sitemap — no page on the site links to them, which is a weak signal
+        // and a slow discovery path.
+        if (route.path === '/subjects') {
+            body += subjectsMarkup(subjects)
         }
         html = html.replace(
             '<div id="root"></div>',

--- a/src/pages/SubjectsPage.test.tsx
+++ b/src/pages/SubjectsPage.test.tsx
@@ -35,18 +35,28 @@ describe('SubjectsPage', () => {
         expect(screen.getByText('40 questions')).toBeInTheDocument()
     })
 
-    it('links each subject to its own bank', () => {
+    it('links each subject by its readable URL', () => {
+        // Linking by uuid and letting the redirect rewrite it means the uuid
+        // is what lands in the address bar.
         mockQuery.mockReturnValue({
-            data: [{ id: 'chem-id', name: 'SPM Chemistry', code: 'CHEM', topicCount: 1, questionCount: 40 }],
+            data: [{ id: 'chem-id', slug: 'chemistry', name: 'SPM Chemistry', code: 'CHEM', topicCount: 1, questionCount: 40 }],
             isLoading: false,
             isError: false,
         })
         renderGrid()
 
-        expect(screen.getByRole('link')).toHaveAttribute(
-            'href',
-            '/questions/chem-id'
-        )
+        expect(screen.getByRole('link')).toHaveAttribute('href', '/spm/chemistry')
+    })
+
+    it('still links a subject that has no slug, by id', () => {
+        mockQuery.mockReturnValue({
+            data: [{ id: 'old-id', name: 'Legacy Subject', code: 'X', topicCount: 1, questionCount: 2 }],
+            isLoading: false,
+            isError: false,
+        })
+        renderGrid()
+
+        expect(screen.getByRole('link')).toHaveAttribute('href', '/questions/old-id')
     })
 
     it('renders a subject it has no styling for rather than dropping it', () => {

--- a/src/pages/SubjectsPage.tsx
+++ b/src/pages/SubjectsPage.tsx
@@ -79,7 +79,17 @@ function SubjectCard({ subject }: { subject: PublishedSubject }) {
     const { icon: Icon, gradient, description } = presentationFor(subject.name)
 
     return (
-        <Link to={`/questions/${subject.id}`}>
+        // The readable URL is the one to link: sending people to
+        // /questions/<uuid> and letting the redirect rewrite it means the uuid
+        // is what they see land in the address bar.
+        // A subject without a slug still works, by id, rather than not linking.
+        <Link
+            to={
+                subject.slug
+                    ? `/spm/${subject.slug}`
+                    : `/questions/${subject.id}`
+            }
+        >
             <Card className="h-full cursor-pointer transition-all hover:shadow-xl hover:scale-105 group">
                 <CardHeader>
                     <div


### PR DESCRIPTION
Follow-up to #75, which added `/spm/{slug}` and the redirect but **left the links pointing at the old URL**. So clicking a subject card went to `/questions/<uuid>` and the redirect rewrote the address bar a moment later — the uuid is what you saw land.

## What changed

**The `/subjects` cards link to `/spm/{slug}`.** A redirect is a safety net for links already out in the world, not the path your own site should take people down. A subject with no slug still links by id rather than not linking at all.

**The prerendered `/subjects` page now links to each subject too:**

```
/spm/additional-mathematics -> Additional Mathematics
/spm/modern-mathematics     -> Modern Mathematics
/spm/chemistry              -> SPM Chemistry
```

That was a real gap: nothing on the site linked to the new pages, so a crawler could only reach them through the sitemap. An internal link is both a discovery path and a ranking signal, and the list is generated from the same API response the pages are, so it can't drift.

## Verified in a browser

Loaded `/subjects`, checked every card's `href`, then clicked through:

```
hrefs   : /spm/additional-mathematics, /spm/modern-mathematics, /spm/chemistry
after click: /spm/chemistry — "SPM Chemistry Practice Questions | JomExam"
```

Straight there, no uuid in between.

`pnpm build` clean, `68 files / 338 tests` passing — including one asserting the card links by slug, and one asserting a slug-less subject still links by id.