### PR TITLE
Add the ESAT past-papers guide

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -21,6 +21,8 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { GUIDES } from '../src/content/guides.mjs'
+import { AUTHOR } from '../src/content/author.mjs'
+import { guideJsonLd, jsonLdText } from '../src/content/structuredData.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const DIST = join(ROOT, 'dist')
@@ -262,9 +264,44 @@ function guideMarkup(GUIDE) {
             })
             .join('') +
         '</dl></section>'
+    // Everything a crawler needs to see without running JavaScript: the
+    // byline and dates that make the page answerable to somebody, the
+    // breadcrumb trail, and the worked solutions that are the reason the
+    // page is worth ranking. All of it authored in the content module, so
+    // the static copy and the React page cannot drift apart.
+    const breadcrumb =
+        '<nav aria-label="Breadcrumb"><ol>' +
+        '<li><a href="/">Home</a></li>' +
+        '<li><a href="/guides">Guides</a></li>' +
+        `<li>${esc(GUIDE.h1)}</li>` +
+        '</ol></nav>'
+
+    const byline =
+        `<p>By <a href="${esc(AUTHOR.path)}">${esc(AUTHOR.name)}</a>, ` +
+        `${esc(AUTHOR.credential)}. Published ` +
+        `<time datetime="${esc(GUIDE.publishedAt)}">${esc(GUIDE.publishedAt)}</time>` +
+        (GUIDE.updatedAt !== GUIDE.publishedAt
+            ? `, updated <time datetime="${esc(GUIDE.updatedAt)}">${esc(GUIDE.updatedAt)}</time>`
+            : '') +
+        '.</p>'
+
+    const examples = (GUIDE.workedExamples ?? [])
+        .map(
+            (example) =>
+                `<article id="${esc(example.id)}"><p>${esc(example.module)}</p>` +
+                `<p>${esc(example.question)}</p><ol>` +
+                example.steps.map((step) => `<li>${esc(step)}</li>`).join('') +
+                `</ol><p>Answer: ${esc(example.answer)}</p>` +
+                `<p>${esc(example.takeaway)}</p></article>`
+        )
+        .join('')
+
     return (
+        breadcrumb +
         `<h1>${esc(GUIDE.h1)}</h1><p>${esc(GUIDE.standfirst)}</p>` +
+        byline +
         sections +
+        examples +
         faq +
         `<p><a href="${esc(GUIDE.ctaPath)}">${esc(GUIDE.ctaLabel)}</a></p>` +
         '<section><h2>More guides</h2><ul>' +
@@ -275,21 +312,17 @@ function guideMarkup(GUIDE) {
     )
 }
 
