### PR TITLE
Split the sitemap into an index with core and SPM children

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -346,6 +346,10 @@ const GUIDE_ROUTES = GUIDES.map((g) => ({
     description: g.description,
     jsonLd: guideStructuredData(g),
     body: guideMarkup(g),
+    // The date the author last checked this guide's facts. Genuinely
+    // per-page and genuinely maintained, so it is worth telling Google
+    // about; see sitemapFor() for why most pages carry no lastmod at all.
+    lastmod: g.updatedAt,
 }))
 
 const ROUTES = [
@@ -441,6 +445,49 @@ const ROUTES = [
     },
 ].concat([GUIDES_INDEX], GUIDE_ROUTES)
 
+/**
+ * One <urlset> for a group of routes.
+ *
+ * <lastmod> is emitted only where a route genuinely knows when it changed —
+ * in practice the guides, which carry a date their author maintains. Nothing
+ * else does: the SPM pages are built from the questions table, which records
+ * created_at and no updated_at, so a date there would be silently wrong the
+ * moment anyone edited a question through the admin. A lastmod that lies is
+ * worse than none, because Google learns to disregard the field across the
+ * whole site rather than for the one page.
+ *
+ * No <priority> or <changefreq> — Google ignores both.
+ */
+function sitemapFor(routes) {
+    const submitted = routes.filter((route) => route.indexable !== false)
+    const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+        submitted
+            .map((route) => {
+                const loc = `${SITE}${route.path === '/' ? '/' : route.path}`
+                const lastmod = route.lastmod
+                    ? `\n    <lastmod>${esc(route.lastmod)}</lastmod>`
+                    : ''
+                return `  <url>\n    <loc>${esc(loc)}</loc>${lastmod}\n  </url>`
+            })
+            .join('\n') +
+        '\n</urlset>\n'
+    return { xml, count: submitted.length }
+}
+
+/** The index that points at the children. */
+function sitemapIndex(files) {
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+        files
+            .map((file) => `  <sitemap>\n    <loc>${SITE}/${file}</loc>\n  </sitemap>`)
+            .join('\n') +
+        '\n</sitemapindex>\n'
+    )
+}
+
 async function main() {
     // The template is dist/index.html — which this script also *writes*, as
     // the '/' route. A second run therefore reads a template whose #root is
@@ -490,11 +537,15 @@ async function main() {
         ])
     )
 
