### PR TITLE
feat: maths topic pages become indexable

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -152,7 +152,12 @@ async function topicRoutes(subject) {
     for (const topic of subject.topics ?? []) {
         if (!topic.slug) continue
         const page = await fetchTopicQuestions(subject.id, topic.id)
-        const items = (page?.items ?? []).filter((q) => q.stem)
+        // stem for a question authored as text; searchText for one converted
+        // from LaTeX, whose wording lives in a storage file the page loads
+        // into an iframe and no crawler ever sees.
+        const items = (page?.items ?? [])
+            .map((q) => ({ ...q, text: q.stem ?? q.searchText }))
+            .filter((q) => q.text)
         const total = page?.total ?? 0
         const indexable = items.length >= MIN_QUESTIONS_TO_INDEX_A_TOPIC
 
@@ -165,7 +170,7 @@ async function topicRoutes(subject) {
 <p>${esc(String(total))} exam-style questions on ${esc(topic.name.toLowerCase())}, with answers. Free to work through at your own pace.</p>
 ${
     items.length > 0
-        ? `<ul>${items.slice(0, 5).map((q) => `<li>${esc(q.stem)}</li>`).join('')}</ul>`
+        ? `<ul>${items.slice(0, 5).map((q) => `<li>${esc(q.text)}</li>`).join('')}</ul>`
         : ''
 }
 <p><a href="/spm/${esc(subject.slug)}">All ${esc(subject.name)} topics</a></p>`,

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -1435,6 +1435,10 @@ export type QuestionResponse = {
      */
     stem?: string | null;
     /**
+     * Searchtext
+     */
+    searchText?: string | null;
+    /**
      * Correctoption
      */
     correctOption?: string | null;


### PR DESCRIPTION
> Needs [math-be#47](https://github.com/ClintonWeeYuan/math-be/pull/47) merged and deployed first. Without `searchText` the maths topic pages stay `noindex` and the build still succeeds.

## What changes

The prerenderer takes a question's text from `stem` **or** `searchText`:

- `stem` — questions authored as text (Chemistry)
- `searchText` — questions converted from LaTeX, whose wording lives in a storage file the page loads into an iframe and no crawler ever sees (Mathematics)

One line of intent, and the 69 Mathematics topic pages stop being empty shells.

## Effect

```
             before        after
indexable    13            73
noindex      69             9
sitemap      27            87
```

The 9 that stay `noindex` are genuinely thin — Modern Mathematics topics with fewer than 3 questions carrying usable text (`statistics`, `pythagoras-theorem`, `loci-in-2d` and six others). They still work as routes; they're just not offered for indexing until they have something to say.

## What a maths topic page now says

```
/spm/additional-mathematics/function
  title : Function — Additional Mathematics Questions | JomExam
  robots: index, follow
  • Given the functions g : x → 3x + 1, and fg : x → 9x^2 + 6x - 4,
    find g^-1(x), f(x).
  • It is given that f(x) = (3)/(4x-1), x ≠ (1)/(4) and fg(x) = (3)/(4x^2+3)…
```

Real question wording, indexable for the first time.

`69 files / 343 tests` passing, `pnpm build` clean.