### PR TITLE
Tighten the ESAT guides

### DIFF
--- a/src/content/esatBiology.mjs
+++ b/src/content/esatBiology.mjs
@@ -23,7 +23,7 @@ export const GUIDE = {
     ctaPath: '/diagnostics/esat',
     ctaLabel: 'Sit a free Biology paper →',
     h1: 'ESAT Biology questions',
-    standfirst: 'ESAT Biology surprises people by being quantitative. It is not the essay-and-recall paper A-level Biology trains you for: expect ratios, probabilities and data interpretation, at the same 90 seconds a question as every other module.',
+    standfirst: 'ESAT Biology is more quantitative than candidates expect. Not the essay-and-recall paper A-level trains you for: ratios, probabilities and data, at 90 seconds a question.',
     publishedAt: '2026-08-11',
     updatedAt: '2026-08-11',
     sections: [
@@ -31,34 +31,31 @@ export const GUIDE = {
             id: 'what-it-covers',
             h2: 'What Biology covers',
             paras: [
-                'ESAT Biology covers the standard ground — cells and cell transport, biological molecules and enzymes, genetics and inheritance, physiology including gas exchange and circulation, and ecology.',
-                'What differs from A-level habits is the form. Questions tend to give you numbers or a described scenario and ask for a deduction, rather than asking you to reproduce a process.',
-                'The official content specification is the authority on scope, and is revised between cycles.',
+                'The standard ground — cells and transport, biological molecules and enzymes, genetics and inheritance, physiology including gas exchange and circulation, and ecology.',
+                'What differs from A-level habits is the form: questions give you numbers or a scenario and ask for a deduction, rather than asking you to reproduce a process. The official content specification sets the scope.',
             ],
         },
         {
             id: 'where-marks-go',
             h2: 'Where the marks actually go',
             paras: [
-                'The most common loss is treating a genetics question as a diagram exercise. A full Punnett square is often unnecessary: the ratio is usually all you need, and it is faster.',
-                'Next is arithmetic done in the wrong order — probabilities multiplied when they should be added, or a proportion applied to the wrong total.',
-                'And finally, answers that describe rather than deduce. A question giving figures wants a figure back.',
+                'The commonest loss is treating genetics as a diagram exercise. A full Punnett square is usually unnecessary — the ratio is all you need, and it is faster.',
+                'Then arithmetic in the wrong order: probabilities multiplied when they should be added, or a proportion applied to the wrong total. And answers that describe when the question gave you figures and wanted one back.',
             ],
         },
         {
             id: 'worked-examples',
             h2: 'Biology questions, worked through',
             paras: [
-                'These are written to the style of the test rather than copied from an official paper. Each is the kind of multi-step, calculator-free question the ESAT favours: the arithmetic stays clean, and the difficulty is in choosing the route.',
-                'Give each one 90 seconds before reading the working.',
+                'Written in the style of the test, not copied from an official paper. Give each one 90 seconds before reading the working.',
             ],
         },
         {
             id: 'after-the-papers',
             h2: 'Once the official papers run out',
             paras: [
-                'There is not much official ESAT material and it goes quickly. At that point a score out of 27 stops being useful — it tells you the result of the problem, not its cause.',
-                'Our Biology diagnostics are full timed papers in the real format, and the report afterwards names the skills that went wrong rather than handing you a number. Set A is free to sit.',
+                'There is not much official material and it goes quickly. After that, a score out of 27 tells you the result of the problem, not its cause.',
+                'Our Biology diagnostics are full timed papers in the real format, and the report names the skills that went wrong rather than handing you a number. Set A is free.',
             ],
         },
     ],
@@ -68,31 +65,31 @@ export const GUIDE = {
             module: 'Biology',
             question: 'Two plants heterozygous for both of two independently assorting genes (PpTt) are crossed. Of 320 offspring, how many would be expected to show both recessive phenotypes?',
             steps: [
-                'Each gene segregates independently, so treat them separately.',
-                'For one gene, Pp × Pp gives a ¼ chance of the recessive homozygote pp; the same is true of Tt × Tt for tt.',
-                'Independent assortment means the probabilities multiply: ¼ × ¼ = 1/16.',
-                'Expected number = 320 × 1/16.',
+                'The genes assort independently, so treat them separately.',
+                'Pp × Pp gives a ¼ chance of pp; Tt × Tt gives a ¼ chance of tt.',
+                'Independent means the probabilities multiply: ¼ × ¼ = 1/16.',
+                'Expected number = 320 ÷ 16.',
             ],
             answer: '20 offspring',
-            takeaway: 'Multiplying the two single-gene probabilities gets there in one line; a 16-cell Punnett square gets the same answer and costs a minute you do not have. The word to look for is "independently".',
+            takeaway: 'Multiplying two single-gene probabilities takes one line; a 16-cell Punnett square gives the same answer and costs a minute. The word to look for is "independently".',
         },
         {
             id: 'surface-area-volume',
             module: 'Biology',
-            question: 'A cube-shaped organism has sides of 2 mm. Calculate its surface area to volume ratio, and state what happens to that ratio if the sides double to 4 mm.',
+            question: 'A cube-shaped organism has sides of 2 mm. Calculate its surface area to volume ratio, and state what happens if the sides double to 4 mm.',
             steps: [
-                'Surface area = 6 × 2² = 24 mm²; volume = 2³ = 8 mm³, so the ratio is 24 ÷ 8 = 3 mm⁻¹.',
-                'With sides of 4 mm: surface area = 6 × 4² = 96 mm²; volume = 4³ = 64 mm³.',
-                'The ratio becomes 96 ÷ 64 = 1.5 mm⁻¹.',
+                'Surface area = 6 × 2² = 24 mm²; volume = 2³ = 8 mm³, so the ratio is 3 mm⁻¹.',
+                'With 4 mm sides: area = 96 mm², volume = 64 mm³.',
+                'The ratio becomes 1.5 mm⁻¹.',
             ],
             answer: '3 mm⁻¹, halving to 1.5 mm⁻¹ when the sides double',
-            takeaway: 'Area scales with the square and volume with the cube, so the ratio falls as size rises — which is the whole reason large organisms need specialised exchange surfaces. Recognising it as a scaling question means you can predict the direction before calculating.',
+            takeaway: 'Area scales with the square and volume with the cube, so the ratio falls as size rises — which is why large organisms need specialised exchange surfaces.',
         },
     ],
     faq: [
         {
             q: 'How long is the module, and is there negative marking?',
-            a: '27 questions in 40 minutes, no calculator, no negative marking — the same as every other ESAT module. That is under 90 seconds a question, which is why untimed practice tells you so little, and why leaving anything blank is a straightforward loss.',
+            a: '27 questions in 40 minutes, no calculator, no negative marking. That is under 90 seconds a question, so never leave one blank.',
             link: {
                 label: 'How ESAT results are reported (UAT-UK)',
                 url: 'https://esat-tmua.ac.uk/about-the-tests/esat-test/',
@@ -100,15 +97,15 @@ export const GUIDE = {
         },
         {
             q: 'Is ESAT Biology just A-level Biology?',
-            a: 'The content overlaps, but the form does not. Expect ratios, probabilities and data interpretation under time pressure rather than extended written answers, and practise accordingly.',
+            a: 'The content overlaps; the form does not. Expect ratios, probabilities and data interpretation under time pressure rather than extended written answers.',
         },
         {
             q: 'How much maths is in ESAT Biology?',
-            a: 'More than candidates expect. Probability in genetics, ratios and percentages in physiology and ecology, all calculator-free — being slow at the arithmetic costs Biology marks directly.',
+            a: 'More than candidates expect — probability in genetics, ratios and percentages elsewhere, all calculator-free. Slow arithmetic costs Biology marks directly.',
         },
         {
             q: 'Where is the official list of topics?',
-            a: 'In the ESAT content specification published by UAT-UK. It is the authority on what can be assessed, it is revised between cycles, and it should be what you check against — not a topic list on a prep site, this one included.',
+            a: 'In the ESAT content specification from UAT-UK. It is revised between cycles, so check it rather than any prep site — this one included.',
             link: {
                 label: 'ESAT content specification (UAT-UK)',
                 url: 'https://esat-tmua.ac.uk/prepare/',

--- a/src/content/esatChemistry.mjs
+++ b/src/content/esatChemistry.mjs
@@ -23,7 +23,7 @@ export const GUIDE = {
     ctaPath: '/diagnostics/esat',
     ctaLabel: 'Sit a free Chemistry paper →',
     h1: 'ESAT Chemistry questions',
-    standfirst: 'ESAT Chemistry is a calculation paper more than a recall paper. Most questions come down to moles and a balanced equation, done quickly and without a calculator — which makes the balancing, not the chemistry, the step that decides the mark.',
+    standfirst: 'ESAT Chemistry is a calculation paper more than a recall paper. Most questions come down to moles and a balanced equation — which makes the balancing, not the chemistry, the step that decides the mark.',
     publishedAt: '2026-08-11',
     updatedAt: '2026-08-11',
     sections: [
@@ -31,34 +31,31 @@ export const GUIDE = {
             id: 'what-it-covers',
             h2: 'What Chemistry covers',
             paras: [
-                'ESAT Chemistry spans the familiar A-level ground: atomic structure and bonding, the mole and reacting quantities, energetics, rates and equilibria, redox, the periodic table, and introductory organic chemistry.',
-                'The emphasis is applied. A question will usually give you masses, volumes or concentrations and expect a quantitative answer, rather than asking you to describe a mechanism in words.',
-                'Scope is set by the official content specification, which is revised between cycles.',
+                'The familiar A-level ground: atomic structure and bonding, the mole and reacting quantities, energetics, rates and equilibria, redox, the periodic table, and introductory organic chemistry.',
+                'The emphasis is quantitative. Expect masses, volumes or concentrations and a number back, rather than a mechanism described in words. The official content specification sets the scope.',
             ],
         },
         {
             id: 'where-marks-go',
             h2: 'Where the marks actually go',
             paras: [
-                'The single biggest cost is an unbalanced or half-remembered equation. Every mole calculation downstream inherits the error, and the arithmetic can be flawless while the answer is wrong.',
-                'Close behind is assuming a one-to-one ratio in a titration when the acid is diprotic — the numbers still work out neatly, which is what makes it dangerous.',
-                'Then units: cm³ against dm³, and grams against moles. None of it is difficult, and all of it is easy at speed.',
+                'The biggest cost is an unbalanced equation. Every mole calculation downstream inherits the error, and the arithmetic can be flawless while the answer is wrong.',
+                'Close behind: assuming a 1:1 ratio in a titration when the acid is diprotic — the numbers still come out neatly, which is what makes it dangerous. Then units, cm³ against dm³.',
             ],
         },
         {
             id: 'worked-examples',
             h2: 'Chemistry questions, worked through',
             paras: [
-                'These are written to the style of the test rather than copied from an official paper. Each is the kind of multi-step, calculator-free question the ESAT favours: the arithmetic stays clean, and the difficulty is in choosing the route.',
-                'Give each one 90 seconds before reading the working.',
+                'Written in the style of the test, not copied from an official paper. Give each one 90 seconds before reading the working.',
             ],
         },
         {
             id: 'after-the-papers',
             h2: 'Once the official papers run out',
             paras: [
-                'There is not much official ESAT material and it goes quickly. At that point a score out of 27 stops being useful — it tells you the result of the problem, not its cause.',
-                'Our Chemistry diagnostics are full timed papers in the real format, and the report afterwards names the skills that went wrong rather than handing you a number. Set A is free to sit.',
+                'There is not much official material and it goes quickly. After that, a score out of 27 tells you the result of the problem, not its cause.',
+                'Our Chemistry diagnostics are full timed papers in the real format, and the report names the skills that went wrong rather than handing you a number. Set A is free.',
             ],
         },
     ],
@@ -68,31 +65,31 @@ export const GUIDE = {
             module: 'Chemistry',
             question: '25.0 cm³ of 0.100 mol dm⁻³ sodium hydroxide is exactly neutralised by 20.0 cm³ of sulfuric acid. Calculate the concentration of the acid.',
             steps: [
-                'Moles of NaOH = 0.0250 dm³ × 0.100 mol dm⁻³ = 2.50 × 10⁻³ mol.',
-                'The equation is H₂SO₄ + 2NaOH → Na₂SO₄ + 2H₂O, so the acid reacts in a 1:2 ratio with the hydroxide.',
+                'Moles of NaOH = 0.0250 × 0.100 = 2.50 × 10⁻³ mol.',
+                'H₂SO₄ + 2NaOH → Na₂SO₄ + 2H₂O, so the acid reacts 1:2 with the hydroxide.',
                 'Moles of H₂SO₄ = 2.50 × 10⁻³ ÷ 2 = 1.25 × 10⁻³ mol.',
-                'Concentration = 1.25 × 10⁻³ mol ÷ 0.0200 dm³.',
+                'Concentration = 1.25 × 10⁻³ ÷ 0.0200.',
             ],
             answer: '0.0625 mol dm⁻³',
-            takeaway: 'Sulfuric acid is diprotic, and assuming 1:1 gives 0.125 — exactly double, and a perfectly reasonable-looking number. Writing the balanced equation before touching the arithmetic is what stops it.',
+            takeaway: 'Sulfuric acid is diprotic; assuming 1:1 gives 0.125 — exactly double, and a perfectly reasonable-looking number. Write the equation before the arithmetic.',
         },
         {
             id: 'combustion-volume',
             module: 'Chemistry',
-            question: 'What volume of oxygen, measured at room temperature and pressure, is needed to burn 0.20 mol of propane completely? (Molar gas volume at RTP = 24 dm³ mol⁻¹)',
+            question: 'What volume of oxygen at room temperature and pressure is needed to burn 0.20 mol of propane completely? (Molar gas volume at RTP = 24 dm³ mol⁻¹)',
             steps: [
-                'Balance the combustion: C₃H₈ + 5O₂ → 3CO₂ + 4H₂O.',
-                'So each mole of propane needs 5 moles of oxygen: 0.20 × 5 = 1.0 mol of O₂.',
-                'Volume = 1.0 mol × 24 dm³ mol⁻¹.',
+                'Balance it: C₃H₈ + 5O₂ → 3CO₂ + 4H₂O.',
+                'Each mole of propane needs 5 of oxygen: 0.20 × 5 = 1.0 mol.',
+                'Volume = 1.0 × 24.',
             ],
             answer: '24 dm³',
-            takeaway: 'The whole question is the 5. Balancing hydrocarbon combustion is mechanical — carbons, then hydrogens, then oxygens last — and getting it wrong makes every later step irrelevant however carefully you do it.',
+            takeaway: 'The whole question is the 5. Balance carbons, then hydrogens, then oxygens last — get it wrong and every later step is irrelevant.',
         },
     ],
     faq: [
         {
             q: 'How long is the module, and is there negative marking?',
-            a: '27 questions in 40 minutes, no calculator, no negative marking — the same as every other ESAT module. That is under 90 seconds a question, which is why untimed practice tells you so little, and why leaving anything blank is a straightforward loss.',
+            a: '27 questions in 40 minutes, no calculator, no negative marking. That is under 90 seconds a question, so never leave one blank.',
             link: {
                 label: 'How ESAT results are reported (UAT-UK)',
                 url: 'https://esat-tmua.ac.uk/about-the-tests/esat-test/',
@@ -100,15 +97,15 @@ export const GUIDE = {
         },
         {
             q: 'Is a periodic table provided in the ESAT?',
-            a: 'Check the official preparation material before the day rather than relying on what worked at A-level, and practise as though relative atomic masses need to be recognised quickly either way.',
+            a: 'Check the official preparation material rather than assuming what worked at A-level, and practise as though relative atomic masses need to be recognised quickly.',
         },
         {
             q: 'How much organic chemistry is in ESAT Chemistry?',
-            a: 'Introductory, and applied rather than mechanistic. Expect to use formulae, reacting quantities and simple reaction types rather than to draw extended mechanisms — but confirm the scope in the content specification.',
+            a: 'Introductory and applied rather than mechanistic — formulae, reacting quantities and simple reaction types. Confirm the scope in the content specification.',
         },
         {
             q: 'Where is the official list of topics?',
-            a: 'In the ESAT content specification published by UAT-UK. It is the authority on what can be assessed, it is revised between cycles, and it should be what you check against — not a topic list on a prep site, this one included.',
+            a: 'In the ESAT content specification from UAT-UK. It is revised between cycles, so check it rather than any prep site — this one included.',
             link: {
                 label: 'ESAT content specification (UAT-UK)',
                 url: 'https://esat-tmua.ac.uk/prepare/',

--- a/src/content/esatMaths1.mjs
+++ b/src/content/esatMaths1.mjs
@@ -23,7 +23,7 @@ export const GUIDE = {
     ctaPath: '/diagnostics/esat',
     ctaLabel: 'Sit a free Mathematics 1 paper →',
     h1: 'ESAT Mathematics 1 questions',
-    standfirst: 'Mathematics 1 is the one module every ESAT candidate sits, whatever course they are applying for, and it is the foundation the science modules lean on. It is also where speed matters most: the content is familiar, so the marks go to whoever finds the short route first.',
+    standfirst: 'Every ESAT candidate sits Mathematics 1, whatever course they are applying for. The content is familiar A-level pure maths, so the marks go to whoever finds the short route first.',
     publishedAt: '2026-08-11',
     updatedAt: '2026-08-11',
     sections: [
@@ -31,34 +31,31 @@ export const GUIDE = {
             id: 'what-it-covers',
             h2: 'What Mathematics 1 covers',
             paras: [
-                'Mathematics 1 covers the core pure mathematics of an A-level first year — algebra and functions, sequences and series, coordinate geometry, trigonometry, logarithms and exponentials, differentiation and integration of straightforward functions, and elementary probability and statistics.',
-                'Because every candidate takes it, it is the module with the least room to specialise. There is no section you can safely be weak at.',
-                'The definitive list is the official content specification, which is revised between cycles — check anything you are unsure about there rather than against a topic list on a prep site, this one included.',
+                'Core pure mathematics from the first year of A-level: algebra and functions, sequences and series, coordinate geometry, trigonometry, logarithms and exponentials, straightforward differentiation and integration, and elementary probability.',
+                'Every candidate takes it, so there is no section you can safely be weak at. The official content specification is the authority on scope and is revised between cycles.',
             ],
         },
         {
             id: 'where-marks-go',
             h2: 'Where the marks actually go',
             paras: [
-                'Almost nothing here is conceptually hard for a candidate who has done the A-level content. What separates scores is whether you spot the efficient route inside 90 seconds.',
-                'The recurring losses are ordinary: domain restrictions dropped after taking logarithms, a discriminant condition solved the long way by substitution, sign errors in a rushed rearrangement, and geometric series treated as convergent without checking the common ratio.',
-                'None of those are gaps in knowledge. They are what happens when a method is applied on autopilot, which is exactly what time pressure produces.',
+                'Little of this is conceptually hard. What separates scores is spotting the efficient route inside 90 seconds.',
+                'The recurring losses are ordinary: domains dropped after taking logarithms, discriminant conditions solved the long way, sign errors in a rushed rearrangement, geometric series assumed to converge. All habits under time pressure, not gaps in knowledge.',
             ],
         },
         {
             id: 'worked-examples',
             h2: 'Mathematics 1 questions, worked through',
             paras: [
-                'These are written to the style of the test rather than copied from an official paper. Each is the kind of multi-step, calculator-free question the ESAT favours: the arithmetic stays clean, and the difficulty is in choosing the route.',
-                'Give each one 90 seconds before reading the working.',
+                'Written in the style of the test, not copied from an official paper. Give each one 90 seconds before reading the working.',
             ],
         },
         {
             id: 'after-the-papers',
             h2: 'Once the official papers run out',
             paras: [
-                'There is not much official ESAT material and it goes quickly. At that point a score out of 27 stops being useful — it tells you the result of the problem, not its cause.',
-                'Our Mathematics 1 diagnostics are full timed papers in the real format, and the report afterwards names the skills that went wrong rather than handing you a number. Set A is free to sit.',
+                'There is not much official material and it goes quickly. After that, a score out of 27 tells you the result of the problem, not its cause.',
+                'Our Mathematics 1 diagnostics are full timed papers in the real format, and the report names the skills that went wrong rather than handing you a number. Set A is free.',
             ],
         },
     ],
@@ -71,28 +68,28 @@ export const GUIDE = {
                 'Combine the logarithms: log₂(x(x − 2)) = 3.',
                 'So x(x − 2) = 2³ = 8, giving x² − 2x − 8 = 0.',
                 'Factorise: (x − 4)(x + 2) = 0, so x = 4 or x = −2.',
-                'Check both against the domain: log₂(−2) is undefined, so x = −2 is not a solution.',
+                'Check the domain: log₂(−2) is undefined, so x = −2 is not a solution.',
             ],
             answer: 'x = 4',
-            takeaway: 'Combining logarithms quietly widens the domain, so the algebra hands back a root the original equation never had. Checking each answer against the original expression is the whole difference between full marks and half.',
+            takeaway: 'Combining logarithms widens the domain, so the algebra hands back a root the original equation never had.',
         },
         {
             id: 'divergent-series',
             module: 'Mathematics 1',
             question: 'The first three terms of a geometric series are 8, 12 and 18. Find the sum to infinity, or explain why it does not exist.',
             steps: [
-                'Find the common ratio: r = 12 ÷ 8 = 1.5, and 18 ÷ 12 = 1.5 confirms it.',
+                'Common ratio: r = 12 ÷ 8 = 1.5, confirmed by 18 ÷ 12 = 1.5.',
                 'A sum to infinity exists only when |r| < 1.',
-                'Here |r| = 1.5, so the terms grow without limit and the series diverges.',
+                'Here |r| = 1.5, so the terms grow without limit.',
             ],
             answer: 'It does not exist — the series diverges because |r| = 1.5 ≥ 1',
-            takeaway: 'Applying a ÷ (1 − r) regardless gives 8 ÷ (−0.5) = −16: a negative total for a series of positive terms. An answer that cannot be true is the signal the formula did not apply.',
+            takeaway: 'Using a ÷ (1 − r) anyway gives −16: a negative total for positive terms, and an answer that cannot be true is the signal the formula did not apply.',
         },
     ],
     faq: [
         {
             q: 'How long is the module, and is there negative marking?',
-            a: '27 questions in 40 minutes, no calculator, no negative marking — the same as every other ESAT module. That is under 90 seconds a question, which is why untimed practice tells you so little, and why leaving anything blank is a straightforward loss.',
+            a: '27 questions in 40 minutes, no calculator, no negative marking. That is under 90 seconds a question, so never leave one blank.',
             link: {
                 label: 'How ESAT results are reported (UAT-UK)',
                 url: 'https://esat-tmua.ac.uk/about-the-tests/esat-test/',
@@ -100,15 +97,15 @@ export const GUIDE = {
         },
         {
             q: 'Is ESAT Maths 1 compulsory?',
-            a: 'Yes — every candidate sits Mathematics 1 whatever course they are applying for. Which further modules you take depends on the course and university, so check the requirements for each of your choices on their own admissions pages.',
+            a: 'Yes, for every candidate. Which further modules you need depends on the course and university, so check each of your choices on their own admissions pages.',
         },
         {
             q: 'Is ESAT Maths 1 harder than A-level maths?',
-            a: 'The content is not harder; the constraint is. Questions are multi-step and calculator-free at under 90 seconds each, so what is tested is whether you can find the efficient route, not whether you could reach the answer eventually.',
+            a: 'The content is not harder; the constraint is. Multi-step and calculator-free at under 90 seconds a question, it tests whether you find the efficient route, not whether you could get there eventually.',
         },
         {
             q: 'Where is the official list of topics?',
-            a: 'In the ESAT content specification published by UAT-UK. It is the authority on what can be assessed, it is revised between cycles, and it should be what you check against — not a topic list on a prep site, this one included.',
+            a: 'In the ESAT content specification from UAT-UK. It is revised between cycles, so check it rather than any prep site — this one included.',
             link: {
                 label: 'ESAT content specification (UAT-UK)',
                 url: 'https://esat-tmua.ac.uk/prepare/',

--- a/src/content/esatMaths2.mjs
+++ b/src/content/esatMaths2.mjs
@@ -23,7 +23,7 @@ export const GUIDE = {
     ctaPath: '/diagnostics/esat',
     ctaLabel: 'Sit a free Mathematics 2 paper →',
     h1: 'ESAT Mathematics 2 questions',
-    standfirst: 'Mathematics 2 goes past the compulsory module into the material that separates a strong mathematician from a competent one: further calculus, logic and proof. It is the module most often required by the courses with the highest competition.',
+    standfirst: 'Mathematics 2 goes past the compulsory module into further calculus, logic and proof. It is the module most often required by the courses with the highest competition.',
     publishedAt: '2026-08-11',
     updatedAt: '2026-08-11',
     sections: [
@@ -31,34 +31,31 @@ export const GUIDE = {
             id: 'what-it-covers',
             h2: 'What Mathematics 2 covers',
             paras: [
-                'Mathematics 2 builds on Mathematics 1 with further pure content — more demanding differentiation and integration, sequences and series pushed further, and, distinctively, questions that ask you to reason about a mathematical statement rather than only compute with it.',
-                'Proof and logical structure are the part candidates are least prepared for, because school mathematics rewards executing a method and this module also rewards justifying one.',
-                'As with every module, the official content specification is the authority on what is examinable, and it changes between cycles.',
+                'Builds on Mathematics 1 with more demanding differentiation and integration, sequences and series pushed further, and — distinctively — questions that ask you to reason about a statement rather than only compute with it.',
+                'Proof is the part candidates are least ready for: school maths rewards executing a method, and this module also rewards justifying one. Scope is set by the official content specification, which changes between cycles.',
             ],
         },
         {
             id: 'where-marks-go',
             h2: 'Where the marks actually go',
             paras: [
-                'Two failure modes dominate. The first is stopping at a stationary point without establishing its nature, because the question said "find" and the mark scheme wanted "and determine".',
-                'The second is proof: writing a demonstration that the statement holds for a few cases and treating that as an argument. A general proof needs a general object — an arbitrary n, not 2, 4 and 6.',
-                'Both are habits rather than gaps, and both are cheap to fix once you have seen them named.',
+                'Two failures dominate. Stopping at a stationary point without establishing its nature, because the question said "find" and the marks were for "and determine".',
+                'And proof by example: showing a statement holds for a few cases and treating that as an argument. A general proof needs a general object — an arbitrary n, not 2, 4 and 6.',
             ],
         },
         {
             id: 'worked-examples',
             h2: 'Mathematics 2 questions, worked through',
             paras: [
-                'These are written to the style of the test rather than copied from an official paper. Each is the kind of multi-step, calculator-free question the ESAT favours: the arithmetic stays clean, and the difficulty is in choosing the route.',
-                'Give each one 90 seconds before reading the working.',
+                'Written in the style of the test, not copied from an official paper. Give each one 90 seconds before reading the working.',
             ],
         },
         {
             id: 'after-the-papers',
             h2: 'Once the official papers run out',
             paras: [
-                'There is not much official ESAT material and it goes quickly. At that point a score out of 27 stops being useful — it tells you the result of the problem, not its cause.',
-                'Our Mathematics 2 diagnostics are full timed papers in the real format, and the report afterwards names the skills that went wrong rather than handing you a number. Set A is free to sit.',
+                'There is not much official material and it goes quickly. After that, a score out of 27 tells you the result of the problem, not its cause.',
+                'Our Mathematics 2 diagnostics are full timed papers in the real format, and the report names the skills that went wrong rather than handing you a number. Set A is free.',
             ],
         },
     ],
@@ -69,31 +66,31 @@ export const GUIDE = {
             question: 'Find the x-coordinates of the stationary points of y = x³ − 6x² + 9x + 1, and determine the nature of each.',
             steps: [
                 'Differentiate: dy/dx = 3x² − 12x + 9.',
-                'Set it to zero: 3(x² − 4x + 3) = 3(x − 1)(x − 3) = 0, so x = 1 and x = 3.',
-                'Differentiate again for the nature: d²y/dx² = 6x − 12.',
-                'At x = 1, d²y/dx² = −6, which is negative, so it is a maximum. At x = 3 it is +6, positive, so a minimum.',
+                'Set to zero: 3(x − 1)(x − 3) = 0, so x = 1 and x = 3.',
+                'Differentiate again: d²y/dx² = 6x − 12.',
+                'At x = 1 it is −6, so a maximum; at x = 3 it is +6, so a minimum.',
             ],
             answer: 'x = 1 is a maximum; x = 3 is a minimum',
-            takeaway: 'The second derivative is one line and answers the half of the question that carries the marks. Stopping at "x = 1 and x = 3" is the most common way to lose half a question you had entirely right.',
+            takeaway: 'The second derivative is one line and carries half the marks — stopping at the x-values is the commonest way to lose a question you had right.',
         },
         {
             id: 'consecutive-even-proof',
             module: 'Mathematics 2',
             question: 'Prove that the product of any two consecutive even integers is divisible by 8.',
             steps: [
-                'Write the integers generally: any two consecutive even integers are 2n and 2n + 2 for some integer n.',
+                'Write them generally: 2n and 2n + 2, for some integer n.',
                 'Their product is 2n × 2(n + 1) = 4n(n + 1).',
-                'n and n + 1 are consecutive integers, so exactly one of them is even; write n(n + 1) = 2k for some integer k.',
-                'Then the product is 4 × 2k = 8k, which is divisible by 8.',
+                'n and n + 1 are consecutive, so one of them is even: write n(n + 1) = 2k.',
+                'The product is then 4 × 2k = 8k.',
             ],
             answer: 'Proved: the product equals 8k for some integer k',
-            takeaway: 'The proof turns on n(n + 1) always being even, which is worth stating rather than assuming. Testing 2 × 4, 4 × 6 and 6 × 8 shows the claim is plausible and proves nothing — a general statement needs a general n.',
+            takeaway: 'It turns on n(n + 1) always being even, which is worth stating. Testing 2 × 4 and 4 × 6 shows the claim is plausible and proves nothing.',
         },
     ],
     faq: [
         {
             q: 'How long is the module, and is there negative marking?',
-            a: '27 questions in 40 minutes, no calculator, no negative marking — the same as every other ESAT module. That is under 90 seconds a question, which is why untimed practice tells you so little, and why leaving anything blank is a straightforward loss.',
+            a: '27 questions in 40 minutes, no calculator, no negative marking. That is under 90 seconds a question, so never leave one blank.',
             link: {
                 label: 'How ESAT results are reported (UAT-UK)',
                 url: 'https://esat-tmua.ac.uk/about-the-tests/esat-test/',
@@ -101,15 +98,15 @@ export const GUIDE = {
         },
         {
             q: 'Do I need ESAT Maths 2?',
-            a: 'It depends on the course and the university, and the requirements differ between them. Check each of your choices on their own admissions pages rather than assuming the modules are the same everywhere.',
+            a: 'It depends on the course and university, and requirements differ between them. Check each of your choices on their own admissions pages.',
         },
         {
             q: 'What is the difference between ESAT Maths 1 and Maths 2?',
-            a: 'Mathematics 1 is the compulsory core — the pure mathematics every candidate is expected to have. Mathematics 2 goes further, into more demanding calculus and into logic and proof, where you are asked to justify a statement rather than only compute with it.',
+            a: 'Maths 1 is the compulsory pure core. Maths 2 goes further, into harder calculus and into logic and proof, where you justify a statement rather than only compute with it.',
         },
         {
             q: 'Where is the official list of topics?',
-            a: 'In the ESAT content specification published by UAT-UK. It is the authority on what can be assessed, it is revised between cycles, and it should be what you check against — not a topic list on a prep site, this one included.',
+            a: 'In the ESAT content specification from UAT-UK. It is revised between cycles, so check it rather than any prep site — this one included.',
             link: {
                 label: 'ESAT content specification (UAT-UK)',
                 url: 'https://esat-tmua.ac.uk/prepare/',

--- a/src/content/esatPastPapers.mjs
+++ b/src/content/esatPastPapers.mjs
@@ -28,7 +28,7 @@ export const GUIDE = {
     ctaLabel: 'Sit a free ESAT paper →',
     h1: 'ESAT past papers and specimen papers',
     standfirst:
-        'There is less official ESAT material than students expect, and it runs out quickly. This page sets out exactly what exists, where to get it, how to get the most from each paper — and what to do next, because the honest answer to "where are the rest of the past papers" is that they do not exist yet.',
+        'There is less official ESAT material than students expect, and it runs out quickly. This page sets out what exists, how to get the most from each paper, and what to do next — because the honest answer to "where are the rest" is that they do not exist yet.',
     publishedAt: '2026-08-11',
     updatedAt: '2026-08-11',
     sections: [
@@ -36,17 +36,17 @@ export const GUIDE = {
             id: 'what-exists',
             h2: 'What official ESAT papers exist',
             paras: [
-                'UAT-UK, the body that runs the test, publishes the material worth starting with: a content specification setting out precisely what can be assessed, an ESAT guide to the underlying maths and science, and specimen and practice tests delivered through Pearson, alongside an archive of past papers.',
-                'Work through those first, and under timed conditions. They are the only material written by the people who write the real test, and no third-party paper — ours included — is a substitute for that.',
-                'The catch is depth. The ESAT replaced the older ENGAA and NSAA only recently, so there is nothing like the twenty-year back catalogue you would have for an A-level subject. Most candidates exhaust the official papers well before the October sitting, and a paper you have already seen cannot tell you anything new about your timing.',
+                'UAT-UK, the body that runs the test, publishes a content specification, an ESAT guide to the underlying maths and science, and specimen and practice tests through Pearson, alongside an archive of past papers.',
+                'Work through those first, under timed conditions. They are the only material written by the people who write the real test.',
+                'The catch is depth. The ESAT replaced the ENGAA and NSAA only recently, so there is no twenty-year back catalogue. Most candidates exhaust the official papers before October, and a paper you have already seen tells you nothing new about your timing.',
             ],
         },
         {
             id: 'papers-vs-questions',
             h2: 'Past papers, specimen papers and sample questions are not the same thing',
             paras: [
-                'The three terms get used interchangeably in forums, and they are worth separating, because they are useful at different points.',
-                'A specimen paper shows the format: how the questions are worded, how long you get, what the answer sheet looks like. A past paper is a test that was actually sat, so it also tells you the real standard. Sample questions are individual items, useful for drilling one topic but useless for practising the thing the ESAT is genuinely hard at, which is finishing.',
+                'The terms get used interchangeably, and they are useful at different points.',
+                'A specimen paper shows the format. A past paper was actually sat, so it also shows the real standard. Sample questions are single items — good for drilling one topic, useless for practising the thing the ESAT is hard at, which is finishing.',
             ],
             table: {
                 caption:
@@ -80,25 +80,24 @@ export const GUIDE = {
             id: 'timing',
             h2: 'The constraint the papers are really testing',
             paras: [
-                'Each ESAT module gives you 27 questions in 40 minutes. That is under 90 seconds per question, with no calculator, on multi-step problems. Almost nobody fails the ESAT because they could not eventually do the questions; they fail because they could not do them at that pace.',
-                'This changes how a past paper should be used. Working slowly through one, checking answers as you go, tells you very little. Sitting it once, timed, with no interruptions, tells you nearly everything — and it is the only way to find out that a question you can solve in four minutes is worth zero to you.',
-                'There is no negative marking, so leaving anything blank is a straightforward loss. If you have not started a question with ten seconds left, answer it anyway.',
+                'Each module is 27 questions in 40 minutes: under 90 seconds each, no calculator, multi-step. Almost nobody fails because they could not eventually do the questions — they fail because they could not do them at that pace.',
+                'So working slowly through a paper, checking as you go, tells you very little. Sitting it once, timed and uninterrupted, tells you nearly everything — including that a question you can solve in four minutes is worth zero to you.',
+                'There is no negative marking. If you have not started a question with ten seconds left, answer it anyway.',
             ],
         },
         {
             id: 'worked-examples',
             h2: 'Three ESAT-style questions, worked through',
             paras: [
-                'These are written to the style of the test rather than copied from an official paper. Each is the kind of multi-step, calculator-free question the ESAT favours: the arithmetic stays clean, and the difficulty is in choosing the route.',
-                'Try each one under 90 seconds before reading the working.',
+                'Written in the style of the test, not copied from an official paper. Try each in under 90 seconds before reading the working.',
             ],
         },
         {
             id: 'after-the-papers',
             h2: 'What to do once the official papers are gone',
             paras: [
-                'At that point the useful question is no longer "what is my score" but "which specific thing costs me marks". A total out of 27 does not answer that; it tells you the result of the problem, not its cause.',
-                'That is the gap our diagnostics are built for. Each is a full timed paper in the real format — 27 questions, 40 minutes — and the report afterwards names the skills that went wrong rather than handing you a number. Set A of every module is free, and you do not need an account to read this page or to see what the questions look like.',
+                'The useful question stops being "what is my score" and becomes "which specific thing costs me marks". A total out of 27 tells you the result of the problem, not its cause.',
+                'That is what our diagnostics are for: a full timed paper in the real format, and a report naming the skills that went wrong. Set A of every module is free.',
             ],
         },
     ],
@@ -116,7 +115,7 @@ export const GUIDE = {
             ],
             answer: 'c = 19/4',
             takeaway:
-                'The word "tangent" is the whole question. Recognising it as "discriminant equals zero" turns a curve-sketching problem into one line of algebra — the substitution is the slow route and there is no time for it.',
+                'The word "tangent" is the whole question: read it as "discriminant equals zero" and a curve-sketching problem becomes one line of algebra.',
         },
         {
             id: 'kinetic-energy-twice',
@@ -131,7 +130,7 @@ export const GUIDE = {
             ],
             answer: '2 seconds',
             takeaway:
-                'Energy is a scalar, so it cannot tell you which direction the ball is moving — that is exactly why there are two answers. Solving for v and stopping at 1 s is the trap.',
+                'Energy is a scalar and cannot tell you direction — which is exactly why there are two answers. Stopping at 1 s is the trap.',
         },
         {
             id: 'combustion-formula',
@@ -145,7 +144,7 @@ export const GUIDE = {
             ],
             answer: 'C₂H₆ (ethane)',
             takeaway:
-                'Dividing by the moles of the compound burnt — not by the smallest number of moles — is what gives the molecular formula directly. Reaching for empirical formula out of habit gives CH₃, which is not a molecule.',
+                'Divide by the moles burnt, not by the smallest number of moles. Reaching for the empirical formula out of habit gives CH₃, which is not a molecule.',
         },
     ],
     faq: [

--- a/src/content/esatPhysics.mjs
+++ b/src/content/esatPhysics.mjs
@@ -23,7 +23,7 @@ export const GUIDE = {
     ctaPath: '/diagnostics/esat',
     ctaLabel: 'Sit a free Physics paper →',
     h1: 'ESAT Physics questions',
-    standfirst: 'ESAT Physics rewards candidates who can pick the right conserved quantity and commit to it in seconds. The content is A-level; the difficulty is that almost every question is two or three steps and there is no calculator to hide behind.',
+    standfirst: 'ESAT Physics rewards picking the right conserved quantity and committing to it. The content is A-level; the difficulty is that every question is two or three steps with no calculator.',
     publishedAt: '2026-08-11',
     updatedAt: '2026-08-11',
     sections: [
@@ -31,34 +31,31 @@ export const GUIDE = {
             id: 'what-it-covers',
             h2: 'What Physics covers',
             paras: [
-                'ESAT Physics draws on the standard A-level areas — mechanics and motion, energy and momentum, electricity and circuits, waves, and materials — applied rather than recalled.',
-                'Questions rarely ask you to state a definition. They give you a situation and expect you to notice which principle makes it tractable, which is a different skill from knowing the principle.',
-                'The official content specification is the authority on scope, and it is revised between cycles.',
+                'The standard A-level areas — mechanics and motion, energy and momentum, electricity and circuits, waves, and materials — applied rather than recalled.',
+                'Questions rarely ask for a definition. They give a situation and expect you to notice which principle makes it tractable, which is a different skill from knowing the principle. The official content specification sets the scope.',
             ],
         },
         {
             id: 'where-marks-go',
             h2: 'Where the marks actually go',
             paras: [
-                'The characteristic loss is choosing a valid method that takes four minutes when a one-line method existed. Conservation of energy or momentum will usually beat working through the kinematics.',
-                'The other is dropping a case. Speed does not tell you direction, a square root has two signs, and a quantity that is equal at two moments usually is equal at two moments.',
-                'Unit slips come third, and are mostly a symptom of rushing rather than of not knowing.',
+                'The characteristic loss is a valid method that takes four minutes when a one-line method existed. Conservation of energy or momentum usually beats working through the kinematics.',
+                'The other is dropping a case: speed does not tell you direction, a square root has two signs, and a quantity equal at two moments usually is equal at two moments.',
             ],
         },
         {
             id: 'worked-examples',
             h2: 'Physics questions, worked through',
             paras: [
-                'These are written to the style of the test rather than copied from an official paper. Each is the kind of multi-step, calculator-free question the ESAT favours: the arithmetic stays clean, and the difficulty is in choosing the route.',
-                'Give each one 90 seconds before reading the working.',
+                'Written in the style of the test, not copied from an official paper. Give each one 90 seconds before reading the working.',
             ],
         },
         {
             id: 'after-the-papers',
             h2: 'Once the official papers run out',
             paras: [
-                'There is not much official ESAT material and it goes quickly. At that point a score out of 27 stops being useful — it tells you the result of the problem, not its cause.',
-                'Our Physics diagnostics are full timed papers in the real format, and the report afterwards names the skills that went wrong rather than handing you a number. Set A is free to sit.',
+                'There is not much official material and it goes quickly. After that, a score out of 27 tells you the result of the problem, not its cause.',
+                'Our Physics diagnostics are full timed papers in the real format, and the report names the skills that went wrong rather than handing you a number. Set A is free.',
             ],
         },
     ],
@@ -66,33 +63,33 @@ export const GUIDE = {
         {
             id: 'parallel-resistors',
             module: 'Physics',
-            question: 'A 6.0 Ω resistor and a 3.0 Ω resistor are connected in parallel across a 12 V supply of negligible internal resistance. Find the total current drawn from the supply.',
+            question: 'A 6.0 Ω resistor and a 3.0 Ω resistor are connected in parallel across a 12 V supply of negligible internal resistance. Find the total current drawn.',
             steps: [
-                'For resistors in parallel, 1/R = 1/6 + 1/3 = 1/6 + 2/6 = 3/6.',
+                'In parallel, 1/R = 1/6 + 1/3 = 3/6.',
                 'So R = 2.0 Ω — smaller than either resistor, as a parallel combination always is.',
                 'Then I = V/R = 12 ÷ 2.0.',
             ],
             answer: '6.0 A',
-            takeaway: 'The check that catches the common error is the sanity one: a parallel combination is always less resistive than its smallest branch. Adding to get 9 Ω gives 1.3 A, and the answer being larger than either branch alone should look wrong immediately.',
+            takeaway: 'A parallel combination is always less resistive than its smallest branch, so adding to get 9 Ω should look wrong before you finish the arithmetic.',
         },
         {
             id: 'inelastic-collision',
             module: 'Physics',
-            question: 'A 2.0 kg trolley moving at 3.0 m s⁻¹ collides with a stationary 4.0 kg trolley, and the two move off together. Find their common speed and the kinetic energy lost in the collision.',
+            question: 'A 2.0 kg trolley moving at 3.0 m s⁻¹ collides with a stationary 4.0 kg trolley, and the two move off together. Find their common speed and the kinetic energy lost.',
             steps: [
-                'Momentum is conserved: 2.0 × 3.0 = 6.0 kg m s⁻¹ before, and (2.0 + 4.0)v after.',
-                'So v = 6.0 ÷ 6.0 = 1.0 m s⁻¹.',
+                'Momentum is conserved: 2.0 × 3.0 = 6.0, and (2.0 + 4.0)v after.',
+                'So v = 1.0 m s⁻¹.',
                 'Kinetic energy before = ½ × 2.0 × 3.0² = 9.0 J.',
-                'Kinetic energy after = ½ × 6.0 × 1.0² = 3.0 J, so 6.0 J was lost.',
+                'After = ½ × 6.0 × 1.0² = 3.0 J, so 6.0 J was lost.',
             ],
             answer: '1.0 m s⁻¹, with 6.0 J of kinetic energy lost',
-            takeaway: 'Momentum is conserved here and kinetic energy is not — that is what "move off together" tells you. Trying to conserve both gives an inconsistent pair of equations, and the time is lost before you work out why.',
+            takeaway: '"Move off together" tells you momentum is conserved and kinetic energy is not — trying to conserve both gives inconsistent equations.',
         },
     ],
     faq: [
         {
             q: 'How long is the module, and is there negative marking?',
-            a: '27 questions in 40 minutes, no calculator, no negative marking — the same as every other ESAT module. That is under 90 seconds a question, which is why untimed practice tells you so little, and why leaving anything blank is a straightforward loss.',
+            a: '27 questions in 40 minutes, no calculator, no negative marking. That is under 90 seconds a question, so never leave one blank.',
             link: {
                 label: 'How ESAT results are reported (UAT-UK)',
                 url: 'https://esat-tmua.ac.uk/about-the-tests/esat-test/',
@@ -100,15 +97,15 @@ export const GUIDE = {
         },
         {
             q: 'Is a formula sheet given in ESAT Physics?',
-            a: 'Do not plan around one. Work on the assumption that the standard relationships need to be at your fingertips, and confirm what is provided against the official preparation material before the day.',
+            a: 'Do not plan around one. Assume the standard relationships need to be at your fingertips, and confirm what is provided in the official preparation material.',
         },
         {
             q: 'How much maths is in ESAT Physics?',
-            a: 'Enough that Mathematics 1 fluency matters — rearranging, ratios, powers and roots, all without a calculator. Candidates who are slow at the algebra lose Physics marks for reasons that have nothing to do with physics.',
+            a: 'Enough that Maths 1 fluency matters — rearranging, ratios, powers and roots, all without a calculator. Slow algebra costs Physics marks.',
         },
         {
             q: 'Where is the official list of topics?',
-            a: 'In the ESAT content specification published by UAT-UK. It is the authority on what can be assessed, it is revised between cycles, and it should be what you check against — not a topic list on a prep site, this one included.',
+            a: 'In the ESAT content specification from UAT-UK. It is revised between cycles, so check it rather than any prep site — this one included.',
             link: {
                 label: 'ESAT content specification (UAT-UK)',
                 url: 'https://esat-tmua.ac.uk/prepare/',


### PR DESCRIPTION
The prose was wordy — saying a thing, then explaining that it had said it.

### About a quarter shorter
| Page | Before | After | |
|---|---|---|---|
| `esat-past-papers` | 1334 | 1116 | −16% |
| `esat-maths-1` | 742 | 524 | −29% |
| `esat-maths-2` | 777 | 563 | −28% |
| `esat-physics` | 731 | 532 | −27% |
| `esat-chemistry` | 691 | 518 | −25% |
| `esat-biology` | 693 | 526 | −24% |
| **Total** | **4968** | **3779** | **−24%** |

### What was cut, and what wasn't
Cut: third paragraphs that restated the first two, and second sentences of takeaways that made the point again in different words.

**Not cut** — verified rather than assumed:
- Every worked example keeps its question, **all** of its steps and its answer (3+2+2+2+2+2 examples, step counts unchanged)
- Every factual claim keeps the source link behind it
- The content-specification and UAT-UK references are all still there

The worked examples are the reason these pages are worth ranking, so shortening them would have defeated the point.

### One thing worth noting
The shared "how long is the module" and "where is the topic list" answers appeared **verbatim on all five module pages**, so their length was paid five times over — and near-identical blocks across sibling pages read as templated. Both are now two sentences.

456 tests pass. Build and all 102 prerendered routes unchanged.

### Not included
`/guides/esat-practice-tests` — it's the page currently ranking (position ~30) and it has the wordiest FAQ on the site at 524 words. I've deliberately left it alone rather than edit a ranking page as a side effect of a tidy-up. Say the word and I'll do it as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)