### PR TITLE
Build on Node 22 so the image can actually run the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-# Use Node.js official image as base
-FROM node:18-alpine
+# Node 22, not 18: vite, vitest and react-router all require Node 20 or
+# newer, and the image is where that gets decided. Building on 18 fails here
+# while passing on a developer's own machine, so the site keeps serving the
+# previous bundle and the deploy is the only thing that tells you.
+FROM node:22-alpine
 
 # Set working directory
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -83,5 +83,8 @@
         "typescript-eslint": "^8.30.1",
         "vite": "^8.2.1",
         "vitest": "^4.1.9"
+    },
+    "engines": {
+        "node": ">=22.18.0"
     }
 }

--- a/src/lib/dockerNodeVersion.test.ts
+++ b/src/lib/dockerNodeVersion.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * The Docker image is where the build's Node version is actually decided,
+ * and nothing else in the repo mentions it.
+ *
+ * Upgrading vite, vitest or react-router quietly raised the floor to Node 20+
+ * while the image stayed on 18. Everything passed locally — a developer's own
+ * Node is newer — and the only symptom was that production kept serving the
+ * previous bundle, because the deploy failed rather than the tests.
+ */
+
+const ROOT = join(__dirname, '..', '..')
+
+function dockerNodeMajor(): number {
+    const dockerfile = readFileSync(join(ROOT, 'Dockerfile'), 'utf8')
+    const match = dockerfile.match(/^FROM node:(\d+)/m)
+    if (match === null) throw new Error('No `FROM node:<major>` in the Dockerfile')
+    return Number(match[1])
+}
+
+/** The lowest major this package will run on, from its engines field. */
+function requiredMajor(pkg: string): number | null {
+    const path = join(ROOT, 'node_modules', pkg, 'package.json')
+    if (!existsSync(path)) return null
+    const engines = JSON.parse(readFileSync(path, 'utf8')).engines
+    const range: string | undefined = engines?.node
+    if (range === undefined) return null
+
+    // A range like "^20.19.0 || >=22.12.0" is satisfied by the *lowest* major
+    // it names — that is the floor the image has to clear.
+    const majors = [...range.matchAll(/(\d+)\.\d+/g)].map((m) => Number(m[1]))
+    return majors.length > 0 ? Math.min(...majors) : null
+}
+
+// The packages that run during `pnpm build` and `pnpm test`.
+const BUILD_TOOLCHAIN = ['vite', 'vitest', 'react-router-dom', 'typescript']
+
+describe('the Docker image can run the build', () => {
+    it.each(BUILD_TOOLCHAIN)('is new enough for %s', (pkg) => {
+        const required = requiredMajor(pkg)
+        if (required === null) return // no constraint declared
+
+        expect(
+            dockerNodeMajor(),
+            `Dockerfile builds on Node ${dockerNodeMajor()}, but ${pkg} needs ${required}+. ` +
+                `The build passes locally and fails in the image.`
+        ).toBeGreaterThanOrEqual(required)
+    })
+
+    it('agrees with the engines field this package declares', () => {
+        const declared = JSON.parse(
+            readFileSync(join(ROOT, 'package.json'), 'utf8')
+        ).engines?.node
+        expect(declared, 'package.json should declare engines.node').toBeDefined()
+
+        const floor = Number(declared.match(/(\d+)/)![1])
+        expect(dockerNodeMajor()).toBeGreaterThanOrEqual(floor)
+    })
+})


### PR DESCRIPTION
**The frontend deploy is currently failing. My fault, from [#87](https://github.com/ClintonWeeYuan/math-fe/pull/87).**

The site is up and unaffected — Railway keeps serving the last good bundle — but nothing merged to `main` reaches production until this lands, including the security headers and the login hint from #87.

### What happened
#87 raised the toolchain's Node floor while the Dockerfile stayed on `node:18-alpine`:

| Package | Needs |
|---|---|
| `vite` 8.2.1 | `^20.19.0 \|\| >=22.12.0` |
| `vitest` 4.1.9 | `^20 \|\| ^22 \|\| >=24` |
| `react-router-dom` 7.18.2 | `>=20.0.0` |

`react-router` alone already broke Node 18, so this was broken the moment #87 merged — vite just made it certain.

It passed every check I ran because I build and test on Node 22. The image is the only place the build's Node version is decided, and nothing in the test suite looked at it.

### Fix
`node:18-alpine` → `node:22-alpine`, plus an `engines` field so the requirement is stated where people look.

### Guard
A test reads the Dockerfile's `FROM node:<major>` and compares it against what each build tool declares it needs. Verified it catches the real thing — put the image back on 18 and it fails with:

```
Dockerfile builds on Node 18, but vite needs 20+.
The build passes locally and fails in the image.
```

That's the property worth pinning: a mismatch here is invisible locally and only shows up as a deploy that quietly doesn't happen.

361 tests pass (74 files), build and all 96 prerendered routes unchanged.

**Not a draft — this unblocks deploys.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)