-    const routes = [
-        ...ROUTES,
+    // Two groups, kept apart from here on. The split is what makes Search
+    // Console able to say *which* group is going uncrawled: one flat sitemap
+    // reports "11 of 88 indexed" and leaves you guessing which 11.
+    const coreRoutes = ROUTES
+    const spmRoutes = [
         ...subjectRoutes(subjects, topicPathsBySubject),
         ...topicPages,
     ]
+    const routes = [...coreRoutes, ...spmRoutes]
 
     for (const route of routes) {
         const url = `${SITE}${route.path}`
@@ -576,27 +627,29 @@ async function main() {
         console.log(`  prerendered ${route.path}`)
         written++
     }
-    // The sitemap is generated from the same list that was just written, so
-    // it cannot drift from what actually exists. It used to be a static file
-    // in public/, which meant every new page needed someone to remember.
-    const sitemap =
-        '<?xml version="1.0" encoding="UTF-8"?>\n' +
-        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
-        routes
-            .filter((route) => route.indexable !== false)
-            .map((route) => `  <url>\n    <loc>${SITE}${route.path === '/' ? '/' : route.path}</loc>\n  </url>`)
-            .join('\n') +
-        '\n</urlset>\n'
-    await writeFile(join(DIST, 'sitemap.xml'), sitemap)
+    // Generated from the same lists that were just written, so a sitemap
+    // cannot drift from what actually exists. It used to be a static file in
+    // public/, which meant every new page needed someone to remember.
+    //
+    // Split into an index and two children. Google does not work through a
+    // sitemap in order, so this does not let new pages "jump the queue" —
+    // what it buys is a per-sitemap indexed count in Search Console, which
+    // turns "11 of 88 indexed" into a statement about which group is going
+    // uncrawled. That is the question actually worth answering.
+    const coreSubmitted = sitemapFor(coreRoutes)
+    const spmSubmitted = sitemapFor(spmRoutes)
+    await writeFile(join(DIST, 'sitemap-core.xml'), coreSubmitted.xml)
+    await writeFile(join(DIST, 'sitemap-spm.xml'), spmSubmitted.xml)
+    await writeFile(
+        join(DIST, 'sitemap.xml'),
+        sitemapIndex(['sitemap-core.xml', 'sitemap-spm.xml'])
+    )
 
-    // routes.length was reported here as the sitemap size, which it is not:
-    // deliberately-noindex pages are prerendered and then filtered out just
-    // above. The two numbers differed by nine, and the log stated the larger
-    // one, which is how a healthy build came to look like a stale deploy.
-    const submitted = routes.filter((route) => route.indexable !== false).length
+    const submitted = coreSubmitted.count + spmSubmitted.count
     console.log(
-        `prerender: ${written} pages written, ${submitted} in the sitemap ` +
-            `(${routes.length - submitted} deliberately noindex)`
+        `prerender: ${written} pages written, ${submitted} in the sitemaps ` +
+            `(${coreSubmitted.count} core, ${spmSubmitted.count} SPM, ` +
+            `${routes.length - submitted} deliberately noindex)`
     )
 
     if (FAILURES.length > 0) {

--- a/src/content/esatPracticeGuide.mjs
+++ b/src/content/esatPracticeGuide.mjs
@@ -26,11 +26,13 @@ export const GUIDE = {
     h1: 'ESAT practice tests',
     standfirst:
         'Start with the official specimen papers — then the problem becomes what to do next, because the ESAT is new and the back catalogue is shallow. This guide explains what the test actually asks of you, and gives you a timed paper for every module: free, and with a report naming the specific skills to fix rather than just a mark.',
-    // The date the page went live, and the date its facts were last
-    // checked against the official sources. Both shown to readers: a guide
-    // to a test whose dates move every cycle is worth little undated.
+    // When the page went live, and when it last changed. updatedAt drives
+    // <lastmod>, which sitemaps.org defines as the modification date of the
+    // page — not "when someone last re-read the facts". It moved to the 11th
+    // because that is when the page gained its byline and dates, which is a
+    // change a reader can see.
     publishedAt: '2026-08-01',
-    updatedAt: '2026-08-01',
+    updatedAt: '2026-08-11',
     sections: [
         {
             id: 'what-practice-exists',

--- a/src/content/guideTypes.ts
+++ b/src/content/guideTypes.ts
@@ -47,8 +47,13 @@ export type Guide = {
     ctaPath: string
     ctaLabel: string
     sections: GuideSection[]
-    /** ISO dates. Shown to readers and emitted as Article metadata; a guide
-     *  about a test whose dates move every year is worth nothing undated. */
+    /** ISO dates, shown to readers and emitted as Article metadata — a guide
+     *  to a test whose dates move every year is worth little undated.
+     *
+     *  updatedAt is when the *page* last changed, which is what <lastmod>
+     *  means, and it is checked against git: change the content without
+     *  moving it and the build fails rather than telling Google a date that
+     *  is not true. */
     publishedAt: string
     updatedAt: string
     workedExamples?: WorkedExample[]

--- a/src/content/tmuaPracticeGuide.mjs
+++ b/src/content/tmuaPracticeGuide.mjs
@@ -26,11 +26,13 @@ export const GUIDE = {
     h1: 'TMUA practice tests',
     standfirst:
         'The TMUA is two papers that feel like different exams: one asks you to apply mathematics you already know, the other asks you to reason about it. This guide explains what each paper actually tests, and gives you a timed paper for both — free, with a report naming the specific gaps rather than just a mark.',
-    // The date the page went live, and the date its facts were last
-    // checked against the official sources. Both shown to readers: a guide
-    // to a test whose dates move every cycle is worth little undated.
+    // When the page went live, and when it last changed. updatedAt drives
+    // <lastmod>, which sitemaps.org defines as the modification date of the
+    // page — not "when someone last re-read the facts". It moved to the 11th
+    // because that is when the page gained its byline and dates, which is a
+    // change a reader can see.
     publishedAt: '2026-08-01',
-    updatedAt: '2026-08-01',
+    updatedAt: '2026-08-11',
     sections: [
         {
             id: 'two-papers',

--- a/src/lib/sitemap.test.ts
+++ b/src/lib/sitemap.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { GUIDES } from '@/content/guides.mjs'
+
+const ROOT = join(__dirname, '..', '..')
+const DIST = join(ROOT, 'dist')
+const NS = 'http://www.sitemaps.org/schemas/sitemap/0.9'
+
+/**
+ * These read dist/, so they only mean anything after a build. Skipped rather
+ * than failed when it is absent, so `pnpm test` on a clean checkout does not
+ * report a problem that is not one.
+ */
+const built = existsSync(join(DIST, 'sitemap.xml'))
+const whenBuilt = built ? describe : describe.skip
+
+function read(name: string) {
+    return readFileSync(join(DIST, name), 'utf8')
+}
+
+whenBuilt('the sitemap index', () => {
+    it('points at both children and lists no URLs of its own', () => {
+        const xml = read('sitemap.xml')
+        expect(xml).toContain('<sitemapindex')
+        expect(xml).toContain('/sitemap-core.xml')
+        expect(xml).toContain('/sitemap-spm.xml')
+        expect(xml).not.toContain('<url>')
+    })
+
+    it.each(['sitemap.xml', 'sitemap-core.xml', 'sitemap-spm.xml'])(
+        '%s declares the sitemaps.org namespace and starts without a BOM',
+        (name) => {
+            const raw = readFileSync(join(DIST, name))
+            // A BOM makes some validators reject the file outright, and it is
+            // invisible in every editor that would show you the problem.
+            expect(raw[0]).not.toBe(0xef)
+            const xml = raw.toString('utf8')
+            expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true)
+            expect(xml).toContain(NS)
+        }
+    )
+
+    it('splits every submitted URL into exactly one child', () => {
+        const core = read('sitemap-core.xml').match(/<loc>/g) ?? []
+        const spm = read('sitemap-spm.xml').match(/<loc>/g) ?? []
+        expect(core.length).toBeGreaterThan(0)
+        expect(spm.length).toBeGreaterThan(0)
+
+        const locs = (xml: string) => [...xml.matchAll(/<loc>(.*?)<\/loc>/g)].map((m) => m[1])
+        const overlap = locs(read('sitemap-core.xml')).filter((l) =>
+            locs(read('sitemap-spm.xml')).includes(l)
+        )
+        // A URL in two sitemaps is a URL Search Console cannot attribute to
+        // either, which defeats the only reason for splitting them.
+        expect(overlap).toEqual([])
+    })
+
+    it('puts the guides in core, not with the SPM pages', () => {
+        const core = read('sitemap-core.xml')
+        for (const guide of GUIDES) expect(core).toContain(guide.path)
+        expect(read('sitemap-spm.xml')).not.toContain('/guides/')
+    })
+
+    it('never emits priority or changefreq', () => {
+        // Google ignores both, and they invite arguments about numbers that
+        // change nothing.
+        for (const name of ['sitemap-core.xml', 'sitemap-spm.xml']) {
+            expect(read(name)).not.toContain('<priority>')
+            expect(read(name)).not.toContain('<changefreq>')
+        }
+    })
+
+    it('claims lastmod only where a real date exists', () => {
+        // The SPM pages come from the questions table, which has created_at
+        // and no updated_at — editing a question through the admin would
+        // never move the date. A lastmod that lies teaches Google to ignore
+        // the field site-wide, so those pages carry none.
+        expect(read('sitemap-spm.xml')).not.toContain('<lastmod>')
+
+        const dated = [...read('sitemap-core.xml').matchAll(/<lastmod>(.*?)<\/lastmod>/g)]
+        expect(dated).toHaveLength(GUIDES.length)
+        for (const [, value] of dated) expect(value).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    })
+})
+
+describe('guide dates are maintained, not decorative', () => {
+    it.each(GUIDES.map((g) => [g.path, g] as const))(
+        '%s was updated no earlier than its content was last edited',
+        (_path, guide) => {
+            // The whole lastmod policy rests on an author remembering to move
+            // this date when they revise the facts. This is what notices when
+            // they do not: git knows when the file actually changed.
+            const file = GUIDE_FILES[guide.path]
+            expect(file, `no content file mapped for ${guide.path}`).toBeDefined()
+
+            let committed: string
+            try {
+                committed = execFileSync(
+                    'git',
+                    ['log', '-1', '--format=%cs', '--', file],
+                    { cwd: ROOT, encoding: 'utf8' }
+                ).trim()
+            } catch {
+                return // no git available (e.g. inside the built image)
+            }
+            if (committed === '') return // not yet committed
+
+            expect(
+                guide.updatedAt >= committed,
+                `${file} was last committed ${committed} but the guide says it ` +
+                    `was updated ${guide.updatedAt}. Move updatedAt when you ` +
+                    `change the content, or the sitemap tells Google a date ` +
+                    `that is not true.`
+            ).toBe(true)
+        }
+    )
+})
+
+const GUIDE_FILES: Record<string, string> = {
+    '/guides/esat-practice-tests': 'src/content/esatPracticeGuide.mjs',
+    '/guides/esat-past-papers': 'src/content/esatPastPapers.mjs',
+    '/guides/tmua-practice-tests': 'src/content/tmuaPracticeGuide.mjs',
+}


### PR DESCRIPTION
**Task 1 / PR 3 in the approved order.**

`/sitemap.xml` becomes an index pointing at two children:

| Sitemap | URLs |
|---|---|
| `sitemap-core.xml` | 12 — core pages + the three guides |
| `sitemap-spm.xml` | 76 — subject hubs and topic pages |

Same 88 URLs submitted as the flat file, split so they can be reported on separately.

### On the reason for doing it
As I flagged in the plan: Google does **not** work through a sitemap in order, so new pages were never queueing behind the SPM ones. What the split actually buys is a **per-sitemap indexed count in Search Console** — turning "11 of 88 indexed" into a statement about *which group* is going uncrawled. One flat file can't answer that, and it's the question worth answering.

### lastmod: guides only, deliberately
Emitted for the three guides, which carry a date their author maintains. **Omitted everywhere else**, including all 76 SPM pages — they're built from the `questions` table, which has `created_at` and no `updated_at`, so editing a question through the admin would never move the date. A `lastmod` that lies teaches Google to disregard the field site-wide, not just for that page.

No `priority`, no `changefreq`.

### The date guard earned its place immediately
A hand-maintained date is only worth submitting if someone actually maintains it, so a test compares each guide's `updatedAt` against the last commit touching its content file. It failed on the first run — the two existing guides had been edited that morning while their date still said the 1st.

That also settled a question I'd been sloppy about. I'd documented `updatedAt` as "when the facts were last checked", but `lastmod` is defined as when the *page* was modified — and those pages had visibly changed by gaining a byline. Both now say 2026-08-11, which is true.

### Verified through `serve`, as production runs it
```
/sitemap.xml       200  application/xml   (index, no <url> entries)
/sitemap-core.xml  200  application/xml   12 urls
/sitemap-spm.xml   200  application/xml   76 urls
```
All three well-formed per `xmllint`, no BOM, correct sitemaps.org 0.9 namespace, children resolve from the index, and `robots.txt` still points at `/sitemap.xml` — which is now the index, so no change needed there.

399 tests pass, 11 new — including one that fails if a URL ever appears in both children, since a URL Search Console can't attribute to either defeats the point of splitting.

### After this deploys
Re-submit `sitemap.xml` in Search Console. Google will pick up the two children from the index, and the per-sitemap counts are the thing to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)