### PR TITLE
Make the prerenderer refuse rather than ship a smaller site

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -43,10 +43,21 @@ async function fetchSets(test) {
         if (!res.ok) throw new Error(`HTTP ${res.status}`)
         return await res.json()
     } catch (error) {
-        console.warn(`  ! could not fetch ${url}: ${error.message} — using static copy only`)
+        FAILURES.push(`diagnostic sets: ${error.message}`)
+        console.warn(`  ! could not fetch ${url}: ${error.message}`)
         return null
     }
 }
+
+/**
+ * Every API call that did not come back.
+ *
+ * Each fetch below degrades to null so one bad response cannot take out the
+ * whole run — but degrading quietly is how a build ships the SPA shell with
+ * no static pages and a sitemap to match, and reports success. These are
+ * collected so the end of the run can refuse.
+ */
+const FAILURES = []
 
 /** Published subjects, or null if the API can't be reached. */
 async function fetchSubjects() {
@@ -55,7 +66,8 @@ async function fetchSubjects() {
         if (!res.ok) throw new Error(`HTTP ${res.status}`)
         return await res.json()
     } catch (error) {
-        console.warn(`  ! could not fetch subjects: ${error.message} — skipping subject pages`)
+        FAILURES.push(`subject list: ${error.message}`)
+        console.warn(`  ! could not fetch subjects: ${error.message}`)
         return null
     }
 }
@@ -106,6 +118,7 @@ async function fetchSubjectDetail(slug) {
         if (!res.ok) throw new Error(`HTTP ${res.status}`)
         return await res.json()
     } catch (error) {
+        FAILURES.push(`subject ${slug}: ${error.message}`)
         console.warn(`  ! could not fetch subject ${slug}: ${error.message}`)
         return null
     }
@@ -122,6 +135,7 @@ async function fetchTopicQuestions(subjectId, topicId) {
         const page = await res.json()
         return page
     } catch (error) {
+        FAILURES.push(`questions for topic ${topicId}: ${error.message}`)
         console.warn(`  ! could not fetch questions for topic ${topicId}: ${error.message}`)
         return null
     }
@@ -541,11 +555,34 @@ async function main() {
             .join('\n') +
         '\n</urlset>\n'
     await writeFile(join(DIST, 'sitemap.xml'), sitemap)
-    console.log(`prerender: ${written} routes, sitemap: ${routes.length} urls`)
+
+    // routes.length was reported here as the sitemap size, which it is not:
+    // deliberately-noindex pages are prerendered and then filtered out just
+    // above. The two numbers differed by nine, and the log stated the larger
+    // one, which is how a healthy build came to look like a stale deploy.
+    const submitted = routes.filter((route) => route.indexable !== false).length
+    console.log(
+        `prerender: ${written} pages written, ${submitted} in the sitemap ` +
+            `(${routes.length - submitted} deliberately noindex)`
+    )
+
+    if (FAILURES.length > 0) {
+        throw new Error(
+            `${FAILURES.length} API call(s) failed, so this build is missing ` +
+                `pages it should have:\n  ${FAILURES.join('\n  ')}`
+        )
+    }
+    if (submitted === 0) {
+        throw new Error('the sitemap came out empty — nothing would be submitted')
+    }
 }
 
 main().catch((error) => {
-    // A prerender failure must not break a deploy: the SPA still works, it
-    // just loses the static copy until the next build.
-    console.error('prerender failed (continuing):', error)
+    // Fail the build. This used to continue, on the reasoning that the SPA
+    // still works without its static copy — but a deploy that quietly drops
+    // every prerendered page and shrinks the sitemap is worse than no deploy
+    // at all, and it announces nothing. A failed build leaves the previous
+    // bundle serving, which is the safe state to be in while someone looks.
+    console.error('prerender failed:', error.message)
+    process.exitCode = 1
 })


### PR DESCRIPTION
**PR 1 from the SEO plan**, with the log-line fix folded in as agreed. Worth doing before adding six guide pages, since all of them will depend on this script.

### The silent failure
Every fetch in `prerender.mjs` caught its error, warned, and returned `null`. So an API blip during a build produced a *smaller site* and exited 0:

- `fetchSubjects()` fails → **all 85 SPM pages vanish**, the sitemap is rewritten to match, build succeeds
- Nothing in the log says anything louder than a `!` line

The previous reasoning was that a prerender failure shouldn't break a deploy because the SPA still works. That's true of the app and false of the SEO: a deploy that drops every static page is worse than no deploy, and a failed build leaves the previous bundle serving — which is the safe place to be while someone looks.

Failures are now collected and the run refuses at the end, naming each one.

### The count was lying
The completion line reported `routes.length` as the sitemap size. That counts the deliberately-`noindex` pages the sitemap then filters out — it printed **96** while writing **87**.

I compared that 96 against production's 87 and told you the deploy was weeks stale. It wasn't. The build was healthy and the label was wrong. It now reports what it actually wrote:

```
prerender: 96 pages written, 87 in the sitemap (9 deliberately noindex)
```

### Verified both ways
| | |
|---|---|
| Normal build | `96 pages written, 87 in the sitemap` — matches the file exactly |
| `PRERENDER_API` unreachable | **exit 1**, listing every call that failed |

365 tests pass.

### Trade-off worth knowing
A transient API outage during a build will now block that deploy instead of shipping a degraded site. That's deliberate — it's recoverable by re-running, whereas a silently de-indexed site is discovered weeks later in Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)