### PR TITLE
fix: topic routes 404 for every subject without prerendered pages

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -492,10 +492,14 @@ async function main() {
         }
         // The page exists so the route works; it just isn't offered for
         // indexing until it has something to say.
+        //
+        // The template already carries a robots tag, so this replaces it
+        // rather than adding a second — two robots tags is ambiguous, and
+        // appending left the permissive one first and apparently winning.
         if (route.indexable === false) {
             html = html.replace(
-                '</head>',
-                '<meta name="robots" content="noindex,follow"/></head>'
+                /<meta name="robots" content="[^"]*"\s*\/?>/,
+                '<meta name="robots" content="noindex, follow"/>'
             )
         }
 

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -127,18 +127,24 @@ async function fetchTopicQuestions(subjectId, topicId) {
     }
 }
 
-// A topic page earns its place by having real questions to show. Below this,
-// the page would be a heading and a count — and eighty of those across the
-// site is the doorway-page pattern search engines penalise, not an SEO win.
-const MIN_QUESTIONS_FOR_A_TOPIC_PAGE = 3
+// A topic page is worth *indexing* only if it has real questions to show.
+// Below this it would be a heading and a count, and eighty of those across
+// the site is the doorway-page pattern search engines penalise.
+const MIN_QUESTIONS_TO_INDEX_A_TOPIC = 3
 
 /**
- * A page per topic that has published questions with text.
+ * A page for every topic — but only the ones with real text are indexable.
  *
- * Deliberately not one per topic: the Mathematics banks are converted images
- * with no stem at all, so their topic pages would have nothing to say. They
- * still work as routes for students — they're just not worth indexing until
- * they hold something a search engine can read.
+ * Every topic gets a file, because /spm/** is deliberately not rewritten in
+ * serve.json (a rewrite would shadow the prerendered pages, which was the
+ * original bug), so a topic without a file is a hard 404 for a student who
+ * clicks its link. That is what happened to all 69 Mathematics topics.
+ *
+ * The Mathematics banks are converted images with no stem at all, so their
+ * topic pages have nothing a search engine can read. Those are written with
+ * noindex and left out of the sitemap: the route works, and the thin page
+ * isn't offered up for indexing. They become indexable on their own if the
+ * subject ever gains text-based questions.
  */
 async function topicRoutes(subject) {
     if (!subject?.slug) return []
@@ -147,19 +153,21 @@ async function topicRoutes(subject) {
         if (!topic.slug) continue
         const page = await fetchTopicQuestions(subject.id, topic.id)
         const items = (page?.items ?? []).filter((q) => q.stem)
-        if (items.length < MIN_QUESTIONS_FOR_A_TOPIC_PAGE) continue
+        const total = page?.total ?? 0
+        const indexable = items.length >= MIN_QUESTIONS_TO_INDEX_A_TOPIC
 
-        const total = page.total
         routes.push({
             path: `/spm/${subject.slug}/${topic.slug}`,
+            indexable,
             title: `${topic.name} — ${subject.name} Questions | JomExam`,
             description: `Practise ${topic.name} for ${subject.name}: ${total} exam-style questions with answers, filterable by difficulty.`,
             body: `<h1>${esc(topic.name)} — ${esc(subject.name)} questions</h1>
 <p>${esc(String(total))} exam-style questions on ${esc(topic.name.toLowerCase())}, with answers. Free to work through at your own pace.</p>
-<ul>${items
-                .slice(0, 5)
-                .map((q) => `<li>${esc(q.stem)}</li>`)
-                .join('')}</ul>
+${
+    items.length > 0
+        ? `<ul>${items.slice(0, 5).map((q) => `<li>${esc(q.stem)}</li>`).join('')}</ul>`
+        : ''
+}
 <p><a href="/spm/${esc(subject.slug)}">All ${esc(subject.name)} topics</a></p>`,
         })
     }
@@ -420,7 +428,7 @@ async function main() {
         details.map((d) => [
             d.slug,
             topicPages
-                .filter((r) => r.path.startsWith(`/spm/${d.slug}/`))
+                .filter((r) => r.indexable && r.path.startsWith(`/spm/${d.slug}/`))
                 .map((r) => ({
                     path: r.path,
                     name: (d.topics ?? []).find(
@@ -482,6 +490,14 @@ async function main() {
         if (route.jsonLd) {
             html = html.replace('</head>', `${route.jsonLd}</head>`)
         }
+        // The page exists so the route works; it just isn't offered for
+        // indexing until it has something to say.
+        if (route.indexable === false) {
+            html = html.replace(
+                '</head>',
+                '<meta name="robots" content="noindex,follow"/></head>'
+            )
+        }
 
         const outDir = route.path === '/' ? DIST : join(DIST, route.path)
         await mkdir(outDir, { recursive: true })
@@ -511,6 +527,7 @@ async function main() {
         '<?xml version="1.0" encoding="UTF-8"?>\n' +
         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
         routes
+            .filter((route) => route.indexable !== false)
             .map((route) => `  <url>\n    <loc>${SITE}${route.path === '/' ? '/' : route.path}</loc>\n  </url>`)
             .join('\n') +
         '\n</urlset>\n'


### PR DESCRIPTION
## The bug

I claimed in #77 that Mathematics topic routes "still work for students — they're just not indexed". **They didn't work.** They 404.

```
/spm/modern-mathematics/straight-lines   404
/spm/modern-mathematics/matrices         404
/spm/chemistry/polymers                  200
```

`/spm/**` is deliberately *not* rewritten in `serve.json` — a rewrite would shadow the prerendered pages, which was the original bug this whole thread started with. So a route without a prerendered file has nothing to serve. Skipping the 69 Mathematics topics didn't make them "unindexed", it made them **unreachable**: every link from the topic dropdown to a Mathematics topic was broken.

## The fix

Write a page for **every** topic route, and mark the thin ones `noindex` rather than omitting them.

That solves both halves properly — the route works, and the page isn't offered up for indexing:

```
topic pages written : 82   (chemistry 13, modern 49, additional 20)
indexable           : 13
noindex, follow     : 69
sitemap URLs        : 27   (unchanged — noindex pages are excluded)
```

`noindex, follow` rather than plain `noindex`: the links out of those pages are still worth crawling, they just shouldn't be indexed themselves. They become indexable on their own if a subject ever gains text-based questions.

Internal links from a subject page still only point at indexable topics — `/spm/chemistry` has 13, `/spm/modern-mathematics` has 0 — so nothing invites a crawler to a page marked noindex.

## A second bug found while fixing the first

The template already carries `<meta name="robots" content="index, follow"/>`, and my first attempt **appended** a second tag. The result was two robots tags per page, with the permissive one first — so the pages I believed were noindex were reporting `index, follow`:

```
robots tags ['index, follow'] -> 82 pages     ← before
robots tags ['noindex, follow'] -> 69 pages   ← after
robots tags ['index, follow']   -> 13 pages
```

Caught by checking the built output rather than trusting the count of pages I'd flagged.

`69 files / 343 tests` passing, `pnpm build` clean.