### PR TITLE
feat: per-topic SPM pages

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -68,7 +68,7 @@ async function fetchSubjects() {
  * these replace served the prerendered homepage, canonical tag and all, which
  * told Google all three were duplicates of the front page.
  */
-function subjectRoutes(subjects) {
+function subjectRoutes(subjects, topicPathsBySubject = new Map()) {
     return (subjects ?? [])
         .filter((s) => s.slug)
         .map((s) => ({
@@ -78,8 +78,92 @@ function subjectRoutes(subjects) {
                 `Practise ${s.name} by topic and difficulty — ${s.questionCount} exam-style SPM questions across ${s.topicCount} topics, free to work through at your own pace.`,
             body: `<h1>${esc(s.name)} practice questions</h1>
 <p>${esc(String(s.questionCount))} exam-style questions across ${esc(String(s.topicCount))} topics, filterable by topic and difficulty. Free to work through at your own pace.</p>
-<p><a href="/subjects">All SPM subjects</a></p>`,
+<p><a href="/subjects">All SPM subjects</a></p>
+${topicListMarkup(topicPathsBySubject.get(s.slug))}`,
         }))
+}
+
+/**
+ * Links from a subject page to its topic pages.
+ *
+ * Only topics that actually got a page — linking to one that was skipped for
+ * having nothing to show would send a crawler to the bare SPA shell.
+ */
+function topicListMarkup(topics) {
+    const listed = (topics ?? []).filter((t) => t.name)
+    if (listed.length === 0) return ''
+    return `<h2>Practise by topic</h2><ul>${listed
+        .map((t) => `<li><a href="${t.path}">${esc(t.name)}</a></li>`)
+        .join('')}</ul>`
+}
+
+/** One subject with its topics, or null if the API can't be reached. */
+async function fetchSubjectDetail(slug) {
+    try {
+        const res = await fetch(`${API}/subjects/by-slug/${slug}`, {
+            signal: AbortSignal.timeout(15000),
+        })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return await res.json()
+    } catch (error) {
+        console.warn(`  ! could not fetch subject ${slug}: ${error.message}`)
+        return null
+    }
+}
+
+/** Published questions for one topic — what a crawler will actually read. */
+async function fetchTopicQuestions(subjectId, topicId) {
+    try {
+        const res = await fetch(
+            `${API}/questions/subject/paginated/${subjectId}?topics=${topicId}&size=6`,
+            { signal: AbortSignal.timeout(15000) }
+        )
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const page = await res.json()
+        return page
+    } catch (error) {
+        console.warn(`  ! could not fetch questions for topic ${topicId}: ${error.message}`)
+        return null
+    }
+}
+
+// A topic page earns its place by having real questions to show. Below this,
+// the page would be a heading and a count — and eighty of those across the
+// site is the doorway-page pattern search engines penalise, not an SEO win.
+const MIN_QUESTIONS_FOR_A_TOPIC_PAGE = 3
+
+/**
+ * A page per topic that has published questions with text.
+ *
+ * Deliberately not one per topic: the Mathematics banks are converted images
+ * with no stem at all, so their topic pages would have nothing to say. They
+ * still work as routes for students — they're just not worth indexing until
+ * they hold something a search engine can read.
+ */
+async function topicRoutes(subject) {
+    if (!subject?.slug) return []
+    const routes = []
+    for (const topic of subject.topics ?? []) {
+        if (!topic.slug) continue
+        const page = await fetchTopicQuestions(subject.id, topic.id)
+        const items = (page?.items ?? []).filter((q) => q.stem)
+        if (items.length < MIN_QUESTIONS_FOR_A_TOPIC_PAGE) continue
+
+        const total = page.total
+        routes.push({
+            path: `/spm/${subject.slug}/${topic.slug}`,
+            title: `${topic.name} — ${subject.name} Questions | JomExam`,
+            description: `Practise ${topic.name} for ${subject.name}: ${total} exam-style questions with answers, filterable by difficulty.`,
+            body: `<h1>${esc(topic.name)} — ${esc(subject.name)} questions</h1>
+<p>${esc(String(total))} exam-style questions on ${esc(topic.name.toLowerCase())}, with answers. Free to work through at your own pace.</p>
+<ul>${items
+                .slice(0, 5)
+                .map((q) => `<li>${esc(q.stem)}</li>`)
+                .join('')}</ul>
+<p><a href="/spm/${esc(subject.slug)}">All ${esc(subject.name)} topics</a></p>`,
+        })
+    }
+    return routes
 }
 
 /** The subject catalogue as links a crawler can follow. */
@@ -317,7 +401,40 @@ async function main() {
     // Fetched once, not per route: every subject page comes from this list,
     // and so does the sitemap.
     const subjects = await fetchSubjects()
-    const routes = [...ROUTES, ...subjectRoutes(subjects)]
+
+    // Topic pages need each subject's topic list and a sample of its
+    // questions, so the detail is fetched once per subject and reused for
+    // both the topic routes and the links from the subject page.
+    const details = []
+    for (const s of subjects ?? []) {
+        if (!s.slug) continue
+        const detail = await fetchSubjectDetail(s.slug)
+        if (detail) details.push({ ...detail, questionCount: s.questionCount })
+    }
+
+    const topicPages = []
+    for (const detail of details) {
+        topicPages.push(...(await topicRoutes(detail)))
+    }
+    const topicPathsBySubject = new Map(
+        details.map((d) => [
+            d.slug,
+            topicPages
+                .filter((r) => r.path.startsWith(`/spm/${d.slug}/`))
+                .map((r) => ({
+                    path: r.path,
+                    name: (d.topics ?? []).find(
+                        (t) => r.path.endsWith(`/${t.slug}`)
+                    )?.name,
+                })),
+        ])
+    )
+
+    const routes = [
+        ...ROUTES,
+        ...subjectRoutes(subjects, topicPathsBySubject),
+        ...topicPages,
+    ]
 
     for (const route of routes) {
         const url = `${SITE}${route.path}`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Route, Routes, useParams } from 'react-router-dom'
 import { SpmSubjectPage } from '@/pages/SpmSubjectPage.tsx'
+import { SpmTopicPage } from '@/pages/SpmTopicPage.tsx'
 import { LegacySubjectRedirect } from '@/components/routing/LegacySubjectRedirect.tsx'
 import { QuestionManagerPage } from '@/pages/Admin/QuestionManagerPage.tsx'
 import { SandboxPage } from '@/pages/SandboxPage.tsx'
@@ -112,6 +113,10 @@ function App() {
                 />
                 <Route path="subjects" element={<SubjectsPage />} />
                 <Route path="spm/:slug" element={<SpmSubjectPage />} />
+                <Route
+                    path="spm/:slug/:topicSlug"
+                    element={<SpmTopicPage />}
+                />
                 {/* The old uuid URLs have been shared and may be indexed, so
                     they redirect rather than 404. */}
                 <Route

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -292,6 +292,10 @@ export type BaseTopic = {
      * Sortorder
      */
     sortOrder: number;
+    /**
+     * Slug
+     */
+    slug?: string | null;
 };
 
 /**

--- a/src/pages/SpmTopicPage.test.tsx
+++ b/src/pages/SpmTopicPage.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { SpmTopicPage } from './SpmTopicPage'
+
+const mockSubject = vi.fn()
+const mockSetSearchParams = vi.fn()
+let currentParams = new URLSearchParams()
+
+vi.mock('@/hooks/useGetSubjectBySlugQuery.ts', () => ({
+    default: () => mockSubject(),
+}))
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual<object>('react-router-dom')
+    return {
+        ...actual,
+        useParams: () => ({ slug: 'chemistry', topicSlug: 'acids-bases-and-salts' }),
+        useSearchParams: () => [currentParams, mockSetSearchParams],
+    }
+})
+vi.mock('@/components/questionBank/QuestionBank.tsx', () => ({
+    QuestionBank: ({ subjectId }: { subjectId: string }) => (
+        <div>bank for {subjectId}</div>
+    ),
+}))
+vi.mock('@/components/layout/UserLayout.tsx', () => ({
+    UserLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+vi.mock('@/components/Seo.tsx', () => ({
+    Seo: ({ title, path }: { title: string; path: string }) => (
+        <div data-testid="seo" data-title={title} data-path={path} />
+    ),
+}))
+
+const TOPIC = { id: 'topic-uuid', name: 'Acids, Bases and Salts', slug: 'acids-bases-and-salts' }
+const SUBJECT = { id: 'chem-uuid', name: 'SPM Chemistry', topics: [TOPIC] }
+
+function renderPage() {
+    render(
+        <MemoryRouter>
+            <SpmTopicPage />
+        </MemoryRouter>
+    )
+}
+
+describe('SpmTopicPage', () => {
+    beforeEach(() => {
+        mockSubject.mockReset()
+        mockSetSearchParams.mockReset()
+        currentParams = new URLSearchParams()
+    })
+
+    it('filters the bank to the topic in the URL', () => {
+        // The bank filters from the query string, so the page puts the topic
+        // there rather than teaching the bank a second way to be filtered.
+        mockSubject.mockReturnValue({ data: SUBJECT, isLoading: false, isError: false })
+        renderPage()
+
+        const next = mockSetSearchParams.mock.calls[0][0] as URLSearchParams
+        expect(next.getAll('topics')).toEqual(['topic-uuid'])
+        expect(mockSetSearchParams.mock.calls[0][1]).toEqual({ replace: true })
+    })
+
+    it('does not rewrite the URL once the filter is already set', () => {
+        currentParams = new URLSearchParams([['topics', 'topic-uuid']])
+        mockSubject.mockReturnValue({ data: SUBJECT, isLoading: false, isError: false })
+        renderPage()
+
+        expect(mockSetSearchParams).not.toHaveBeenCalled()
+    })
+
+    it('gives the page its own title and canonical', () => {
+        mockSubject.mockReturnValue({ data: SUBJECT, isLoading: false, isError: false })
+        renderPage()
+
+        const seo = screen.getByTestId('seo')
+        expect(seo.dataset.title).toBe(
+            'Acids, Bases and Salts — SPM Chemistry Questions | JomExam'
+        )
+        expect(seo.dataset.path).toBe('/spm/chemistry/acids-bases-and-salts')
+    })
+
+    it('says so when the subject exists but the topic does not', () => {
+        mockSubject.mockReturnValue({
+            data: { ...SUBJECT, topics: [] },
+            isLoading: false,
+            isError: false,
+        })
+        renderPage()
+
+        expect(screen.getByText('No such topic')).toBeInTheDocument()
+        expect(screen.queryByText(/^bank for/)).not.toBeInTheDocument()
+    })
+
+    it('does not render a bank before the subject resolves', () => {
+        mockSubject.mockReturnValue({ data: undefined, isLoading: true, isError: false })
+        renderPage()
+
+        expect(screen.queryByText(/^bank for/)).not.toBeInTheDocument()
+    })
+})

--- a/src/pages/SpmTopicPage.tsx
+++ b/src/pages/SpmTopicPage.tsx
@@ -1,0 +1,70 @@
+import { QuestionBank } from '@/components/questionBank/QuestionBank.tsx'
+import { UserLayout } from '@/components/layout/UserLayout.tsx'
+import { Seo } from '@/components/Seo.tsx'
+import { useParams, Link, useSearchParams } from 'react-router-dom'
+import { useEffect } from 'react'
+import useGetSubjectBySlugQuery from '@/hooks/useGetSubjectBySlugQuery.ts'
+
+/**
+ * One topic of a subject: /spm/chemistry/acids-bases-and-salts.
+ *
+ * A subject page ranks for "SPM Chemistry practice questions"; these rank for
+ * what students actually search, which is narrower — "mole concept questions".
+ *
+ * The bank does its own filtering from the query string, so rather than
+ * teaching it a second way to be filtered, this page puts the topic there and
+ * lets the existing mechanism work. The canonical stays the clean path.
+ */
+export function SpmTopicPage() {
+    const { slug, topicSlug } = useParams()
+    const [searchParams, setSearchParams] = useSearchParams()
+    const { data: subject, isLoading, isError } = useGetSubjectBySlugQuery({
+        slug: slug ?? '',
+    })
+
+    const topic = subject?.topics?.find((t) => t.slug === topicSlug)
+
+    useEffect(() => {
+        if (!topic) return
+        if (searchParams.getAll('topics').includes(topic.id)) return
+        const next = new URLSearchParams(searchParams)
+        next.delete('topics')
+        next.append('topics', topic.id)
+        // replace: arriving here is one navigation, not two.
+        setSearchParams(next, { replace: true })
+    }, [topic, searchParams, setSearchParams])
+
+    const notFound = isError || (!isLoading && subject && !topic)
+
+    if (notFound) {
+        return (
+            <UserLayout>
+                <div className="py-16 text-center">
+                    <h1 className="text-2xl font-semibold">No such topic</h1>
+                    <p className="mt-2 text-gray-500">
+                        <Link className="underline" to={`/spm/${slug}`}>
+                            See all topics for this subject
+                        </Link>
+                    </p>
+                </div>
+            </UserLayout>
+        )
+    }
+
+    return (
+        <UserLayout>
+            {subject && topic && (
+                <Seo
+                    title={`${topic.name} — ${subject.name} Questions | JomExam`}
+                    description={`Practise ${topic.name} for ${subject.name} — exam-style questions with answers, filterable by difficulty.`}
+                    path={`/spm/${slug}/${topicSlug}`}
+                />
+            )}
+            {isLoading || !subject || !topic ? (
+                <div className="py-16 text-center text-gray-500">Loading…</div>
+            ) : (
+                <QuestionBank subjectId={subject.id} />
+            )}
+        </UserLayout>
+    )
+}


### PR DESCRIPTION
> Needs [math-be#46](https://github.com/ClintonWeeYuan/math-be/pull/46) merged and deployed first. Without topic slugs the prerenderer skips these pages and the build still succeeds — verified.

## Why

The subject pages rank for *"SPM Chemistry practice questions"*. Students search narrower than that: *"spm chemistry mole concept questions"*. A page per topic turns one Chemistry page into **thirteen**, each about something specific — and, for the first time, puts **real question text** in front of a crawler.

```
/spm/chemistry/acids-bases-and-salts
  title    : Acids, Bases and Salts — SPM Chemistry Questions | JomExam
  canonical: https://www.jomexam.com/spm/chemistry/acids-bases-and-salts
  content  : 69 exam-style questions on acids, bases and salts, with answers.
             "Equal volumes of 1.0 mol dm⁻³ hydrochloric acid and 1.0 mol dm⁻³
              ethanoic acid are each added to excess zinc powder…"
```

## The important decision: 13 pages, not 83

There are 83 topics, and I'm deliberately generating pages for **13**.

Only Chemistry has text. The Mathematics banks are converted images — **0 stems across 1,156 published questions**:

```
Additional Mathematics | 622 published | 0 with text
Modern Mathematics     | 534 published | 0 with text
SPM Chemistry          | 577 published | 577 with text
```

Seventy pages consisting of a heading and a count is the doorway-page pattern search engines penalise, not an SEO win. So a topic page is generated only where there are at least 3 published questions with real text. The Maths topic routes still **work for students** — they're just not indexed until they hold something a search engine can read. If you later import text-based Maths questions, those pages appear on their own.

## The rest

- **`/spm/{subject}/{topic}`** route, filtering the bank to that topic. The bank already filters from the query string, so the page puts the topic there rather than teaching the bank a second way to be filtered — and the canonical stays the clean path.
- **The subject page links to its topic pages** (13 links on `/spm/chemistry`), so they're discoverable by crawling and not just the sitemap. Only topics that actually got a page are linked — linking to a skipped one would send a crawler to the bare SPA shell.
- **Sitemap grows to 27 URLs** automatically, since it's generated from what was built.

## Verification

Built against a backend with topic slugs: 27 routes, 13 of them Chemistry topics, zero for the Maths subjects. Built against the currently-deployed API: 14 routes, topic pages skipped cleanly.

`69 files / 343 tests` passing, `pnpm build` clean. Five new for the topic page: filters the bank, doesn't rewrite an already-correct URL, sets its own title and canonical, reports an unknown topic, and doesn't render a bank before the subject resolves.