### PR TITLE
fix: the logo in the student header links home

### DIFF
--- a/src/components/layout/UserLayout.test.tsx
+++ b/src/components/layout/UserLayout.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { UserLayout } from './UserLayout'
+
+vi.mock('@/components/auth/AuthContext.tsx', () => ({
+    useAuth: () => ({ user: null, logout: vi.fn() }),
+}))
+
+describe('UserLayout header', () => {
+    it('links the logo to the homepage', () => {
+        // Without this the only way out of a question bank was the browser's
+        // back button — the landing header has always linked it.
+        render(
+            <MemoryRouter>
+                <UserLayout>
+                    <div>page</div>
+                </UserLayout>
+            </MemoryRouter>
+        )
+
+        expect(
+            screen.getByRole('link', { name: 'JomExam home' })
+        ).toHaveAttribute('href', '/')
+    })
+})

--- a/src/components/layout/UserLayout.tsx
+++ b/src/components/layout/UserLayout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import { Button } from '@/components/ui/button.tsx'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/components/auth/AuthContext.tsx'
 import { Avatar } from '../ui/avatar'
 import { AvatarFallback } from '@/components/ui/avatar.tsx'
@@ -26,15 +26,21 @@ const Header = () => {
         <header className="sticky top-0 z-10 bg-white/70 dark:bg-gray-900/70 backdrop-blur-lg shadow-md">
             <div className="bg-neutral px-4 sm:px-6 lg:px-8">
                 <div className="flex items-center justify-between py-4">
-                    <div className="flex items-center">
-                        <img
-                            src="/logo-1.png"
-                            alt="Logo"
-                            height={60}
-                            width={70}
-                        />{' '}
-                        <span className="text-xl font-bold">JomExam</span>
-                    </div>
+                    {/* The logo is how people expect to get home, and here
+                        it was a plain div — so from a question bank the only
+                        way back was the browser's back button. The landing
+                        header has always linked it; this matches. */}
+                    <Link to="/" aria-label="JomExam home">
+                        <div className="flex items-center cursor-pointer">
+                            <img
+                                src="/logo-1.png"
+                                alt="Logo"
+                                height={60}
+                                width={70}
+                            />{' '}
+                            <span className="text-xl font-bold">JomExam</span>
+                        </div>
+                    </Link>
                     <div className="flex gap-2">
                         {user !== null ? (
                             <div className="flex space-x-2 items-center">


### PR DESCRIPTION
## The bug

In `UserLayout` — the header on the SPM question bank and topic pages — the logo and "JomExam" wordmark sat in a plain `<div>`:

```tsx
<div className="flex items-center">
    <img src="/logo-1.png" ... />
    <span className="text-xl font-bold">JomExam</span>
</div>
```

No link, no pointer cursor. So from a question bank the only way back to the homepage was the browser's back button.

The landing header has always wrapped the same markup in `<Link to="/">`; this one just never did.

## The fix

Wrapped in `<Link to="/">` with `cursor-pointer`, matching the landing header. `aria-label="JomExam home"` so it's a named link for screen readers and testable by role.

Fixes it everywhere `UserLayout` is used — `/spm/{subject}` and `/spm/{subject}/{topic}`.

## Verified in a browser

```
/spm/chemistry                        → click logo → /
/spm/chemistry/acids-bases-and-salts  → click logo → /
```

Lands on the homepage both times, client-side (no reload).

`pnpm build` clean, `69 files / 347 tests` passing, including one asserting the logo is a link to `/`.