-/** FAQPage structured data — makes the answers eligible for rich results. */
-function faqJsonLd(GUIDE) {
-    const data = {
-        '@context': 'https://schema.org',
-        '@type': 'FAQPage',
-        mainEntity: GUIDE.faq.map((f) => ({
-            '@type': 'Question',
-            name: f.q,
-            acceptedAnswer: {
-                '@type': 'Answer',
-                text: f.link ? `${f.a} See: ${f.link.url}` : f.a,
-            },
-        })),
-    }
-    return `<script type="application/ld+json">${JSON.stringify(data)}</script>`
+/**
+ * Article, BreadcrumbList and FAQPage for a guide, in one script.
+ *
+ * Built from src/content/structuredData.mjs, which the React page reads too,
+ * so the two describe the page identically. This replaced a local FAQPage
+ * builder — briefly the page carried FAQPage twice, once from each, which
+ * is the sort of thing that gets a site's structured data discounted rather
+ * than doubled.
+ */
+function guideStructuredData(GUIDE) {
+    return `<script type="application/ld+json">${jsonLdText(guideJsonLd(GUIDE, SITE))}</script>`
 }
 
 const GUIDES_INDEX = {
@@ -311,7 +344,7 @@ const GUIDE_ROUTES = GUIDES.map((g) => ({
     path: g.path,
     title: g.title,
     description: g.description,
-    jsonLd: faqJsonLd(g),
+    jsonLd: guideStructuredData(g),
     body: guideMarkup(g),
 }))
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { EsatTmuaPage } from '@/pages/EsatTmuaPage.tsx'
 import { DiagnosticsCatalogPage } from '@/pages/DiagnosticsCatalogPage.tsx'
 import { GuidesIndexPage } from '@/pages/GuidesIndexPage.tsx'
 import { EsatPracticeGuidePage } from '@/pages/EsatPracticeGuidePage.tsx'
+import { EsatPastPapersPage } from '@/pages/EsatPastPapersPage.tsx'
 import { TmuaPracticeGuidePage } from '@/pages/TmuaPracticeGuidePage.tsx'
 import { StudentProtectedRoute } from '@/components/auth/StudentProtectedRoute.tsx'
 import { DiagnosticQuestionsListPage } from '@/pages/Admin/Diagnostic/DiagnosticQuestionsListPage.tsx'
@@ -96,6 +97,10 @@ function App() {
                 <Route
                     path="guides/esat-practice-tests"
                     element={<EsatPracticeGuidePage />}
+                />
+                <Route
+                    path="guides/esat-past-papers"
+                    element={<EsatPastPapersPage />}
                 />
                 <Route
                     path="guides/tmua-practice-tests"

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
+import { SITE_URL } from '@/lib/site.ts'
 
-const SITE_URL = 'https://www.jomexam.com'
+
 const OG_IMAGE = `${SITE_URL}/og-image.png`
 
 type Props = {

--- a/src/components/guides/GuideArticle.tsx
+++ b/src/components/guides/GuideArticle.tsx
@@ -3,6 +3,19 @@ import { Button } from '@/components/ui/button.tsx'
 import { Seo } from '@/components/Seo.tsx'
 import type { Guide } from '@/content/guideTypes.ts'
 import { GUIDES } from '@/content/guides.mjs'
+import { AUTHOR } from '@/content/author.mjs'
+import { guideJsonLd, jsonLdText } from '@/content/structuredData.mjs'
+import { SITE_URL } from '@/lib/site.ts'
+
+/** A date a reader can read, from the ISO date the content module stores. */
+function readable(iso: string) {
+    return new Date(`${iso}T00:00:00Z`).toLocaleDateString('en-GB', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+        timeZone: 'UTC',
+    })
+}
 
 const PERIWINKLE = '#799ED1'
 
@@ -24,15 +37,75 @@ export function GuideArticle({ guide }: { guide: Guide }) {
                 description={guide.description}
                 path={guide.path}
             />
+            {/* The same structured data the prerenderer writes into the
+                static HTML, so the page a crawler reads and the page a
+                reader sees describe themselves identically. */}
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{
+                    __html: jsonLdText(guideJsonLd(guide, SITE_URL)),
+                }}
+            />
             <article className="px-4 md:px-[50px] xl:px-[150px] py-12 md:py-16 max-w-3xl">
+                <nav aria-label="Breadcrumb" className="mb-4">
+                    <ol className="flex flex-wrap gap-2 text-xs text-slate-400">
+                        <li>
+                            <Link to="/" className="underline underline-offset-2">
+                                Home
+                            </Link>
+                        </li>
+                        <li aria-hidden="true">/</li>
+                        <li>
+                            <Link
+                                to="/guides"
+                                className="underline underline-offset-2"
+                            >
+                                Guides
+                            </Link>
+                        </li>
+                        <li aria-hidden="true">/</li>
+                        <li aria-current="page" className="text-slate-500">
+                            {guide.h1}
+                        </li>
+                    </ol>
+                </nav>
                 <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-4">
                     {guide.eyebrow}
                 </p>
                 <h1 className="text-3xl md:text-5xl font-bold mb-5 leading-tight">
                     {guide.h1}
                 </h1>
-                <p className="text-lg text-slate-600 leading-relaxed mb-8">
+                <p className="text-lg text-slate-600 leading-relaxed mb-6">
                     {guide.standfirst}
+                </p>
+
+                {/* Who wrote this and when it was last checked. The test's
+                    dates move every cycle, so an undated guide gives a reader
+                    no way to judge whether it still holds. */}
+                <p className="text-sm text-slate-500 mb-8">
+                    By{' '}
+                    <Link
+                        to={AUTHOR.path}
+                        className="font-medium underline underline-offset-2 text-slate-600"
+                    >
+                        {AUTHOR.name}
+                    </Link>
+                    , {AUTHOR.credential}.{' '}
+                    <span className="whitespace-nowrap">
+                        Published{' '}
+                        <time dateTime={guide.publishedAt}>
+                            {readable(guide.publishedAt)}
+                        </time>
+                        {guide.updatedAt !== guide.publishedAt && (
+                            <>
+                                , updated{' '}
+                                <time dateTime={guide.updatedAt}>
+                                    {readable(guide.updatedAt)}
+                                </time>
+                            </>
+                        )}
+                        .
+                    </span>
                 </p>
 
                 <div className="flex flex-col sm:flex-row gap-3 mb-12">
@@ -99,6 +172,41 @@ export function GuideArticle({ guide }: { guide: Guide }) {
                         )}
                     </section>
                 ))}
