### PR TITLE
Give students a way to sign out

### DIFF
--- a/src/components/auth/AuthContext.tsx
+++ b/src/components/auth/AuthContext.tsx
@@ -41,6 +41,10 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
 
     const logout = (callback: (() => void) | undefined) => {
         localStorage.removeItem('token')
+        // Cleared outright, the mirror of login, rather than left to the
+        // refetch that invalidation schedules — otherwise the header keeps
+        // showing the signed-in name until that round trip lands.
+        queryClient.setQueryData(['current-user'], null)
         queryClient.invalidateQueries({
             queryKey: ['current-user'],
         })

--- a/src/components/layout/UserLayout.tsx
+++ b/src/components/layout/UserLayout.tsx
@@ -56,9 +56,10 @@ const Header = () => {
                                 <Button
                                     variant="destructive"
                                     className="cursor-pointer"
-                                    onClick={() =>
-                                        logout(() => navigate('/auth/login'))
-                                    }
+                                    // Home, not the login page: signing out
+                                    // and being shown a sign-in form reads
+                                    // like the sign-out failed.
+                                    onClick={() => logout(() => navigate('/'))}
                                 >
                                     Sign out
                                 </Button>

--- a/src/components/layout/landing/LandingHeader.test.tsx
+++ b/src/components/layout/landing/LandingHeader.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { LandingHeader } from './LandingHeader'
+
+const mockLogout = vi.fn()
+let mockUser: { name: string; email: string } | null = null
+
+vi.mock('@/components/auth/AuthContext.tsx', () => ({
+    useAuth: () => ({ user: mockUser, logout: mockLogout }),
+}))
+
+function renderHeader() {
+    return render(
+        <MemoryRouter>
+            <LandingHeader />
+        </MemoryRouter>
+    )
+}
+
+describe('LandingHeader', () => {
+    beforeEach(() => {
+        mockLogout.mockReset()
+        mockUser = null
+    })
+
+    it('offers sign up / login to a visitor', () => {
+        renderHeader()
+        expect(
+            screen.getByRole('button', { name: /sign up\/ login/i })
+        ).toBeInTheDocument()
+    })
+
+    it('lets a signed-in student sign out', async () => {
+        // The name used to be a button with no click handler: it looked like
+        // a menu and did nothing, so on every page but the SPM banks there
+        // was no way to sign out at all.
+        mockUser = { name: 'A Student', email: 'student@example.com' }
+        renderHeader()
+
+        await userEvent.click(screen.getByRole('button', { name: 'A Student' }))
+        await userEvent.click(screen.getByRole('button', { name: /sign out/i }))
+
+        expect(mockLogout).toHaveBeenCalledTimes(1)
+    })
+
+    it('shows which account is signed in', () => {
+        // Two students sharing a laptop is the case that matters — signing
+        // out is only useful if you can tell whose session you are in.
+        mockUser = { name: 'A Student', email: 'student@example.com' }
+        renderHeader()
+
+        expect(
+            screen.getByRole('button', { name: 'A Student' })
+        ).toBeInTheDocument()
+    })
+})

--- a/src/components/layout/landing/LandingHeader.tsx
+++ b/src/components/layout/landing/LandingHeader.tsx
@@ -1,6 +1,11 @@
 import { Button } from '@/components/ui/button.tsx'
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/components/auth/AuthContext.tsx'
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@/components/ui/popover.tsx'
 
 /**
  * Public-site header. The menu mirrors the goal fork on the landing page —
@@ -28,7 +33,7 @@ const MENU_ITEMS: { text: string; link: string }[] = [
 
 export function LandingHeader() {
     const navigate = useNavigate()
-    const { user } = useAuth()
+    const { user, logout } = useAuth()
 
     return (
         <div className="flex px-2 md:px-12 py-4 md:py-8 items-center justify-between">
@@ -55,7 +60,34 @@ export function LandingHeader() {
                     </Link>
                 ))}
                 {user !== null ? (
-                    <Button className="ml-4">{user.name}</Button>
+                    // This used to be a plain button showing the name with no
+                    // click handler — it looked like a menu and did nothing,
+                    // so on every page but the SPM banks there was no way to
+                    // sign out at all.
+                    <Popover>
+                        <PopoverTrigger asChild>
+                            <Button className="ml-4 hover:cursor-pointer">
+                                {user.name}
+                            </Button>
+                        </PopoverTrigger>
+                        <PopoverContent align="end" className="w-56 p-2">
+                            <div className="px-2 py-1.5">
+                                <p className="text-sm font-medium truncate">
+                                    {user.name}
+                                </p>
+                                <p className="text-xs text-slate-500 truncate">
+                                    {user.email}
+                                </p>
+                            </div>
+                            <Button
+                                variant="destructive"
+                                className="mt-2 w-full hover:cursor-pointer"
+                                onClick={() => logout(() => navigate('/'))}
+                            >
+                                Sign out
+                            </Button>
+                        </PopoverContent>
+                    </Popover>
                 ) : (
                     <Button
                         className="ml-4 hover:cursor-pointer"


### PR DESCRIPTION
**There was no way to sign out from almost anywhere on the site.**

The landing header rendered the signed-in name as a plain `<Button>` **with no `onClick`** — it looked like a menu and did nothing. Only `SpmSubjectPage` and `SpmTopicPage` use the other header (`UserLayout`), which does have a Sign out. So on the homepage, `/subjects`, `/diagnostics`, `/guides`, `/about` and the rest, a signed-in student was stuck.

### Fix
The name now opens a menu showing **which account is signed in** (name + email) with **Sign out** under it. Two students sharing a laptop is the case that matters, and that only works if you can see whose session you're in.

Two smaller things found while doing it:

- **Sign out went to the login page.** Being shown a sign-in form the instant you sign out reads like it failed. Both headers now go home.
- **The header kept showing the old name after signing out.** `logout` only invalidated the cached user, so the name persisted until the refetch landed. It now clears the cache outright — the mirror of what `login` already did.

### Verified in the browser
Signed in with a throwaway account against production:

| Step | Result |
|---|---|
| Header signed in | Shows the account name |
| Click the name | Menu opens with name, email, Sign out |
| Click Sign out | `localStorage.token` → `null`, header flips to "Sign up/ Login" **immediately**, lands on `/` |

The throwaway account was deleted afterwards and confirmed gone — `users` back to 21 rows, no orphaned `user_info`.

### Tests
356 pass, 3 new — including one that pins the click actually reaching `logout`, which is the thing that was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)