### PR TITLE
Pin the build toolchain so deploys stop breaking on their own

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,12 @@ WORKDIR /app
 # Copy package files first (better caching)
 COPY package.json pnpm-lock.yaml ./
 
-# Install pnpm
-RUN npm install -g pnpm
+# Pinned, not `npm install -g pnpm`. Unpinned, the build silently picks up
+# whatever pnpm is newest on the day it runs: pnpm 11 turned "ignored build
+# scripts" into a hard error and every deploy failed on an unchanged
+# lockfile, while local installs on pnpm 10 stayed green. Production kept
+# serving the last good bundle, so nothing announced it.
+RUN npm install -g pnpm@10.28.1
 
 # Install dependencies
 RUN pnpm install --frozen-lockfile
@@ -30,8 +34,9 @@ ENV VITE_GOOGLE_CLIENT_ID=$VITE_GOOGLE_CLIENT_ID
 # Build the app
 RUN pnpm run build
 
-# Install serve globally
-RUN npm install -g serve
+# Pinned for the same reason — this one serves the site, so a surprise major
+# version lands in production rather than in the build log.
+RUN npm install -g serve@14.2.4
 
 # Expose port 3000
 EXPOSE 3000

--- a/src/lib/dockerToolchainPinned.test.ts
+++ b/src/lib/dockerToolchainPinned.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Every tool the image installs must name its version.
+ *
+ * `npm install -g pnpm` installs whatever is newest on the day the image is
+ * built, so the build environment changes on its own. pnpm 11 turned "ignored
+ * build scripts" into a hard error, every deploy began failing on a lockfile
+ * nobody had touched, and local installs stayed green on pnpm 10. Production
+ * went on serving the previous bundle, so the only symptom was that new work
+ * quietly never appeared.
+ *
+ * A pinned version turns that into a decision someone makes in a diff.
+ */
+
+const DOCKERFILE = readFileSync(join(__dirname, '..', '..', 'Dockerfile'), 'utf8')
+
+/** Global npm installs, as [line, packages] pairs. */
+function globalInstalls(): { line: string; packages: string[] }[] {
+    return DOCKERFILE.split('\n')
+        .filter((line) => /^\s*RUN\s+npm\s+install\s+-g\s/.test(line))
+        .map((line) => ({
+            line: line.trim(),
+            packages: line
+                .replace(/^\s*RUN\s+npm\s+install\s+-g\s+/, '')
+                .split(/\s+/)
+                .filter((token) => token.length > 0 && !token.startsWith('-')),
+        }))
+}
+
+describe('the Docker build toolchain is pinned', () => {
+    it('installs something globally, or this test is watching nothing', () => {
+        expect(globalInstalls().length).toBeGreaterThan(0)
+    })
+
+    it.each(globalInstalls())('pins every package in `$line`', ({ packages }) => {
+        for (const pkg of packages) {
+            // A scoped name carries its own @, so look past the first character.
+            expect(
+                pkg.slice(1).includes('@'),
+                `"${pkg}" has no version. Unpinned, the image installs whatever ` +
+                    `is newest that day and the build changes without a diff.`
+            ).toBe(true)
+        }
+    })
+
+    it('pins pnpm to a major that accepts this lockfile', () => {
+        // pnpm 11 rejects it outright: ERR_PNPM_IGNORED_BUILDS on
+        // @tailwindcss/oxide, core-js and esbuild. Moving to 11 means
+        // recording approved build scripts in the lockfile first — a
+        // deliberate change, not a version drift.
+        const match = DOCKERFILE.match(/npm install -g pnpm@(\d+)/)
+        expect(match, 'pnpm should be installed with an explicit version').not.toBeNull()
+        expect(Number(match![1])).toBe(10)
+    })
+})


### PR DESCRIPTION
**This is why nothing has deployed.** Not the Node version I guessed at in #88 — the build never gets that far.

### The actual failure
Your Railway log shows it at step 5/8:

```
[5/8] RUN pnpm install --frozen-lockfile
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts:
  @tailwindcss/oxide@4.1.10, core-js@3.44.0, esbuild@0.14.54
process "/bin/sh -c pnpm install --frozen-lockfile" did not complete successfully
```

The Dockerfile ran `npm install -g pnpm` — **unpinned**. That installs whatever pnpm is newest on the day the image builds. pnpm 11 turned "ignored build scripts" from a warning into a hard error, so the image started rejecting an install that pnpm 10 completes happily.

Reproduced both ways against the committed lockfile, unchanged:

| pnpm | Exit |
|---|---|
| 10.28.1 | **0** (warning only) |
| 11.21.0 | **1** — `ERR_PNPM_IGNORED_BUILDS` |

Nothing in the repo changed. The build tool changed underneath it.

### Why it went unnoticed
A failed build leaves the previous bundle serving, so the site stays up and merged work simply never appears. The live sitemap still lists **87 URLs** where a build now produces **96** — production has been stale for several deploys, not just the last one.

### Fix
`pnpm@10.28.1` and `serve@14.2.4`, both pinned. `serve` matters too: it runs the site rather than the build, so a surprise major version lands in front of students.

I deliberately did **not** "fix" this by declaring approved build scripts. `--frozen-lockfile` won't honour that setting unless the lockfile records it, which means moving to pnpm 11 properly — a deliberate upgrade, not a repair for a broken pipeline. Worth doing on purpose, later.

### Guard
A test asserts every global npm install in the Dockerfile names a version. Verified against the real bug — unpin pnpm and it fails with:

```
"pnpm" has no version. Unpinned, the image installs whatever is
newest that day and the build changes without a diff.
```

That's the property worth pinning: this class of bug is invisible locally and silent in production.

365 tests pass (75 files), build and all 96 prerendered routes unchanged.

### A correction
My diagnosis in #88 was wrong. Node 18 *was* genuinely too old for `vite` and `react-router`, so that change was needed — but it was not what was failing, and I should have asked for the logs instead of inferring from a local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)