+
+                {guide.workedExamples !== undefined && (
+                    <section className="mb-10">
+                        {guide.workedExamples.map((example) => (
+                            <article
+                                key={example.id}
+                                id={example.id}
+                                className="mb-6 rounded-xl border border-slate-200 p-5"
+                            >
+                                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 mb-2">
+                                    {example.module}
+                                </p>
+                                <p className="font-medium text-slate-900 leading-relaxed mb-4">
+                                    {example.question}
+                                </p>
+                                <ol className="list-decimal pl-5 mb-4">
+                                    {example.steps.map((step, i) => (
+                                        <li
+                                            key={i}
+                                            className="text-slate-600 leading-relaxed mb-2"
+                                        >
+                                            {step}
+                                        </li>
+                                    ))}
+                                </ol>
+                                <p className="font-semibold text-slate-900 mb-3">
+                                    Answer: {example.answer}
+                                </p>
+                                <p className="text-sm text-slate-500 leading-relaxed">
+                                    {example.takeaway}
+                                </p>
+                            </article>
+                        ))}
+                    </section>
+                )}
 
                 <section className="mb-10">
                     <h2 className="text-xl md:text-2xl font-bold mb-4">

--- a/src/content/author.d.mts
+++ b/src/content/author.d.mts
@@ -1,0 +1,5 @@
+export declare const AUTHOR: {
+    name: string
+    credential: string
+    path: string
+}

--- a/src/content/author.mjs
+++ b/src/content/author.mjs
@@ -1,0 +1,16 @@
+/**
+ * Who writes the guides.
+ *
+ * One record, because it is one person and repeating it per guide is how the
+ * credential ends up spelled three ways. Rendered as a visible byline and
+ * emitted as schema.org Person — the qualification is a real reason to
+ * believe the pages, and until now it appeared nowhere on the site at all.
+ */
+
+export const AUTHOR = {
+    name: 'Hazel Wee Ling',
+    /** Shown after the name, and used as the Person jobTitle in JSON-LD. */
+    credential: 'DPhil in Engineering Science, University of Oxford',
+    /** Where a reader can check who that is. */
+    path: '/about',
+}

--- a/src/content/esatPastPapers.d.mts
+++ b/src/content/esatPastPapers.d.mts
@@ -1,0 +1,2 @@
+import type { Guide } from './guideTypes'
+export declare const GUIDE: Guide

--- a/src/content/esatPastPapers.mjs
+++ b/src/content/esatPastPapers.mjs
@@ -1,0 +1,207 @@
+/**
+ * Content for the ESAT past-papers guide.
+ *
+ * Targets the words students actually search — "past papers", "specimen
+ * papers", "sample papers" — rather than our own product vocabulary of
+ * diagnostics and skills reports. Search Console shows every top query for
+ * the existing ESAT guide is a "papers" or "questions" query.
+ *
+ * Factual claims match the ESAT practice guide and come from the same
+ * sources: UAT-UK, Cambridge and Imperial, checked August 2026. Where that
+ * guide and this one state the same fact, they must agree — a reader who
+ * lands on both should not have to work out which is current.
+ *
+ * The worked examples are written for this page, in the style of the test.
+ * They are deliberately not taken from the official papers (not ours to
+ * republish) nor from our own diagnostic bank (that is the scored
+ * instrument, and publishing it with solutions would spend it). Every
+ * numerical answer below has been worked through by hand.
+ */
+
+export const GUIDE = {
+    path: '/guides/esat-past-papers',
+    title: 'ESAT Past Papers, Specimen Papers and Sample Questions | JomExam',
+    description:
+        'Every official ESAT past paper and specimen paper, where to find them, and what to do once you have worked through them. Includes worked ESAT questions with full solutions, and a free timed paper for each module.',
+    eyebrow: 'ESAT guide',
+    ctaPath: '/diagnostics/esat',
+    ctaLabel: 'Sit a free ESAT paper →',
+    h1: 'ESAT past papers and specimen papers',
+    standfirst:
+        'There is less official ESAT material than students expect, and it runs out quickly. This page sets out exactly what exists, where to get it, how to get the most from each paper — and what to do next, because the honest answer to "where are the rest of the past papers" is that they do not exist yet.',
+    publishedAt: '2026-08-11',
+    updatedAt: '2026-08-11',
+    sections: [
+        {
+            id: 'what-exists',
+            h2: 'What official ESAT papers exist',
+            paras: [
+                'UAT-UK, the body that runs the test, publishes the material worth starting with: a content specification setting out precisely what can be assessed, an ESAT guide to the underlying maths and science, and specimen and practice tests delivered through Pearson, alongside an archive of past papers.',
+                'Work through those first, and under timed conditions. They are the only material written by the people who write the real test, and no third-party paper — ours included — is a substitute for that.',
+                'The catch is depth. The ESAT replaced the older ENGAA and NSAA only recently, so there is nothing like the twenty-year back catalogue you would have for an A-level subject. Most candidates exhaust the official papers well before the October sitting, and a paper you have already seen cannot tell you anything new about your timing.',
+            ],
+        },
+        {
+            id: 'papers-vs-questions',
+            h2: 'Past papers, specimen papers and sample questions are not the same thing',
+            paras: [
+                'The three terms get used interchangeably in forums, and they are worth separating, because they are useful at different points.',
+                'A specimen paper shows the format: how the questions are worded, how long you get, what the answer sheet looks like. A past paper is a test that was actually sat, so it also tells you the real standard. Sample questions are individual items, useful for drilling one topic but useless for practising the thing the ESAT is genuinely hard at, which is finishing.',
+            ],
+            table: {
+                caption:
+                    'What each kind of ESAT material is good for and where it comes from',
+                head: ['Material', 'Comes from', 'Best used for'],
+                rows: [
+                    [
+                        'Specimen papers',
+                        'UAT-UK, via Pearson',
+                        'Learning the format before you spend a real paper on it',
+                    ],
+                    [
+                        'Past papers',
+                        'UAT-UK archive',
+                        'Judging the genuine standard, under strict timing',
+                    ],
+                    [
+                        'Sample questions',
+                        'UAT-UK content specification and guide',
+                        'Drilling one topic where you know you are weak',
+                    ],
+                    [
+                        'ENGAA and NSAA papers',
+                        'The predecessor tests',
+                        'Extra material of a similar flavour, but not the same syllabus — check each question against the current specification',
+                    ],
+                ],
+            },
+        },
+        {
+            id: 'timing',
+            h2: 'The constraint the papers are really testing',
+            paras: [
+                'Each ESAT module gives you 27 questions in 40 minutes. That is under 90 seconds per question, with no calculator, on multi-step problems. Almost nobody fails the ESAT because they could not eventually do the questions; they fail because they could not do them at that pace.',
+                'This changes how a past paper should be used. Working slowly through one, checking answers as you go, tells you very little. Sitting it once, timed, with no interruptions, tells you nearly everything — and it is the only way to find out that a question you can solve in four minutes is worth zero to you.',
+                'There is no negative marking, so leaving anything blank is a straightforward loss. If you have not started a question with ten seconds left, answer it anyway.',
+            ],
+        },
+        {
+            id: 'worked-examples',
+            h2: 'Three ESAT-style questions, worked through',
+            paras: [
+                'These are written to the style of the test rather than copied from an official paper. Each is the kind of multi-step, calculator-free question the ESAT favours: the arithmetic stays clean, and the difficulty is in choosing the route.',
+                'Try each one under 90 seconds before reading the working.',
+            ],
+        },
+        {
+            id: 'after-the-papers',
+            h2: 'What to do once the official papers are gone',
+            paras: [
+                'At that point the useful question is no longer "what is my score" but "which specific thing costs me marks". A total out of 27 does not answer that; it tells you the result of the problem, not its cause.',
+                'That is the gap our diagnostics are built for. Each is a full timed paper in the real format — 27 questions, 40 minutes — and the report afterwards names the skills that went wrong rather than handing you a number. Set A of every module is free, and you do not need an account to read this page or to see what the questions look like.',
+            ],
+        },
+    ],
+    workedExamples: [
+        {
+            id: 'tangent-line',
+            module: 'Mathematics 1',
+            question:
+                'The line y = 2x + c is a tangent to the curve y = x² + 3x + 5. Find the value of c.',
+            steps: [
+                'A tangent meets the curve exactly once, so set them equal and require a single root: x² + 3x + 5 = 2x + c.',
+                'Rearrange to x² + x + (5 − c) = 0.',
+                'One repeated root means the discriminant is zero: b² − 4ac = 1² − 4(1)(5 − c) = 0.',
+                'So 1 − 20 + 4c = 0, giving 4c = 19.',
+            ],
+            answer: 'c = 19/4',
+            takeaway:
+                'The word "tangent" is the whole question. Recognising it as "discriminant equals zero" turns a curve-sketching problem into one line of algebra — the substitution is the slow route and there is no time for it.',
+        },
+        {
+            id: 'kinetic-energy-twice',
+            module: 'Physics',
+            question:
+                'A ball of mass 0.50 kg is thrown vertically upwards at 20 m s⁻¹. Taking g = 10 m s⁻², how much time passes between the two moments at which its kinetic energy is 25 J? Ignore air resistance.',
+            steps: [
+                'Kinetic energy is ½mv², so 25 = ½ × 0.50 × v², giving v² = 100 and v = 10 m s⁻¹.',
+                'Speed 10 m s⁻¹ happens twice: once going up, once coming back down.',
+                'Using v = u − gt on the way up: 10 = 20 − 10t, so t = 1 s.',
+                'On the way down the velocity is −10 m s⁻¹: −10 = 20 − 10t, so t = 3 s.',
+            ],
+            answer: '2 seconds',
+            takeaway:
+                'Energy is a scalar, so it cannot tell you which direction the ball is moving — that is exactly why there are two answers. Solving for v and stopping at 1 s is the trap.',
+        },
+        {
+            id: 'combustion-formula',
+            module: 'Chemistry',
+            question:
+                'Burning 0.25 mol of a hydrocarbon completely produces 22.0 g of carbon dioxide and 13.5 g of water. Determine its molecular formula. (Mr: CO₂ = 44, H₂O = 18)',
+            steps: [
+                'Moles of CO₂ = 22.0 ÷ 44 = 0.50 mol, and every carbon atom ends up in one CO₂, so there are 0.50 mol of carbon.',
+                'Moles of H₂O = 13.5 ÷ 18 = 0.75 mol, and each water carries two hydrogens, so there are 1.50 mol of hydrogen.',
+                'Divide through by the 0.25 mol of hydrocarbon burnt: 0.50 ÷ 0.25 = 2 carbons, 1.50 ÷ 0.25 = 6 hydrogens.',
+            ],
+            answer: 'C₂H₆ (ethane)',
+            takeaway:
+                'Dividing by the moles of the compound burnt — not by the smallest number of moles — is what gives the molecular formula directly. Reaching for empirical formula out of habit gives CH₃, which is not a molecule.',
+        },
+    ],
+    faq: [
+        {
+            q: 'Where can I download official ESAT past papers?',
+            a: 'From UAT-UK, the body that runs the test. It publishes the content specification, an ESAT guide, and specimen and practice tests delivered through Pearson, alongside an archive of past papers. Use the official material before anything written by a prep company, ours included.',
+            link: {
+                label: 'Official ESAT preparation materials (UAT-UK)',
+                url: 'https://esat-tmua.ac.uk/prepare/',
+            },
+        },
+        {
+            q: 'How many ESAT past papers are there?',
+            a: 'Far fewer than for an established A-level subject. The ESAT only replaced the ENGAA and NSAA recently, so there is no long back catalogue, and most candidates work through everything official well before the October sitting. Once you have sat a paper under timed conditions it is spent — you cannot un-see the questions.',
+        },
+        {
+            q: 'Can I use ENGAA and NSAA past papers for ESAT practice?',
+            a: 'They are worth using for extra material of a similar flavour, but they are not the same test and not the same syllabus. Check anything you attempt against the current ESAT content specification before assuming it is representative, particularly in Physics and Chemistry.',
+            link: {
+                label: 'Official ESAT preparation materials (UAT-UK)',
+                url: 'https://esat-tmua.ac.uk/prepare/',
+            },
+        },
+        {
+            q: 'Are ESAT specimen papers the same as past papers?',
+            a: 'No. A specimen paper shows you the format and the style of question; a past paper is one that candidates actually sat, so it also shows you the real standard. Use a specimen paper first, so that you spend a past paper on a timed attempt rather than on learning what the answer sheet looks like.',
+        },
+        {
+            q: 'How long is each ESAT module?',
+            a: '27 questions in 40 minutes per module, with no calculator and no negative marking. That is under 90 seconds a question, which is why practising untimed tells you so little — and why leaving anything blank is a straightforward loss.',
+            link: {
+                label: 'How ESAT results are reported (UAT-UK)',
+                url: 'https://esat-tmua.ac.uk/about-the-tests/esat-test/',
+            },
+        },
+        {
+            q: 'When is the next ESAT sitting?',
+            a: 'There are two: 12–16 October 2026 and 4–8 January 2027. Applicants to Cambridge and Oxford must sit the October window. Booking for October closes on 28 September 2026 at 6pm BST. You register yourself through a UAT-UK account and then book a seat with Pearson — your school will not do it for you. Confirm every date on the official site before relying on it, as they move each cycle.',
+            link: {
+                label: 'Official ESAT dates and registration (UAT-UK)',
+                url: 'https://esat-tmua.ac.uk/register/',
+            },
+        },
+    ],
+    sources: [
+        {
+            label: 'UAT-UK (the official ESAT body)',
+            url: 'https://esat-tmua.ac.uk/about-the-tests/esat-test/',
+        },
+        {
+            label: 'University of Cambridge — ESAT',
+            url: 'https://www.undergraduate.study.cam.ac.uk/apply/how/science-engineering-admission-test',
+        },
+        {
+            label: 'Imperial College London — ESAT',
+            url: 'https://www.imperial.ac.uk/study/apply/undergraduate/process/admissions-tests/esat/',
+        },
+    ],
+}

--- a/src/content/esatPracticeGuide.mjs
+++ b/src/content/esatPracticeGuide.mjs
@@ -26,6 +26,11 @@ export const GUIDE = {
     h1: 'ESAT practice tests',
     standfirst:
         'Start with the official specimen papers — then the problem becomes what to do next, because the ESAT is new and the back catalogue is shallow. This guide explains what the test actually asks of you, and gives you a timed paper for every module: free, and with a report naming the specific skills to fix rather than just a mark.',
+    // The date the page went live, and the date its facts were last
+    // checked against the official sources. Both shown to readers: a guide
+    // to a test whose dates move every cycle is worth little undated.
+    publishedAt: '2026-08-01',
+    updatedAt: '2026-08-01',
     sections: [
         {
             id: 'what-practice-exists',

--- a/src/content/guideStructuredData.test.ts
+++ b/src/content/guideStructuredData.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { GUIDES } from './guides.mjs'
+import { guideJsonLd, jsonLdText } from './structuredData.mjs'
+import { AUTHOR } from './author.mjs'
+
+const SITE = 'https://www.jomexam.com'
+
+/**
+ * Structured data is only worth emitting if it describes the page honestly.
+ * Nothing here checks that it looks nice — it checks the claims are ones the
+ * page actually backs up.
+ */
+describe.each(GUIDES.map((guide) => [guide.h1, guide] as const))(
+    '%s',
+    (_name, guide) => {
+        const blocks = guideJsonLd(guide, SITE)
+        const typeOf = (type: string) =>
+            blocks.find((b) => (b as { '@type': string })['@type'] === type)
+
+        it('describes itself as an Article with a real author', () => {
+            const article = typeOf('Article') as Record<string, never>
+            expect(article).toBeDefined()
+            expect((article.author as unknown as { name: string }).name).toBe(
+                AUTHOR.name
+            )
+        })
+
+        it('states when it was published and last checked', () => {
+            const article = typeOf('Article') as unknown as {
+                datePublished: string
+                dateModified: string
+            }
+            // A guide to a test whose dates move every cycle is worth little
+            // undated, and Google will not invent one.
+            expect(article.datePublished).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+            expect(article.dateModified).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+            expect(
+                new Date(article.dateModified) >= new Date(article.datePublished)
+            ).toBe(true)
+        })
+
+        it('points its canonical identity at its own URL', () => {
+            const article = typeOf('Article') as unknown as {
+                mainEntityOfPage: { '@id': string }
+            }
+            expect(article.mainEntityOfPage['@id']).toBe(`${SITE}${guide.path}`)
+        })
+
+        it('claims exactly the questions the page answers', () => {
+            const faq = typeOf('FAQPage') as unknown as {
+                mainEntity: { name: string }[]
+            }
+            // Marking up Q&A a reader cannot see is the classic way to have
+            // structured data ignored across a whole site.
+            expect(faq.mainEntity.map((q) => q.name)).toEqual(
+                guide.faq.map((f) => f.q)
+            )
+        })
+
+        it('emits FAQPage once, not once per builder', () => {
+            const faqBlocks = blocks.filter(
+                (b) => (b as { '@type': string })['@type'] === 'FAQPage'
+            )
+            expect(faqBlocks).toHaveLength(1)
+        })
+
+        it('leads a crawler back up the site through the breadcrumb', () => {
+            const crumbs = typeOf('BreadcrumbList') as unknown as {
+                itemListElement: { position: number; item: string }[]
+            }
+            expect(crumbs.itemListElement.map((c) => c.item)).toEqual([
+                SITE,
+                `${SITE}/guides`,
+                `${SITE}${guide.path}`,
+            ])
+        })
+    }
+)
+
+describe('jsonLdText', () => {
+    it('cannot be broken out of by the content it carries', () => {
+        // A guide that mentions a closing script tag in its prose would
+        // otherwise end the block early and spill the rest onto the page.
+        const hostile = {
+            ...GUIDES[0],
+            h1: 'Mind the </script> tag',
+            faq: [],
+        }
+        const text = jsonLdText(guideJsonLd(hostile, SITE))
+
+        expect(text).not.toContain('</script>')
+        expect(JSON.parse(text)).toBeInstanceOf(Array)
+    })
+})
+
+describe('worked examples', () => {
+    const withExamples = GUIDES.filter((g) => g.workedExamples !== undefined)
+
+    it('are present on the past-papers guide', () => {
+        expect(withExamples.length).toBeGreaterThan(0)
+    })
+
+    it.each(withExamples.flatMap((g) => g.workedExamples ?? []))(
+        'shows its reasoning and its answer: $id',
+        (example) => {
+            // The point of these pages is the working, not the answer. A
+            // worked example with no steps is a thin page with extra words.
+            expect(example.steps.length).toBeGreaterThanOrEqual(2)
+            expect(example.answer.trim()).not.toBe('')
+            expect(example.takeaway.trim()).not.toBe('')
+        }
+    )
+})

--- a/src/content/guideTypes.ts
+++ b/src/content/guideTypes.ts
@@ -16,6 +16,25 @@ export type GuideFaqItem = {
     link?: { label: string; url: string }
 }
 
+/**
+ * A question written to the style of the test, with its reasoning shown.
+ *
+ * Deliberately not pulled from the diagnostic bank: those are the scored
+ * instrument, and publishing them with answers would mean students meet them
+ * before they sit them. These are written for the page.
+ */
+export type WorkedExample = {
+    id: string
+    /** Which module's style this is written to, e.g. "Mathematics 1". */
+    module: string
+    question: string
+    /** One step per line, in the order you would actually work. */
+    steps: string[]
+    answer: string
+    /** What the question was really testing — the reason it is here. */
+    takeaway: string
+}
+
 export type Guide = {
     path: string
     title: string
@@ -28,6 +47,11 @@ export type Guide = {
     ctaPath: string
     ctaLabel: string
     sections: GuideSection[]
+    /** ISO dates. Shown to readers and emitted as Article metadata; a guide
+     *  about a test whose dates move every year is worth nothing undated. */
+    publishedAt: string
+    updatedAt: string
+    workedExamples?: WorkedExample[]
     faq: GuideFaqItem[]
     sources: { label: string; url: string }[]
 }

--- a/src/content/guides.mjs
+++ b/src/content/guides.mjs
@@ -1,4 +1,5 @@
 import { GUIDE as esatPracticeGuide } from './esatPracticeGuide.mjs'
+import { GUIDE as esatPastPapers } from './esatPastPapers.mjs'
 import { GUIDE as tmuaPracticeGuide } from './tmuaPracticeGuide.mjs'
 
 /**
@@ -9,4 +10,4 @@ import { GUIDE as tmuaPracticeGuide } from './tmuaPracticeGuide.mjs'
  * plus a route, and it appears everywhere it should without anyone having to
  * remember the other places.
  */
-export const GUIDES = [esatPracticeGuide, tmuaPracticeGuide]
+export const GUIDES = [esatPracticeGuide, esatPastPapers, tmuaPracticeGuide]

--- a/src/content/structuredData.d.mts
+++ b/src/content/structuredData.d.mts
@@ -1,0 +1,8 @@
+import type { Guide } from './guideTypes'
+
+export declare function guideJsonLd(
+    guide: Guide,
+    site: string
+): Record<string, unknown>[]
+
+export declare function jsonLdText(blocks: Record<string, unknown>[]): string

--- a/src/content/structuredData.mjs
+++ b/src/content/structuredData.mjs
@@ -1,0 +1,79 @@
+import { AUTHOR } from './author.mjs'
+
+/**
+ * schema.org JSON-LD for a guide.
+ *
+ * Plain data in .mjs for the same reason the guides are: the prerenderer
+ * emits this into the static HTML that crawlers read, and the React page
+ * emits the same object once it takes over. Structured data that disagreed
+ * with the page it describes is worse than none.
+ *
+ * Only what the page genuinely contains is described. A FAQPage block is
+ * emitted when there is a real question-and-answer section and omitted
+ * otherwise — claiming Q&A that a reader cannot see is the kind of thing
+ * that gets structured data ignored site-wide.
+ */
+export function guideJsonLd(guide, site) {
+    const url = `${site}${guide.path}`
+
+    const person = {
+        '@type': 'Person',
+        name: AUTHOR.name,
+        jobTitle: AUTHOR.credential,
+        url: `${site}${AUTHOR.path}`,
+    }
+
+    const article = {
+        '@context': 'https://schema.org',
+        '@type': 'Article',
+        headline: guide.h1,
+        description: guide.description,
+        datePublished: guide.publishedAt,
+        dateModified: guide.updatedAt,
+        author: person,
+        publisher: {
+            '@type': 'Organization',
+            name: 'JomExam',
+            url: site,
+        },
+        mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+        inLanguage: 'en-GB',
+    }
+
+    const breadcrumbs = {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: site },
+            { '@type': 'ListItem', position: 2, name: 'Guides', item: `${site}/guides` },
+            { '@type': 'ListItem', position: 3, name: guide.h1, item: url },
+        ],
+    }
+
+    const blocks = [article, breadcrumbs]
+
+    if (guide.faq.length > 0) {
+        blocks.push({
+            '@context': 'https://schema.org',
+            '@type': 'FAQPage',
+            mainEntity: guide.faq.map((item) => ({
+                '@type': 'Question',
+                name: item.q,
+                acceptedAnswer: { '@type': 'Answer', text: item.a },
+            })),
+        })
+    }
+
+    return blocks
+}
+
+/**
+ * The JSON, safe to sit inside a <script> element.
+ *
+ * A literal "</script>" anywhere in the content — quite possible in a guide
+ * about writing — would end the block early and spill the rest onto the page
+ * as markup. Escaping the slash is inert to a JSON parser.
+ */
+export function jsonLdText(blocks) {
+    return JSON.stringify(blocks, null, 0).replace(/<\//g, '<\\/')
+}

--- a/src/content/tmuaPracticeGuide.mjs
+++ b/src/content/tmuaPracticeGuide.mjs
@@ -26,6 +26,11 @@ export const GUIDE = {
     h1: 'TMUA practice tests',
     standfirst:
         'The TMUA is two papers that feel like different exams: one asks you to apply mathematics you already know, the other asks you to reason about it. This guide explains what each paper actually tests, and gives you a timed paper for both — free, with a report naming the specific gaps rather than just a mark.',
+    // The date the page went live, and the date its facts were last
+    // checked against the official sources. Both shown to readers: a guide
+    // to a test whose dates move every cycle is worth little undated.
+    publishedAt: '2026-08-01',
+    updatedAt: '2026-08-01',
     sections: [
         {
             id: 'two-papers',

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,6 @@
+/** The canonical origin, in one place.
+ *
+ * Was a private constant inside Seo.tsx; the structured data needs the same
+ * value, and two copies of an origin is how a canonical and a JSON-LD @id
+ * come to disagree about which site this is. */
+export const SITE_URL = 'https://www.jomexam.com'

--- a/src/pages/EsatPastPapersPage.tsx
+++ b/src/pages/EsatPastPapersPage.tsx
@@ -1,0 +1,13 @@
+import { LandingLayout } from '@/components/layout/landing/LandingLayout.tsx'
+import { GuideArticle } from '@/components/guides/GuideArticle.tsx'
+import { GUIDE } from '@/content/esatPastPapers.mjs'
+
+/** The ESAT past-papers guide. Words live in the content module; layout is
+ *  shared with every other guide via GuideArticle. */
+export function EsatPastPapersPage() {
+    return (
+        <LandingLayout>
+            <GuideArticle guide={GUIDE} />
+        </LandingLayout>
+    )
+}


### PR DESCRIPTION
**PR 2 in the approved order** — the highest-value page, shipped on its own so it goes live soonest.

Covers three of your five top Search Console queries: `esat past papers`, `esat specimen papers`, `esat sample papers`.

### Written in the students' vocabulary
Every top query for `/guides/esat-practice-tests` is a "papers" or "questions" query, while the site says "diagnostics", "skills report", "Set A". This page uses their words and answers the thing they're really asking, including the honest bit: there aren't many ESAT past papers, and they run out.

### The worked examples are the page
Three ESAT-style questions with full reasoning — a Maths 1 tangent/discriminant problem, a Physics kinetic-energy question with two valid times, and a Chemistry combustion-to-formula question. Each has a takeaway naming the trap. I worked every answer by hand.

They're **written for the page**, not taken from the official papers (not ours to republish) or from your diagnostic bank.

**On the decision point in your brief:** fetching from `math-be` isn't viable, and not for the reasons I expected. `diagnostic_questions` has `stem`, `options`, `correct_option` and a per-option `misconception` — **there is no solution or explanation field at all**. There's nothing to fetch that constitutes worked reasoning; you'd be authoring it either way. And publishing live scored questions with answers would spend the instrument.

### Every requirement on your list
| | |
|---|---|
| Self-referencing canonical | ✅ |
| Unique title/description in query vocabulary | ✅ |
| `FAQPage` JSON-LD | ✅ (6 questions) |
| Visible published/updated dates | ✅ |
| Author byline + `Person` schema | ✅ Hazel Wee Ling, DPhil in Engineering Science |
| Breadcrumbs back to `/guides` | ✅ + `BreadcrumbList` |
| Cross-links to sibling guides | ✅ |
| Statically rendered, not client-only | ✅ verified in the static HTML |

Built as reusable parts of the guide content system, so the five module pages become content modules rather than more scaffolding.

### A correction to my plan
I reported "no JSON-LD anywhere on the site". Wrong — I'd grepped `src/` only. There was `EducationalOrganization` in `index.html` and a `FAQPage` builder inside `prerender.mjs`. That mattered: my first version emitted a **second** `FAQPage`, so every guide claimed it twice. Consolidated onto one builder, with a test that fails if a duplicate reappears.

### Verified
Static HTML (what a crawler gets, no JavaScript): title, canonical, byline, dates, breadcrumb, all three worked solutions, and JSON-LD parsing to `Article`, `BreadcrumbList`, `FAQPage` — exactly one each. In the browser: all three examples render with their steps and answers.

388 tests pass, 23 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)